### PR TITLE
fix: update version-bump workflow for new plugin.json path

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Get current version
         id: current
         run: |
-          VERSION=$(jq -r '.version' plugins/webworks-claude-skills/plugin.json)
+          VERSION=$(jq -r '.version' plugins/webworks-claude-skills/.claude-plugin/plugin.json)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Calculate new version
@@ -70,8 +70,8 @@ jobs:
 
           # Update plugin.json
           jq --arg v "$NEW_VERSION" '.version = $v' \
-            plugins/webworks-claude-skills/plugin.json > tmp.json \
-            && mv tmp.json plugins/webworks-claude-skills/plugin.json
+            plugins/webworks-claude-skills/.claude-plugin/plugin.json > tmp.json \
+            && mv tmp.json plugins/webworks-claude-skills/.claude-plugin/plugin.json
 
           # Update marketplace.json (root version only, plugin version is in plugin.json)
           jq --arg v "$NEW_VERSION" '.version = $v' \
@@ -82,6 +82,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add plugins/webworks-claude-skills/plugin.json .claude-plugin/marketplace.json
+          git add plugins/webworks-claude-skills/.claude-plugin/plugin.json .claude-plugin/marketplace.json
           git commit -m "chore: bump version to ${{ steps.new.outputs.version }}"
           git push


### PR DESCRIPTION
## Summary

Fixes the version-bump GitHub Action which was failing after PR #26 moved `plugin.json` to a new location.

**Change:** Update path from `plugins/webworks-claude-skills/plugin.json` to `plugins/webworks-claude-skills/.claude-plugin/plugin.json`

## Failed Run

https://github.com/quadralay/webworks-claude-skills/actions/runs/20834025569

## Files Changed

- `.github/workflows/version-bump.yml` - Updated 3 path references

Generated with [Claude Code](https://claude.com/claude-code)