### PR TITLE
Fix marketplace.json source path prefix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,7 +16,7 @@
         "name": "Quadralay Corporation",
         "url": "https://github.com/quadralay"
       },
-      "source": "plugins/webworks-claude-skills",
+      "source": "./plugins/webworks-claude-skills",
       "category": "development-tools",
       "tags": ["epublisher", "markdown", "markdown++", "automation", "publish", "automap", "reverb", "documentation", "single-sourcing"],
       "strict": false,


### PR DESCRIPTION
## Summary

Add `./` prefix to `source` path in marketplace.json.

## Fix

Schema error: `plugins.0.source: Invalid input: must start with "./"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)