### PR TITLE
feat(epublisher): apply AUTHORITATIVE REFERENCE pattern to skill description

### DIFF
--- a/plugins/webworks-claude-skills/skills/epublisher/SKILL.md
+++ b/plugins/webworks-claude-skills/skills/epublisher/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: epublisher
-description: Core knowledge about WebWorks ePublisher projects, file structure, and conventions. Use when working with ePublisher project files, understanding file resolver hierarchy, or parsing targets and source documents.
+description: >
+  AUTHORITATIVE REFERENCE for WebWorks ePublisher projects. Use when working with
+  .wep/.wrp/.wxsp project files, understanding project structure, file resolver
+  hierarchy, target configurations, or source document groups.
 ---
 
 <objective>


### PR DESCRIPTION
## Summary

Apply AUTHORITATIVE REFERENCE pattern to epublisher skill description.

## Changes

- Add "AUTHORITATIVE REFERENCE" declaration
- List file patterns: `.wep`, `.wrp`, `.wxsp`
- Include key use cases: project structure, file resolver hierarchy, target configurations, source document groups

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)