### PR TITLE
fix(automap): add --skip-reports to wrapper script

### DIFF
--- a/plans/fix-skip-reports-in-wrapper-script.md
+++ b/plans/fix-skip-reports-in-wrapper-script.md
@@ -1,0 +1,86 @@
+# 🐛 Fix: Add --skip-reports to automap-wrapper.sh
+
+**Type:** Bug fix
+**Scope:** Small - update wrapper script to support documented option
+
+## Problem Statement
+
+The `--skip-reports` option was documented in SKILL.md and cli-reference.md but was not added to `automap-wrapper.sh`. This means:
+
+1. Users following the documentation can't use `--skip-reports` via the wrapper
+2. The wrapper rejects the flag as an "Unknown option"
+3. Inconsistency between documented features and script capabilities
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `plugins/webworks-claude-skills/skills/automap/scripts/automap-wrapper.sh` | Add `--skip-reports` support |
+
+## Proposed Solution
+
+### 1. Add Variable (line ~45)
+
+```bash
+# Default options
+CLEAN_BUILD=false
+CLEAN_DEPLOY=false
+NO_DEPLOY=false
+SKIP_REPORTS=false   # <-- ADD THIS
+TARGET=""
+```
+
+### 2. Update Usage Text (line ~98)
+
+```bash
+OPTIONS:
+    -c, --clean            Clean build (remove cached files)
+    -n, --nodeploy         Do not copy files to deployment location
+    -l, --cleandeploy      Clean deployment location before copying output
+    -t, --target TARGET    Build specific target only
+    --deployfolder PATH    Override deployment destination
+    --skip-reports         Skip report pipelines (2025.1+)   # <-- ADD THIS
+    --verbose              Enable verbose output
+```
+
+### 3. Update Examples (line ~110)
+
+```bash
+EXAMPLES:
+    # Build all targets with clean
+    $SCRIPT_NAME -c -n project.wep
+
+    # Fast CI build (skip reports)
+    $SCRIPT_NAME -c -n --skip-reports project.wep   # <-- ADD THIS
+```
+
+### 4. Add Argument Parsing Case (line ~315)
+
+```bash
+        --skip-reports)
+            SKIP_REPORTS=true
+            shift
+            ;;
+```
+
+### 5. Update build_automap_command Function (line ~200)
+
+```bash
+    # Add skip reports flag
+    if [ "$SKIP_REPORTS" = true ]; then
+        cmd="$cmd --skip-reports"
+    fi
+```
+
+## Acceptance Criteria
+
+- [ ] `--skip-reports` is accepted by the wrapper script
+- [ ] Flag is passed through to AutoMap CLI
+- [ ] Usage text documents the option with version note (2025.1+)
+- [ ] Example shows recommended CI/CD usage
+
+## References
+
+- PR #17: Original `--skip-reports` documentation
+- `plugins/webworks-claude-skills/skills/automap/scripts/automap-wrapper.sh:283-342` - argument parsing
+- `plugins/webworks-claude-skills/skills/automap/references/cli-reference.md:67-72` - documented option

--- a/plugins/webworks-claude-skills/skills/automap/scripts/automap-wrapper.sh
+++ b/plugins/webworks-claude-skills/skills/automap/scripts/automap-wrapper.sh
@@ -39,6 +39,7 @@ DETECT_SCRIPT="$SCRIPT_DIR/detect-installation.sh"
 CLEAN_BUILD=false
 CLEAN_DEPLOY=false
 NO_DEPLOY=false
+SKIP_REPORTS=false
 TARGET=""
 DEPLOY_FOLDER=""
 AUTOMAP_VERSION=""
@@ -96,6 +97,7 @@ OPTIONS:
     -l, --cleandeploy      Clean deployment location before copying output
     -t, --target TARGET    Build specific target only
     --deployfolder PATH    Override deployment destination
+    --skip-reports         Skip report pipelines (2025.1+)
     --verbose              Enable verbose output
     --quiet                Suppress informational messages
     --help                 Show this help message
@@ -113,6 +115,9 @@ EXAMPLES:
 
     # Build specific target
     $SCRIPT_NAME -c -n -t "WebWorks Reverb 2.0" project.wep
+
+    # Fast CI build (skip reports, 2025.1+)
+    $SCRIPT_NAME -c -n --skip-reports project.wep
 
     # Build with custom deployment and delete existing files at deployment location
     $SCRIPT_NAME -l --deployfolder "C:\\Output" project.wep
@@ -200,6 +205,11 @@ build_automap_command() {
     # Add deploy folder if specified
     if [ -n "$DEPLOY_FOLDER" ]; then
         cmd="$cmd --deployfolder \"$DEPLOY_FOLDER\""
+    fi
+
+    # Add skip reports flag (2025.1+)
+    if [ "$SKIP_REPORTS" = true ]; then
+        cmd="$cmd --skip-reports"
     fi
 
     # Add project file (always last)
@@ -311,6 +321,10 @@ while [[ $# -gt 0 ]]; do
             fi
             DEPLOY_FOLDER="$2"
             shift 2
+            ;;
+        --skip-reports)
+            SKIP_REPORTS=true
+            shift
             ;;
         --verbose)
             VERBOSE=true


### PR DESCRIPTION
## Summary

The `--skip-reports` option was documented in SKILL.md and cli-reference.md (PR #17) but was missing from `automap-wrapper.sh`. Users couldn't use the documented option via the wrapper.

## Changes

- Added `SKIP_REPORTS` variable to default options
- Added `--skip-reports` to usage text with version note (2025.1+)
- Added example for fast CI builds
- Added argument parsing case
- Added flag to `build_automap_command` function

## Test plan

- [ ] `./automap-wrapper.sh --help` shows `--skip-reports` option
- [ ] `./automap-wrapper.sh -c -n --skip-reports project.wep` passes flag to AutoMap

🤖 Generated with [Claude Code](https://claude.com/claude-code)