### PR TITLE
Add automatic version bumping on PR merge

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "webworks-claude-skills",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Claude Code skills for WebWorks ePublisher platform: Markdown++ authoring, project management, AutoMap automation, and Reverb output testing",
   "owner": {
     "name": "Quadralay Corporation",
@@ -11,7 +11,7 @@
     {
       "name": "webworks-claude-skills",
       "description": "Complete skills suite for WebWorks ePublisher platform including Markdown++ authoring, project management, AutoMap publishing automation, and Reverb output testing",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "author": {
         "name": "Quadralay Corporation",
         "url": "https://github.com/quadralay"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,87 @@
+name: Version Bump
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  bump-version:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine version bump type
+        id: bump-type
+        run: |
+          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+          if echo "$LABELS" | grep -q '"major"'; then
+            echo "type=major" >> $GITHUB_OUTPUT
+          elif echo "$LABELS" | grep -q '"minor"'; then
+            echo "type=minor" >> $GITHUB_OUTPUT
+          else
+            echo "type=patch" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get current version
+        id: current
+        run: |
+          VERSION=$(jq -r '.version' plugins/webworks-claude-skills/plugin.json)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Calculate new version
+        id: new
+        run: |
+          CURRENT="${{ steps.current.outputs.version }}"
+          TYPE="${{ steps.bump-type.outputs.type }}"
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+          case $TYPE in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "Bumping $CURRENT -> $NEW_VERSION ($TYPE)"
+
+      - name: Update version in all files
+        run: |
+          NEW_VERSION="${{ steps.new.outputs.version }}"
+
+          # Update plugin.json
+          jq --arg v "$NEW_VERSION" '.version = $v' \
+            plugins/webworks-claude-skills/plugin.json > tmp.json \
+            && mv tmp.json plugins/webworks-claude-skills/plugin.json
+
+          # Update marketplace.json (both root and plugins[0] version)
+          jq --arg v "$NEW_VERSION" '.version = $v | .plugins[0].version = $v' \
+            .claude-plugin/marketplace.json > tmp.json \
+            && mv tmp.json .claude-plugin/marketplace.json
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add plugins/webworks-claude-skills/plugin.json .claude-plugin/marketplace.json
+          git commit -m "chore: bump version to ${{ steps.new.outputs.version }}"
+          git push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,11 +48,30 @@ See [docs/solutions/bash-syntax-errors-in-skill-tables.md](docs/solutions/bash-s
 - **Documentation:** Clear language with examples
 - **Testing:** Validate with real ePublisher projects
 
+## Versioning
+
+Version numbers are **automatically incremented** when PRs merge to main.
+
+**Default behavior:** Patch version bump (e.g., 2.0.0 → 2.0.1)
+
+**To trigger a different bump type**, add a label to your PR:
+
+| Label | Bump Type | Example |
+|-------|-----------|---------|
+| (none) | patch | 2.0.0 → 2.0.1 |
+| `minor` | minor | 2.0.0 → 2.1.0 |
+| `major` | major | 2.0.0 → 3.0.0 |
+
+The GitHub Action updates all version locations automatically:
+- `plugins/webworks-claude-skills/plugin.json`
+- `.claude-plugin/marketplace.json` (both root and plugin entry)
+
 ## Pull Requests
 
 1. Fork and create a feature branch
 2. Test thoroughly
 3. Submit PR with clear description
+4. Add `minor` or `major` label if needed (patch is default)
 
 ## License
 

--- a/plugins/webworks-claude-skills/plugin.json
+++ b/plugins/webworks-claude-skills/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webworks-claude-skills",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Claude Code skills for WebWorks ePublisher platform: Markdown++ authoring, project management, AutoMap automation, and Reverb output testing",
   "author": "Quadralay Corporation",
   "skills": [


### PR DESCRIPTION
## Summary

- Adds GitHub Action workflow that automatically bumps version when PRs merge to main
- Default behavior: patch bump (2.0.0 → 2.0.1)
- Use PR labels for other bump types:
  - `minor` label → 2.0.0 → 2.1.0
  - `major` label → 2.0.0 → 3.0.0
- Updates all version locations automatically:
  - `plugins/webworks-claude-skills/plugin.json`
  - `.claude-plugin/marketplace.json` (root version)
  - `.claude-plugin/marketplace.json` (plugins[0].version)
- Documents versioning process in CONTRIBUTING.md
- Bumps current version to 2.0.1 (should have been incremented in previous PRs)

## Test plan

- [ ] Merge this PR and verify the workflow runs
- [ ] Create a test PR and verify version bumps to 2.0.2 on merge
- [ ] Verify plugin cache updates correctly with new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)