### PR TITLE
Add IndexMarker documentation to markdown-plus-plus skill

### DIFF
--- a/plugins/webworks-claude-skills/skills/markdown-plus-plus/SKILL.md
+++ b/plugins/webworks-claude-skills/skills/markdown-plus-plus/SKILL.md
@@ -226,7 +226,37 @@ Markers attach metadata to document elements for search, processing, or custom b
 
 Use `marker:key="value"` for single markers, JSON format for multiple.
 
-**Note:** `Keywords` and `Description` markers map to HTML meta tags in web output.
+**Common marker keys:**
+
+- **Keywords** — Maps to HTML meta keywords tag
+- **Description** — Maps to HTML meta description tag
+- **IndexMarker** — Creates index entries for generated output
+
+**Index markers:**
+
+Index markers create entries in generated indexes (back-of-book style).
+
+```markdown
+<!--marker:IndexMarker="creating projects"-->
+## Creating Projects
+```
+
+**Multiple entries** (comma-separated):
+```markdown
+<!--marker:IndexMarker="projects:creating,output:generating,targets"-->
+## Creating Projects
+```
+
+**Sub-entries** (colon for nesting):
+```markdown
+<!--marker:IndexMarker="source documents:opening,documents:opening from Manager"-->
+## Opening Source Documents
+```
+
+**Format rules:**
+- `primary` — Top-level index entry
+- `primary:secondary` — Nested entry under primary
+- Comma separates multiple entries
 
 ### Multiline Tables
 

--- a/plugins/webworks-claude-skills/skills/markdown-plus-plus/references/syntax-reference.md
+++ b/plugins/webworks-claude-skills/skills/markdown-plus-plus/references/syntax-reference.md
@@ -376,10 +376,37 @@ Markers can be placed:
 
 | Marker | Purpose |
 |--------|---------|
-| `Keywords` | Search keywords for Reverb |
+| `Keywords` | Search keywords for Reverb, maps to HTML meta |
+| `Description` | Document description, maps to HTML meta |
+| `IndexMarker` | Index entries (see below) |
 | `Author` | Document author |
 | `Category` | Content categorization |
 | `Passthrough` | Content that bypasses processing |
+
+### Index Markers
+
+Index markers create entries in generated indexes (back-of-book style).
+
+**Single entry:**
+```markdown
+<!--marker:IndexMarker="creating projects"-->
+## Creating Projects
+```
+
+**Multiple entries** (comma-separated):
+```markdown
+<!--marker:IndexMarker="projects:creating,output:generating,targets"-->
+```
+
+**Sub-entries** (colon for nesting):
+```markdown
+<!--marker:IndexMarker="source documents:opening,documents:opening from Manager"-->
+```
+
+**Format:**
+- `primary` — Top-level index entry
+- `primary:secondary` — Nested entry appears under primary
+- Comma separates multiple independent entries
 
 ---
 


### PR DESCRIPTION
## Summary

Document the `IndexMarker` syntax for creating index entries in generated output.

## Changes

- **SKILL.md**: Added common marker keys list and IndexMarker documentation
- **references/syntax-reference.md**: Added IndexMarker to common use cases table and new section

## IndexMarker Syntax

```markdown
<!--marker:IndexMarker="primary entry"-->
<!--marker:IndexMarker="primary:secondary"-->
<!--marker:IndexMarker="entry1,entry2,primary:secondary"-->
```

## Context

This syntax was discovered by examining existing documentation in epublisher-docs but was not previously documented in the skill reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)