### PR TITLE
fix(automap): correct executable name in CLI syntax example

### DIFF
--- a/plugins/webworks-claude-skills/skills/automap/SKILL.md
+++ b/plugins/webworks-claude-skills/skills/automap/SKILL.md
@@ -139,7 +139,7 @@ Job files reference Stationery via `<Project path="..."/>`:
 ### Basic Syntax
 
 ```
-AutoMap.exe [options] <project-file>
+WebWorks.Automap.exe [options] <project-file>
 ```
 
 ### Common Options


### PR DESCRIPTION
## Summary

- Fixes incorrect `AutoMap.exe` reference to `WebWorks.Automap.exe` in SKILL.md line 142
- The generic name caused Claude to use the wrong executable when helping users run AutoMap builds
- All reference documents already used the correct name (25 occurrences verified)

## Test plan

- [ ] Verify no `AutoMap.exe` references remain: `grep -rn "AutoMap\.exe" plugins/webworks-claude-skills/skills/automap/`
- [ ] Test automap skill invocation to confirm correct executable is referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)