### PR TITLE
fix(skills): Use relative paths for cross-platform script resolution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "webworks-claude-skills",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Claude Code skills for WebWorks ePublisher platform: Markdown++ authoring, project management, AutoMap automation, and Reverb output testing",
   "owner": {
     "name": "Quadralay Corporation",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,9 @@ Use `/workflows:review` for code review:
 Bump the plugin version before creating a PR using the bump script:
 
 ```bash
-./scripts/bump-version.sh patch  # 2.1.0 -> 2.1.1 (bug fixes)
-./scripts/bump-version.sh minor  # 2.1.0 -> 2.2.0 (new features)
-./scripts/bump-version.sh major  # 2.1.0 -> 3.0.0 (breaking changes)
+scripts/bump-version.sh patch  # 2.1.0 -> 2.1.1 (bug fixes)
+scripts/bump-version.sh minor  # 2.1.0 -> 2.2.0 (new features)
+scripts/bump-version.sh major  # 2.1.0 -> 3.0.0 (breaking changes)
 ```
 
 The script updates both `plugin.json` and `marketplace.json` to keep versions synchronized.
@@ -52,6 +52,6 @@ The script updates both `plugin.json` and `marketplace.json` to keep versions sy
 
 **Workflow:**
 1. Make your changes
-2. Run `./scripts/bump-version.sh <type>`
+2. Run `scripts/bump-version.sh <type>`
 3. Include the version bump in your PR
 4. Merge PR - version is already updated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,9 +53,9 @@ See [docs/solutions/bash-syntax-errors-in-skill-tables.md](docs/solutions/bash-s
 Bump the plugin version **before creating a PR** using the bump script:
 
 ```bash
-./scripts/bump-version.sh patch  # 2.1.0 → 2.1.1 (bug fixes)
-./scripts/bump-version.sh minor  # 2.1.0 → 2.2.0 (new features)
-./scripts/bump-version.sh major  # 2.1.0 → 3.0.0 (breaking changes)
+scripts/bump-version.sh patch  # 2.1.0 → 2.1.1 (bug fixes)
+scripts/bump-version.sh minor  # 2.1.0 → 2.2.0 (new features)
+scripts/bump-version.sh major  # 2.1.0 → 3.0.0 (breaking changes)
 ```
 
 The script updates both version locations automatically:
@@ -76,7 +76,7 @@ The script updates both version locations automatically:
 
 1. Fork and create a feature branch
 2. Test thoroughly
-3. Run `./scripts/bump-version.sh <type>` to bump version
+3. Run `scripts/bump-version.sh <type>` to bump version
 4. Submit PR with clear description
 
 ## License

--- a/plans/fix-script-invocation-path-resolution.md
+++ b/plans/fix-script-invocation-path-resolution.md
@@ -1,266 +1,38 @@
 # Fix: Script Invocation Path Resolution
 
-## Overview
+**Status: COMPLETED (superseded)**
 
-When the automap skill is invoked, Claude attempts to run wrapper scripts using incorrect relative paths, causing first-attempt failures. This fix standardizes script invocation patterns across all four webworks-claude-skills using `${CLAUDE_PLUGIN_ROOT}` for reliable path resolution.
+## Original Problem
 
-## Problem Statement
+When skills referenced scripts using `${CLAUDE_PLUGIN_ROOT}`, the environment variable expanded with OS-native path separators. On Windows, this produced backslash paths (e.g., `C:\Users\...\skills\automap\scripts\`) which broke bash script execution.
 
-**Current behavior:**
-```bash
-./scripts/automap-wrapper.sh  # Fails - relative to user's CWD
-./.claude/plugins/cache/...    # Fails - wrong directory prefix
-```
+## Solution Applied
 
-**Expected behavior:**
-```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh  # Works
-```
+Replaced all `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/scripts/` references with paths relative to each skill's SKILL.md location:
 
-### Root Causes
+| Reference Type | Old Pattern | New Pattern |
+|---|---|---|
+| Same-skill | `${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/foo.sh` | `scripts/foo.sh` |
+| Cross-skill | `${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/foo.sh` (from reverb2) | `../automap/scripts/foo.sh` |
 
-1. **Path confusion**: `./.claude/` is CWD-relative, but plugins are cached in `~/.claude/plugins/cache/`
-2. **Windows compatibility**: Git Bash requires explicit `bash` prefix for `.sh` scripts
-3. **Missing documentation**: No guidance on using `${CLAUDE_PLUGIN_ROOT}` environment variable
+### Why Relative Paths
 
-### Environment
+- **Cross-platform**: No OS-specific path separator issues
+- **No environment variable dependency**: Works regardless of whether `CLAUDE_PLUGIN_ROOT` is set or how it expands
+- **Simpler**: Claude resolves relative paths from the SKILL.md location
 
-- Windows 11, Git Bash
-- Claude Code CLI
-- Affects all four skills: automap, epublisher, reverb2, markdown-plus-plus
+### Files Updated
 
-## Proposed Solution
+| Skill | Files Changed |
+|---|---|
+| automap | SKILL.md (already done), references/cli-reference.md, references/job-file-guide.md |
+| epublisher | SKILL.md, references/file-resolver-guide.md |
+| markdown-plus-plus | SKILL.md, references/best-practices.md |
+| reverb2 | SKILL.md, workflows/browser-testing.md, workflows/csh-analysis.md, workflows/generate-report.md, workflows/scss-theming.md |
 
-Add "Invoking Scripts" documentation to each skill and update all script path references to use the portable `${CLAUDE_PLUGIN_ROOT}` pattern.
+**Total: 105 occurrences replaced across 12 files.**
 
-### Invocation Patterns by Script Type
+---
 
-| Type | Pattern |
-|------|---------|
-| Shell (.sh) | `bash ${CLAUDE_PLUGIN_ROOT}/skills/<skill>/scripts/<script>.sh` |
-| Python (.py) | `python ${CLAUDE_PLUGIN_ROOT}/skills/<skill>/scripts/<script>.py` |
-| Node.js (.js) | `node ${CLAUDE_PLUGIN_ROOT}/skills/<skill>/scripts/<script>.js` |
-
-## Acceptance Criteria
-
-- [ ] All SKILL.md files include "Invoking Scripts" subsection in `<usage>` section
-- [ ] All script path examples use `${CLAUDE_PLUGIN_ROOT}` instead of `./scripts/`
-- [ ] Shell scripts prefixed with `bash` for Windows compatibility
-- [ ] Reference docs and workflow docs updated with correct paths
-- [ ] Troubleshooting section added for "Script not found" errors
-- [ ] Scripts work on first invocation (Windows Git Bash, macOS, Linux)
-
-## Technical Approach
-
-### Phase 1: Add "Invoking Scripts" Documentation
-
-Add this subsection to each skill's `<usage>` section:
-
-```markdown
-### Invoking Scripts
-
-All scripts must be invoked using the `${CLAUDE_PLUGIN_ROOT}` environment variable:
-
-\`\`\`bash
-# Shell scripts - always use 'bash' prefix for Windows compatibility
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh [options] <project-file>
-
-# Python scripts
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/parse-stationery.py stationery.wxsp
-\`\`\`
-
-**Why this pattern?**
-- `${CLAUDE_PLUGIN_ROOT}` provides the absolute path to the plugin directory
-- Relative paths like `./scripts/` fail because they're relative to your working directory, not the plugin cache
-- The `bash` prefix ensures Windows Git Bash executes `.sh` scripts correctly
-```
-
-### Phase 2: Update All Script References
-
-#### Automap Skill (~60 occurrences)
-
-**SKILL.md** (18 occurrences):
-- Lines 70, 73, 76: Quick start examples
-- Lines 104, 115: Environment variable examples
-- Lines 143-174: Python script references
-- Lines 192, 275, 307, 320, 324, 332, 335: Additional examples
-
-**cli-reference.md** (40+ occurrences):
-- Lines 56, 59-61, 70, 100, 103, 111, 151-152, 159
-- Lines 209, 214, 221, 226, 233, 238, 264, 269, 286
-- Lines 447-448, 455, 462, 469, 476-480, 487, 494, 501
-
-**job-file-guide.md** (9 occurrences):
-- Lines 263-274, 362, 428, 431, 455, 463, 474, 489
-
-#### Epublisher Skill (~4 occurrences)
-
-**SKILL.md**:
-- Lines 142, 155: Script references
-
-**file-resolver-guide.md**:
-- 1 occurrence
-
-#### Reverb2 Skill (~14 occurrences)
-
-**SKILL.md** (10 occurrences):
-- Lines 89, 136, 180, 188, 227, 256, 268-277, 284, 287
-
-**Workflow docs** (12 occurrences across 4 files):
-- `browser-testing.md`: 3 occurrences
-- `csh-analysis.md`: 2 occurrences
-- `generate-report.md`: 5 occurrences
-- `scss-theming.md`: 4 occurrences
-
-#### Markdown-plus-plus Skill (~3 occurrences)
-
-**SKILL.md**:
-- Lines 143, 427, 447
-
-**best-practices.md**:
-- 1 occurrence
-
-### Phase 3: Add Troubleshooting Section
-
-Add to each SKILL.md:
-
-```markdown
-### Troubleshooting: Script Not Found
-
-If you see "No such file or directory" when running scripts:
-
-1. **Verify the variable is set**: `echo ${CLAUDE_PLUGIN_ROOT}`
-2. **Use `bash` prefix on Windows**: Required for Git Bash
-3. **Use forward slashes only**: Never use backslashes in paths
-4. **Check the full path**: Plugin cache is at `~/.claude/plugins/cache/`, not `./.claude/`
-```
-
-## Files Requiring Changes
-
-### Must Update (skill documentation)
-
-| File | Occurrences | Priority |
-|------|-------------|----------|
-| `skills/automap/SKILL.md` | 18 | P1 |
-| `skills/automap/references/cli-reference.md` | 40+ | P1 |
-| `skills/automap/references/job-file-guide.md` | 9 | P1 |
-| `skills/epublisher/SKILL.md` | 3 | P1 |
-| `skills/epublisher/references/file-resolver-guide.md` | 1 | P2 |
-| `skills/reverb2/SKILL.md` | 10 | P1 |
-| `skills/reverb2/workflows/browser-testing.md` | 3 | P2 |
-| `skills/reverb2/workflows/csh-analysis.md` | 2 | P2 |
-| `skills/reverb2/workflows/generate-report.md` | 5 | P2 |
-| `skills/reverb2/workflows/scss-theming.md` | 4 | P2 |
-| `skills/markdown-plus-plus/SKILL.md` | 2 | P1 |
-| `skills/markdown-plus-plus/references/best-practices.md` | 1 | P2 |
-
-### Do NOT Update (correct as-is)
-
-| File | Reason |
-|------|--------|
-| `CLAUDE.md` (project root) | Project-level script, CWD is repo root |
-| `CONTRIBUTING.md` | Project-level script, CWD is repo root |
-| `scripts/bump-version.sh` | Project script, not plugin script |
-| `automap-wrapper.sh` (internal `$SCRIPT_DIR`) | Uses runtime path resolution correctly |
-
-## Search and Replace Patterns
-
-### Shell Scripts
-
-```
-# Find
-./scripts/automap-wrapper.sh
-./scripts/detect-installation.sh
-
-# Replace with
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/detect-installation.sh
-```
-
-### Python Scripts
-
-```
-# Find
-python scripts/parse-stationery.py
-python scripts/validate-job.py
-
-# Replace with
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/parse-stationery.py
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/validate-job.py
-```
-
-### Node.js Scripts
-
-```
-# Find
-node scripts/browser-test.js
-
-# Replace with
-node ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/browser-test.js
-```
-
-## Testing Plan
-
-### Pre-deployment Verification
-
-1. **Windows + Git Bash**: Primary test environment (issue reporter's environment)
-2. **macOS**: Verify no regression
-3. **Linux**: Verify no regression
-
-### Test Cases
-
-| Test | Command | Expected Result |
-|------|---------|-----------------|
-| First invocation | `/automap` then run wrapper | Script executes without path error |
-| Detect installation | Run detect-installation.sh | Returns AutoMap path or error message |
-| Python script | Run parse-stationery.py | Parses stationery file correctly |
-| From different CWD | Navigate to `/tmp`, invoke skill | Script still works |
-
-### Validation Commands
-
-```bash
-# Verify CLAUDE_PLUGIN_ROOT is set
-echo ${CLAUDE_PLUGIN_ROOT}
-
-# Test shell script
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/detect-installation.sh
-
-# Test Python script
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/parse-stationery.py --help
-```
-
-## Success Metrics
-
-- Scripts execute successfully on first invocation
-- No "path not found" errors in normal usage
-- Works consistently across Windows Git Bash, macOS, and Linux
-
-## Dependencies
-
-- `CLAUDE_PLUGIN_ROOT` environment variable (set by Claude Code when loading skills)
-- Git Bash installed on Windows (for shell script execution)
-
-## Risk Assessment
-
-| Risk | Likelihood | Mitigation |
-|------|------------|------------|
-| `CLAUDE_PLUGIN_ROOT` not set in older Claude Code versions | Low | Document minimum version requirement |
-| Search/replace misses edge cases | Medium | Manual review of all changes |
-| Breaks working configurations | Low | Paths were already broken; this is additive fix |
-
-## References
-
-### Internal References
-- Issue: #42
-- Pattern source: `git-worktree` skill (compound-engineering plugin)
-- Current wrapper: `skills/automap/scripts/automap-wrapper.sh:36` (correct `$SCRIPT_DIR` usage)
-
-### External References
-- [Claude Code Skills Documentation](https://code.claude.com/docs/en/skills)
-- [Claude Code Plugins Reference](https://code.claude.com/docs/en/plugins-reference)
-- Related issues: anthropics/claude-code#17257 (Windows compatibility), #18527 (path separators)
-
-### Research Notes
-- The `git-worktree` skill in compound-engineering demonstrates the correct pattern
-- Python scripts need `python` prefix, Node.js scripts need `node` prefix
-- Internal script-to-script references using `$SCRIPT_DIR` are already correct
+**Completed**: 2026-02-11
+**Original Plan**: 2025-01-xx (introduced `${CLAUDE_PLUGIN_ROOT}` pattern)

--- a/plugins/webworks-claude-skills/.claude-plugin/plugin.json
+++ b/plugins/webworks-claude-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webworks-claude-skills",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Claude Code skills for WebWorks ePublisher platform: Markdown++ authoring, project management, AutoMap automation, and Reverb output testing",
   "author": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-claude-skills/skills/automap/SKILL.md
+++ b/plugins/webworks-claude-skills/skills/automap/SKILL.md
@@ -21,8 +21,8 @@ AutoMap is the command-line build tool for ePublisher. It processes source docum
 
 ### Supported File Types
 
-- **Project files (.wep, .wrp)**: Complete self-contained projects
-- **Job files (.waj)**: Lean automation files that reference Stationery
+- **Project files (.wep, .wrp)**: Complete self-contained projects. Require `-t` option to specify which target(s) to build.
+- **Job files (.waj)**: Lean automation files that reference Stationery. Targets to build are controlled by the `build="True"` attribute in the job file itself—the `-t` option is an optional override.
 
 ### Job Files and Stationery
 
@@ -65,15 +65,27 @@ Do NOT use `detect-installation.sh` to find the CLI path and call it directly. T
 
 ### Run a Build
 
+**Project files (.wep, .wrp)** - Use `-t` to specify target:
+
 ```bash
 # Build single target (safe defaults: clean, no-deploy, skip-reports)
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh -t "WebWorks Reverb 2.0" project.wep
+bash scripts/automap-wrapper.sh -t "WebWorks Reverb 2.0" project.wep
 
 # CI/CD: Build all targets explicitly
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --all-targets project.wep
+bash scripts/automap-wrapper.sh --all-targets project.wep
 
 # Production: Deploy with reports
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --deploy --with-reports -t "Target" project.wep
+bash scripts/automap-wrapper.sh --deploy --with-reports -t "Target" project.wep
+```
+
+**Job files (.waj)** - Targets determined by `build="True"` in file:
+
+```bash
+# Build job file (targets set in file, no -t needed)
+bash scripts/automap-wrapper.sh job.waj
+
+# With deployment
+bash scripts/automap-wrapper.sh -l -d /path/to/deploy job.waj
 ```
 
 The wrapper automatically detects the AutoMap installation and applies safe defaults.
@@ -88,12 +100,14 @@ The wrapper now applies these options by default:
 | `-n` (no deploy) | `--deploy` | Prevent accidental overwrites |
 | `--skip-reports` | `--with-reports` | Faster builds *(2025.1+)* |
 
-### Interactive Target Selection
+### Interactive Target Selection (Project Files Only)
 
-When no target is specified:
+When using project files (.wep, .wrp) with no target specified:
 - **Single-target projects**: Auto-builds the only target
 - **Multi-target projects**: Prompts for selection (interactive mode)
 - **CI/CD (non-interactive)**: Requires `-t`, `--target=`, or `--all-targets`
+
+**Note:** Job files (.waj) do not need target selection options — see overview for details.
 
 ### Environment Variable Override
 
@@ -101,7 +115,7 @@ Use `AUTOMAP_EXE_PATH` to bypass auto-detection:
 
 ```bash
 # Cache detected path for multiple builds
-export AUTOMAP_EXE_PATH=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/detect-installation.sh)
+export AUTOMAP_EXE_PATH=$(bash scripts/detect-installation.sh)
 
 # Or point to a development/debug build
 export AUTOMAP_EXE_PATH="/c/builds/debug/net48/WebWorks.Automap.exe"
@@ -112,7 +126,7 @@ export AUTOMAP_EXE_PATH="/c/builds/debug/net48/WebWorks.Automap.exe"
 To check if AutoMap is installed and where:
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/detect-installation.sh --verbose
+bash scripts/detect-installation.sh --verbose
 ```
 </quick_start>
 
@@ -140,38 +154,38 @@ The skill will guide you through:
 
 ```bash
 # Parse Stationery to see available formats and settings
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/parse-stationery.py stationery.wxsp
+python scripts/parse-stationery.py stationery.wxsp
 
 # Create job file interactively
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/create-job.py --stationery stationery.wxsp
+python scripts/create-job.py --stationery stationery.wxsp
 
 # Create job from config file
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/create-job.py --config config.json --output job.waj
+python scripts/create-job.py --config config.json --output job.waj
 
 # Generate a config template from Stationery
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/create-job.py --template --stationery stationery.wxsp > template.json
+python scripts/create-job.py --template --stationery stationery.wxsp > template.json
 ```
 
 ### Working with Existing Job Files
 
 ```bash
 # Parse job file to view configuration
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/parse-job.py job.waj
+python scripts/parse-job.py job.waj
 
 # Export to editable config format
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/parse-job.py --config job.waj > job-config.json
+python scripts/parse-job.py --config job.waj > job-config.json
 
 # Validate job file before building
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/validate-job.py job.waj
+python scripts/validate-job.py job.waj
 
 # Validate with full checks
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/validate-job.py --check-documents --check-stationery job.waj
+python scripts/validate-job.py --check-documents --check-stationery job.waj
 
 # List targets with build status
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/list-job-targets.py job.waj
+python scripts/list-job-targets.py job.waj
 
 # Show only enabled targets
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/list-job-targets.py --enabled job.waj
+python scripts/list-job-targets.py --enabled job.waj
 ```
 
 ### Stationery Relationship
@@ -189,10 +203,16 @@ Job files reference Stationery via `<Project path="..."/>`:
 ### Basic Syntax
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh [options] <project-file> [-t <target-name>]
+# Project files (.wep, .wrp) - target selection required
+bash scripts/automap-wrapper.sh [options] <project-file> [-t <target-name>]
+
+# Job files (.waj) - targets set in file (no -t needed)
+bash scripts/automap-wrapper.sh [options] <job-file>
 ```
 
 ### Target Selection
+
+These options apply primarily to project files (.wep, .wrp). When used with job files, they override the `build="True"` settings.
 
 | Option | Description |
 |--------|-------------|
@@ -236,16 +256,20 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh [options] <
 ### Installation Detection
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/detect-installation.sh
+bash scripts/detect-installation.sh
 ```
 
 ### Build Wrapper
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh [options] <project-or-job-file> [-t <target-name>]
+# Project files - use -t to specify targets
+bash scripts/automap-wrapper.sh [options] <project-file> [-t <target-name>]
+
+# Job files - targets set in file (no -t needed)
+bash scripts/automap-wrapper.sh [options] <job-file>
 ```
 
-Supports both project files (.wep) and job files (.waj). For multiple targets use `--target="Name1", "Name2"`.
+Supports both project files (.wep, .wrp) and job files (.waj). For project files with multiple targets, use `--target="Name1","Name2"` or `--all-targets`.
 </scripts>
 
 <references>
@@ -303,13 +327,18 @@ pip install defusedxml
 
 ```bash
 #!/bin/bash
-# Build all targets (safe defaults applied automatically)
-if bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --all-targets project.wep; then
+# Project files: use --all-targets
+if bash scripts/automap-wrapper.sh --all-targets project.wep; then
     echo "Build successful"
-    # Deploy output...
 else
-    echo "Build failed"
-    exit 1
+    echo "Build failed" && exit 1
+fi
+
+# Job files: targets set in file, no -t needed
+if bash scripts/automap-wrapper.sh -l -d /deploy/path job.waj; then
+    echo "Build successful"
+else
+    echo "Build failed" && exit 1
 fi
 ```
 
@@ -317,11 +346,11 @@ fi
 
 ```bash
 # Cache installation path for efficiency
-export AUTOMAP_EXE_PATH=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/detect-installation.sh)
+export AUTOMAP_EXE_PATH=$(bash scripts/detect-installation.sh)
 
 for project in projects/*.wep; do
     # --all-targets required in non-interactive (CI) mode
-    bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --all-targets "$project" || echo "Failed: $project"
+    bash scripts/automap-wrapper.sh --all-targets "$project" || echo "Failed: $project"
 done
 ```
 
@@ -329,10 +358,10 @@ done
 
 ```bash
 # No target specified - prompts for selection if multiple targets exist
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh project.wep
+bash scripts/automap-wrapper.sh project.wep
 
 # Incremental build (skip clean)
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --no-clean -t "WebWorks Reverb 2.0" project.wep
+bash scripts/automap-wrapper.sh --no-clean -t "WebWorks Reverb 2.0" project.wep
 ```
 </common_workflows>
 
@@ -365,7 +394,7 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --no-clean 
 **Cause:** Specified target name doesn't exist in project.
 
 **Solutions:**
-1. Use `parse-targets.sh` to list available targets
+1. Use the epublisher skill's `parse-targets.py` to list available targets
 2. Verify target name spelling (case-sensitive)
 3. Check project file for available `<Format>` elements
 
@@ -377,7 +406,7 @@ Error: Stationery file not found: ..\stationery\main.wxsp
 ```
 - Check `<Project path="..."/>` in job file
 - Verify path is relative to job file location
-- Run: `python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/validate-job.py job.waj`
+- Run: `python scripts/validate-job.py job.waj`
 
 **Invalid target format**
 ```
@@ -385,7 +414,7 @@ Error: Format "Unknown Format" not found in Stationery
 ```
 - Target `format` attribute must match format name in Stationery
 - Format names are case-sensitive
-- Run: `python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/parse-stationery.py stationery.wxsp` to list available formats
+- Run: `python scripts/parse-stationery.py stationery.wxsp` to list available formats
 
 **Document path errors**
 ```
@@ -393,7 +422,7 @@ Warning: Document not found: Source\missing.md
 ```
 - Document paths are relative to job file location
 - Check for typos in path
-- Run: `python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/validate-job.py --check-documents job.waj`
+- Run: `python scripts/validate-job.py --check-documents job.waj`
 
 </troubleshooting>
 

--- a/plugins/webworks-claude-skills/skills/automap/references/cli-reference.md
+++ b/plugins/webworks-claude-skills/skills/automap/references/cli-reference.md
@@ -24,12 +24,12 @@ Complete reference for WebWorks ePublisher AutoMap command-line interface option
 For multiple consecutive builds, cache the installation path to avoid repeated detection:
 
 ```bash
-export AUTOMAP_EXE_PATH=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/detect-installation.sh)
+export AUTOMAP_EXE_PATH=$(bash scripts/detect-installation.sh)
 
 # All subsequent builds skip detection
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --all-targets project1.wep
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --all-targets project2.wep
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --all-targets project3.wep
+bash scripts/automap-wrapper.sh --all-targets project1.wep
+bash scripts/automap-wrapper.sh --all-targets project2.wep
+bash scripts/automap-wrapper.sh --all-targets project3.wep
 ```
 
 ### Development Builds
@@ -38,7 +38,7 @@ Point to a debug build for testing:
 
 ```bash
 export AUTOMAP_EXE_PATH="/c/builds/debug/net48/WebWorks.Automap.exe"
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh -t "WebWorks Reverb 2.0" project.wep
+bash scripts/automap-wrapper.sh -t "WebWorks Reverb 2.0" project.wep
 ```
 
 ### Clearing the Override
@@ -68,10 +68,10 @@ When no target is specified:
 
 ```bash
 # Interactive mode - shows numbered list for selection
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh project.wep
+bash scripts/automap-wrapper.sh project.wep
 
 # CI/CD mode - explicit all-targets flag required
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --all-targets project.wep
+bash scripts/automap-wrapper.sh --all-targets project.wep
 ```
 
 ## Basic Command Pattern
@@ -79,7 +79,7 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --all-targe
 Always use the wrapper script to execute builds:
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh [options] <project-file> [-t <target-name>]
+bash scripts/automap-wrapper.sh [options] <project-file> [-t <target-name>]
 ```
 
 **Components:**
@@ -119,15 +119,15 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh [options] <
   - Single target: `-t "WebWorks Reverb 2.0"`
   - Multiple targets: `--target="WebWorks Reverb 2.0", "PDF - XSL-FO"`
 - **Examples**:
-  - Single target: `bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh -t "WebWorks Reverb 2.0" project.wep`
-  - Multiple targets: `bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --target="WebWorks Reverb 2.0", "PDF - XSL-FO" project.wep`
+  - Single target: `bash scripts/automap-wrapper.sh -t "WebWorks Reverb 2.0" project.wep`
+  - Multiple targets: `bash scripts/automap-wrapper.sh --target="WebWorks Reverb 2.0", "PDF - XSL-FO" project.wep`
 - **Note**: Target names must exactly match `TargetName` in project file (case-sensitive)
 
 **`--all-targets`**
 - **Purpose**: Build all targets in the project
 - **Use When**: CI/CD pipelines, batch builds, or when you want all outputs
 - **Impact**: Bypasses interactive target selection
-- **Example**: `bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --all-targets project.wep`
+- **Example**: `bash scripts/automap-wrapper.sh --all-targets project.wep`
 - **Note**: Required in non-interactive mode when no specific target is specified
 
 ### Deployment Control
@@ -156,7 +156,7 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh [options] <
 - **Purpose**: Show all build output including progress messages
 - **Use When**: Debugging build issues or monitoring progress manually
 - **Impact**: Full output with progress indicators and informational messages
-- **Example**: `bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --verbose -t "WebWorks Reverb 2.0" project.wep`
+- **Example**: `bash scripts/automap-wrapper.sh --verbose -t "WebWorks Reverb 2.0" project.wep`
 
 **Default output:**
 ```
@@ -177,36 +177,36 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh [options] <
 
 **Build all targets:**
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --all-targets project.wep
+bash scripts/automap-wrapper.sh --all-targets project.wep
 ```
 
 **Build with deployment:**
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --deploy --all-targets project.wep
+bash scripts/automap-wrapper.sh --deploy --all-targets project.wep
 ```
 
 ### Target-Specific Builds
 
 **Build single target:**
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh -t "WebWorks Reverb 2.0" project.wep
+bash scripts/automap-wrapper.sh -t "WebWorks Reverb 2.0" project.wep
 ```
 
 **Build multiple targets:**
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --target="WebWorks Reverb 2.0", "PDF - XSL-FO" project.wep
+bash scripts/automap-wrapper.sh --target="WebWorks Reverb 2.0", "PDF - XSL-FO" project.wep
 ```
 
 ### Custom Deployment
 
 **Deploy to network share:**
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --deploy --deployfolder "\\\\WebServer\\wwwroot\\docs" project.wep
+bash scripts/automap-wrapper.sh --deploy --deployfolder "\\\\WebServer\\wwwroot\\docs" project.wep
 ```
 
 **Deploy to local test folder:**
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --deploy --deployfolder "C:\\TestOutput" project.wep
+bash scripts/automap-wrapper.sh --deploy --deployfolder "C:\\TestOutput" project.wep
 ```
 
 ## Execution Guidelines
@@ -232,12 +232,12 @@ Set appropriate timeout based on project size when using the Bash tool:
 
 **Save output to log file:**
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --all-targets project.wep > build.log 2>&1
+bash scripts/automap-wrapper.sh --all-targets project.wep > build.log 2>&1
 ```
 
 **Verbose mode for debugging:**
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --verbose -t "WebWorks Reverb 2.0" project.wep
+bash scripts/automap-wrapper.sh --verbose -t "WebWorks Reverb 2.0" project.wep
 ```
 
 ### Exit Code Handling
@@ -254,7 +254,7 @@ The wrapper provides consistent exit codes:
 
 **Check build status:**
 ```bash
-if bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --all-targets project.wep; then
+if bash scripts/automap-wrapper.sh --all-targets project.wep; then
     echo "Build succeeded"
 else
     echo "Build failed with exit code: $?"
@@ -403,7 +403,7 @@ Error: Target 'Invalid Target Name' not found in project
 - Case sensitivity mismatch
 
 **Solutions:**
-1. List available targets: `parse-targets.sh project.wep`
+1. List available targets: use the epublisher skill's `parse-targets.py`
 2. Use exact target name from project file
 3. Check for extra spaces or special characters
 4. Ensure case matches exactly
@@ -414,53 +414,53 @@ Error: Target 'Invalid Target Name' not found in project
 
 For production releases, opt-out of safe defaults:
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --deploy --with-reports -t "WebWorks Reverb 2.0" project.wep
+bash scripts/automap-wrapper.sh --deploy --with-reports -t "WebWorks Reverb 2.0" project.wep
 ```
 
 ### 2. Use --all-targets for CI/CD
 
 Non-interactive environments require explicit target specification:
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --all-targets project.wep
+bash scripts/automap-wrapper.sh --all-targets project.wep
 ```
 
 ### 3. Build Specific Targets When Testing
 
 Save time by building only the target(s) you're working on:
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh -t "WebWorks Reverb 2.0" project.wep
+bash scripts/automap-wrapper.sh -t "WebWorks Reverb 2.0" project.wep
 ```
 
 ### 4. Cache Installation Path for Batch Builds
 
 When building multiple projects, cache the installation path:
 ```bash
-export AUTOMAP_EXE_PATH=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/detect-installation.sh)
+export AUTOMAP_EXE_PATH=$(bash scripts/detect-installation.sh)
 
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --all-targets project1.wep
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --all-targets project2.wep
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --all-targets project3.wep
+bash scripts/automap-wrapper.sh --all-targets project1.wep
+bash scripts/automap-wrapper.sh --all-targets project2.wep
+bash scripts/automap-wrapper.sh --all-targets project3.wep
 ```
 
 ### 5. Use Verbose Mode for Debugging
 
 When troubleshooting build issues:
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --verbose -t "WebWorks Reverb 2.0" project.wep
+bash scripts/automap-wrapper.sh --verbose -t "WebWorks Reverb 2.0" project.wep
 ```
 
 ### 6. Capture Build Logs
 
 Save output for troubleshooting:
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh -t "WebWorks Reverb 2.0" project.wep 2>&1 | tee build.log
+bash scripts/automap-wrapper.sh -t "WebWorks Reverb 2.0" project.wep 2>&1 | tee build.log
 ```
 
 ### 7. Incremental Builds During Development
 
 Use `--no-clean` for faster iterative builds:
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh --no-clean -t "WebWorks Reverb 2.0" project.wep
+bash scripts/automap-wrapper.sh --no-clean -t "WebWorks Reverb 2.0" project.wep
 ```
 
 ## Script Reference
@@ -471,7 +471,7 @@ The wrapper is the primary execution interface:
 |--------|---------|
 | **automap-wrapper.sh** | Execute builds (primary interface) |
 | **detect-installation.sh** | Verify installation, cache path |
-| **parse-targets.sh** | List valid target names for `-t` parameter |
+| **parse-targets.py** *(epublisher skill)* | List valid target names for `-t` parameter |
 
 Use `detect-installation.sh` only for:
 - Verifying AutoMap is installed

--- a/plugins/webworks-claude-skills/skills/automap/references/job-file-guide.md
+++ b/plugins/webworks-claude-skills/skills/automap/references/job-file-guide.md
@@ -260,18 +260,18 @@ Container for format setting overrides.
 
 ```bash
 # 1. Parse Stationery to see available formats
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/parse-stationery.py stationery.wxsp
+python scripts/parse-stationery.py stationery.wxsp
 
 # 2a. Create interactively
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/create-job.py --stationery stationery.wxsp
+python scripts/create-job.py --stationery stationery.wxsp
 
 # 2b. Or generate a template and edit
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/create-job.py --template --stationery stationery.wxsp > config.json
+python scripts/create-job.py --template --stationery stationery.wxsp > config.json
 # Edit config.json...
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/create-job.py --config config.json --output job.waj
+python scripts/create-job.py --config config.json --output job.waj
 
 # 3. Validate the result
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/validate-job.py --check-stationery job.waj
+python scripts/validate-job.py --check-stationery job.waj
 ```
 
 ### Configuration File Format
@@ -359,7 +359,7 @@ Settings override format-level configuration from Stationery:
 
 **To see available settings**, run:
 ```bash
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/parse-stationery.py stationery.wxsp
+python scripts/parse-stationery.py stationery.wxsp
 ```
 
 ---
@@ -425,10 +425,10 @@ Use multiple targets with different conditions:
 # Build all enabled targets from job file
 
 # Validate first
-python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/validate-job.py --check-stationery job.waj || exit 1
+python scripts/validate-job.py --check-stationery job.waj || exit 1
 
 # Run build
-./scripts/automap-wrapper.sh job.waj
+bash scripts/automap-wrapper.sh job.waj
 
 # Check result
 if [ $? -eq 0 ]; then
@@ -452,7 +452,7 @@ fi
 1. Check the `<Project path="..."/>` value
 2. Paths are relative to the job file's location
 3. Verify the file exists at the resolved path
-4. Run: `python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/validate-job.py job.waj`
+4. Run: `python scripts/validate-job.py job.waj`
 
 ### Invalid Format Name
 
@@ -460,7 +460,7 @@ fi
 
 **Solutions**:
 1. Format names are case-sensitive
-2. List available formats: `python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/parse-stationery.py stationery.wxsp`
+2. List available formats: `python scripts/parse-stationery.py stationery.wxsp`
 3. Update the `format` attribute to match exactly
 
 ### Document Not Found
@@ -471,7 +471,7 @@ fi
 1. Document paths are relative to job file location
 2. Check for typos in the path
 3. Verify the file exists
-4. Run: `python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/validate-job.py --check-documents job.waj`
+4. Run: `python scripts/validate-job.py --check-documents job.waj`
 
 ### Build Flag Ignored
 
@@ -486,7 +486,7 @@ fi
 **Solutions**:
 1. Verify setting name exactly matches Stationery
 2. Check that setting is valid for this format
-3. List available settings: `python ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/parse-stationery.py stationery.wxsp`
+3. List available settings: `python scripts/parse-stationery.py stationery.wxsp`
 
 ---
 
@@ -494,11 +494,11 @@ fi
 
 | Script | Purpose | Example |
 |--------|---------|---------|
-| `parse-stationery.py` | Extract formats/settings | `python parse-stationery.py stationery.wxsp` |
-| `create-job.py` | Create job files | `python create-job.py --stationery stationery.wxsp` |
-| `parse-job.py` | View job configuration | `python parse-job.py job.waj` |
-| `validate-job.py` | Validate job files | `python validate-job.py --check-stationery job.waj` |
-| `list-job-targets.py` | List targets | `python list-job-targets.py --enabled job.waj` |
+| `parse-stationery.py` | Extract formats/settings | `python scripts/parse-stationery.py stationery.wxsp` |
+| `create-job.py` | Create job files | `python scripts/create-job.py --stationery stationery.wxsp` |
+| `parse-job.py` | View job configuration | `python scripts/parse-job.py job.waj` |
+| `validate-job.py` | Validate job files | `python scripts/validate-job.py --check-stationery job.waj` |
+| `list-job-targets.py` | List targets | `python scripts/list-job-targets.py --enabled job.waj` |
 
 ---
 

--- a/plugins/webworks-claude-skills/skills/epublisher/SKILL.md
+++ b/plugins/webworks-claude-skills/skills/epublisher/SKILL.md
@@ -93,12 +93,12 @@ Documents are organized into groups within projects:
 
 ## Scripts
 
-### parse-targets.sh
+### parse-targets.py
 
 Extract target information from a project file:
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/epublisher/scripts/parse-targets.sh <project-file>
+python scripts/parse-targets.py <project-file>
 ```
 
 Returns JSON with target names, IDs, formats, and output directories.
@@ -108,7 +108,7 @@ Returns JSON with target names, IDs, formats, and output directories.
 List and manage source document groups:
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/epublisher/scripts/manage-sources.sh <project-file> [list|add|remove]
+bash scripts/manage-sources.sh <project-file> [list|add|remove]
 ```
 
 ### copy-customization.py
@@ -116,7 +116,7 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/epublisher/scripts/manage-sources.sh <project-
 Copy format files from installation to project with structure validation:
 
 ```bash
-python ${CLAUDE_PLUGIN_ROOT}/skills/epublisher/scripts/copy-customization.py --source <install-file> --destination <project-file>
+python scripts/copy-customization.py --source <install-file> --destination <project-file>
 ```
 
 Validates parallel folder structure and creates directories as needed.
@@ -139,7 +139,7 @@ Validates parallel folder structure and creates directories as needed.
 ### Find all targets in a project
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/epublisher/scripts/parse-targets.sh /path/to/project.wep
+python scripts/parse-targets.py /path/to/project.wep
 ```
 
 ### Locate format customization files
@@ -152,7 +152,7 @@ Check the file resolver hierarchy:
 ### Identify source documents
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/epublisher/scripts/manage-sources.sh /path/to/project.wep list
+bash scripts/manage-sources.sh /path/to/project.wep list
 ```
 </common_tasks>
 

--- a/plugins/webworks-claude-skills/skills/epublisher/references/file-resolver-guide.md
+++ b/plugins/webworks-claude-skills/skills/epublisher/references/file-resolver-guide.md
@@ -556,7 +556,7 @@ When upgrading ePublisher:
 Python script for validated file copying with parallel structure enforcement:
 
 ```bash
-python ${CLAUDE_PLUGIN_ROOT}/skills/epublisher/scripts/copy-customization.py \
+python scripts/copy-customization.py \
     --source "C:\Program Files\WebWorks\ePublisher\2024.1\Formats\WebWorks Reverb 2.0\Pages\Connect.asp" \
     --destination "C:\projects\my-proj\Formats\WebWorks Reverb 2.0\Pages\Connect.asp"
 ```

--- a/plugins/webworks-claude-skills/skills/epublisher/references/project-parsing-guide.md
+++ b/plugins/webworks-claude-skills/skills/epublisher/references/project-parsing-guide.md
@@ -170,7 +170,7 @@ Both use Reverb format but have different output locations.
 **1. List Available Targets**
 Parse project file to show user all configured targets:
 ```bash
-./parse-targets.sh project.wep
+python scripts/parse-targets.py project.wep
 ```
 
 **2. Validate Target Name**
@@ -593,32 +593,32 @@ fi
 
 ## Helper Scripts
 
-### parse-targets.sh
+### parse-targets.py
 
 Parse project files to extract target and format information.
 
 **Usage:**
 ```bash
 # List all targets
-./parse-targets.sh project.wep
+python scripts/parse-targets.py project.wep
 
 # Detailed info
-./parse-targets.sh --list project.wep
+python scripts/parse-targets.py --list project.wep
 
 # JSON output
-./parse-targets.sh --json project.wep
+python scripts/parse-targets.py --json project.wep
 
 # Base Format Version
-./parse-targets.sh --version project.wep
+python scripts/parse-targets.py --version project.wep
 ```
 
 **Output examples:**
 ```
-$ ./parse-targets.sh project.wep
+$ python scripts/parse-targets.py project.wep
 WebWorks Reverb 2.0
 PDF - XSL-FO
 
-$ ./parse-targets.sh --version project.wep
+$ python scripts/parse-targets.py --version project.wep
 Base Format Version: 2024.1
 ```
 
@@ -629,21 +629,21 @@ Manage source documents in project files.
 **Usage:**
 ```bash
 # List all sources
-./manage-sources.sh --list project.wep
+bash scripts/manage-sources.sh --list project.wep
 
 # Validate paths exist
-./manage-sources.sh --validate project.wep
+bash scripts/manage-sources.sh --validate project.wep
 
 # Toggle inclusion
-./manage-sources.sh --toggle "Source\file.md" project.wep
+bash scripts/manage-sources.sh --toggle "Source\file.md" project.wep
 
 # Show group hierarchy
-./manage-sources.sh --groups project.wep
+bash scripts/manage-sources.sh --groups project.wep
 ```
 
 **Output examples:**
 ```
-$ ./manage-sources.sh --list project.wep
+$ bash scripts/manage-sources.sh --list project.wep
 Group: Getting Started
   ✓ Source\content-seed.md (included)
   ✓ Source\getting-started.md (included)
@@ -652,7 +652,7 @@ Group: Reference
   ✓ Source\api-reference.md (included)
   ✗ Source\old-content.md (excluded)
 
-$ ./manage-sources.sh --validate project.wep
+$ bash scripts/manage-sources.sh --validate project.wep
 ✓ Source\content-seed.md exists
 ✓ Source\getting-started.md exists
 ✗ Source\missing-file.md NOT FOUND

--- a/plugins/webworks-claude-skills/skills/epublisher/templates/project.wep
+++ b/plugins/webworks-claude-skills/skills/epublisher/templates/project.wep
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Version="1.1.2.0" ProjectID="hMDzxVACF5I" ChangeID="_7WZ93Dslfk" RuntimeVersion="2025.1" FormatVersion="{Current}" xmlns="urn:WebWorks-Publish-Project">
+  <Formats>
+    <Format TargetName="TargetName" Name="WebWorks Reverb 2.0" Type="Application" TargetID="Lf3DjZlhl_A">
+      <OutputDirectory>Output\TargetName</OutputDirectory>
+    </Format>
+  </Formats>
+  <Groups>
+    <Group Name="Docs" Type="normal" Included="true" GroupID="QeGxWoyPnS0" ChangeID="" />
+  </Groups>
+  <GlobalConfiguration ChangeID="A6CpOGl6bic">
+    <Rules Type="Paragraph" Default="{WWDefaultRule}" ChangeID="">
+      <Rule Key="{WWDefaultRule}" />
+    </Rules>
+    <Rules Type="Character" Default="{WWDefaultRule}" ChangeID="">
+      <Rule Key="{WWDefaultRule}" />
+    </Rules>
+    <Rules Type="Marker" Default="{WWDefaultRule}" ChangeID="">
+      <Rule Key="{WWDefaultRule}" />
+    </Rules>
+    <Rules Type="Graphic" Default="{WWDefaultRule}" ChangeID="">
+      <Rule Key="{WWDefaultRule}" />
+    </Rules>
+    <Rules Type="Table" Default="{WWDefaultRule}" ChangeID="">
+      <Rule Key="{WWDefaultRule}" />
+    </Rules>
+    <Rules Type="Page" Default="{WWDefaultRule}" ChangeID="">
+      <Rule Key="{WWDefaultRule}" />
+    </Rules>
+  </GlobalConfiguration>
+  <FormatConfigurations>
+    <FormatConfiguration TargetID="Lf3DjZlhl_A" ChangeID="CWJ2qzdnsxU">
+      <MergeSettings Title="">
+        <MergeGroup GroupID="QeGxWoyPnS0" />
+      </MergeSettings>
+    </FormatConfiguration>
+  </FormatConfigurations>
+  <AdapterConfigurations ChangeID="8Lhn5x923ec">
+    <AdapterConfiguration Name="Adobe FrameMaker" ChangeID="bHQWuYTITFA" />
+    <AdapterConfiguration Name="Helper Adapter" ChangeID="dNJ-Zvamyps" />
+    <AdapterConfiguration Name="Microsoft Word" ChangeID="7LPaOQSi4lw">
+      <AdapterConfigurationEntry Name="preserve-change-bars-in-pdf" Value="false" />
+      <AdapterConfigurationEntry Name="rd-field-handling" Value="book" />
+    </AdapterConfiguration>
+    <AdapterConfiguration Name="Xml Adapter" ChangeID="Q-ms96mwyuQ">
+      <AdapterConfigurationEntry Name="dita-combine-character-styles" Value="true" />
+      <AdapterConfigurationEntry Name="dita-ot-version" Value="3.7.4" />
+    </AdapterConfiguration>
+  </AdapterConfigurations>
+  <ProjectSettings />
+</Project>

--- a/plugins/webworks-claude-skills/skills/markdown-plus-plus/SKILL.md
+++ b/plugins/webworks-claude-skills/skills/markdown-plus-plus/SKILL.md
@@ -424,7 +424,7 @@ Apply custom styles to list containers:
 Use the validation script to check Markdown++ syntax:
 
 ```bash
-python ${CLAUDE_PLUGIN_ROOT}/skills/markdown-plus-plus/scripts/validate-mdpp.py document.md
+python scripts/validate-mdpp.py document.md
 ```
 
 **Options:**
@@ -444,7 +444,7 @@ python ${CLAUDE_PLUGIN_ROOT}/skills/markdown-plus-plus/scripts/validate-mdpp.py 
 Generate unique aliases for headings:
 
 ```bash
-python ${CLAUDE_PLUGIN_ROOT}/skills/markdown-plus-plus/scripts/add-aliases.py document.md --levels 1,2,3
+python scripts/add-aliases.py document.md --levels 1,2,3
 ```
 
 **Options:**

--- a/plugins/webworks-claude-skills/skills/markdown-plus-plus/references/best-practices.md
+++ b/plugins/webworks-claude-skills/skills/markdown-plus-plus/references/best-practices.md
@@ -103,7 +103,7 @@ Later: See [Authentication](#api-authentication) for details.
 
 **Generate aliases automatically:**
 ```bash
-python ${CLAUDE_PLUGIN_ROOT}/skills/markdown-plus-plus/scripts/add-aliases.py document.md --levels 1,2,3
+python scripts/add-aliases.py document.md --levels 1,2,3
 ```
 
 ### Conditions
@@ -414,7 +414,7 @@ Ensure include chains never loop back.
 
 1. Run the validation script before publishing:
    ```bash
-   python ${CLAUDE_PLUGIN_ROOT}/skills/markdown-plus-plus/scripts/validate-mdpp.py document.md
+   python scripts/validate-mdpp.py document.md
    ```
 
 2. Test with different condition combinations

--- a/plugins/webworks-claude-skills/skills/reverb2/SKILL.md
+++ b/plugins/webworks-claude-skills/skills/reverb2/SKILL.md
@@ -34,10 +34,7 @@ Reverb 2.0 is a responsive HTML5 help system with:
 | **epublisher** | Use to understand project structure before testing |
 | **automap** | Use to rebuild output after SCSS customizations |
 
-**After customizing themes:** Use the automap skill to rebuild:
-```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh -c -n -t "WebWorks Reverb 2.0" project.wep
-```
+**After customizing themes:** Use the automap skill to rebuild the Reverb target.
 
 </related_skills>
 
@@ -72,11 +69,11 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh -c -n -t "W
 | Feature | Script | Description |
 |---------|--------|-------------|
 | Browser Testing | `browser-test.js` | Load output in headless Chrome, check for errors |
-| CSH Analysis | `parse-url-maps.sh` | Extract topic mappings from url_maps.xml |
-| SCSS Theming | `extract-scss-variables.sh` | Read current theme values |
+| CSH Analysis | `parse-url-maps.py` | Extract topic mappings from url_maps.xml |
+| SCSS Theming | `extract-scss-variables.py` | Read current theme values |
 | Color Override | `generate-color-override.sh` | Generate brand color files |
 | Entry Detection | `detect-entry-point.sh` | Find output location from project |
-| Report Generation | `generate-report.sh` | Create formatted test reports |
+| Report Generation | `generate-report.py` | Create formatted test reports |
 </capabilities>
 
 <browser_testing>
@@ -86,7 +83,7 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/automap/scripts/automap-wrapper.sh -c -n -t "W
 ### Run Test
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/browser-test.js <chrome-path> <entry-url> [format-settings-json]
+node scripts/browser-test.js <chrome-path> <entry-url> [format-settings-json]
 ```
 
 ### What It Checks
@@ -133,7 +130,7 @@ node ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/browser-test.js <chrome-path> 
 ### Parse url_maps.xml
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/parse-url-maps.sh <url-maps-file> [format]
+python scripts/parse-url-maps.py <url-maps-file> [format]
 ```
 
 Format: `json` (default) or `table`
@@ -177,7 +174,7 @@ $neo_page_color: #fefefe;           // Page background
 ### Extract Current Values
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/extract-scss-variables.sh <project-dir> [category]
+python scripts/extract-scss-variables.py <project-dir> [category]
 ```
 
 Categories: `neo`, `layout`, `toolbar`, `header`, `footer`, `menu`, `sizes`
@@ -185,7 +182,8 @@ Categories: `neo`, `layout`, `toolbar`, `header`, `footer`, `menu`, `sizes`
 ### Generate Color Override
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/generate-color-override.sh <output-path> \
+bash scripts/generate-color-override.sh <output-path> \
+
   --main-color "#E63946" \
   --main-text "#FFFFFF" \
   --secondary-color "#F1FAEE" \
@@ -224,7 +222,7 @@ Installs Node.js dependencies for browser testing.
 
 ```bash
 # Install dependencies (run once)
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/setup-dependencies.sh
+bash scripts/setup-dependencies.sh
 ```
 
 **Prerequisites:**
@@ -243,8 +241,7 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/setup-dependencies.sh
 ### Node.js (for browser testing)
 
 ```bash
-cd skills/reverb
-npm install
+bash scripts/setup-dependencies.sh
 ```
 
 Installs `puppeteer-core` for headless Chrome automation.
@@ -253,7 +250,7 @@ Installs `puppeteer-core` for headless Chrome automation.
 
 Browser testing requires Chrome. Detect with:
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/detect-chrome.sh
+bash scripts/detect-chrome.sh
 ```
 </dependencies>
 
@@ -265,26 +262,26 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/detect-chrome.sh
 
 ```bash
 # 1. Detect entry point
-PROJECT_INFO=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/detect-entry-point.sh project.wep)
+PROJECT_INFO=$(bash scripts/detect-entry-point.sh project.wep)
 
 # 2. Run browser test
-TEST_RESULTS=$(node ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/browser-test.js "$CHROME" "$ENTRY_URL")
+TEST_RESULTS=$(node scripts/browser-test.js "$CHROME" "$ENTRY_URL")
 
 # 3. Parse CSH
-CSH_DATA=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/parse-url-maps.sh output/url_maps.xml)
+CSH_DATA=$(python scripts/parse-url-maps.py output/url_maps.xml)
 
 # 4. Generate report
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/generate-report.sh project.wep "$PROJECT_INFO" "$CSH_DATA" "$TEST_RESULTS"
+python scripts/generate-report.py project.wep "$PROJECT_INFO" "$CSH_DATA" "$TEST_RESULTS"
 ```
 
 ### Apply Brand Colors
 
 ```bash
 # 1. Check current colors
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/extract-scss-variables.sh /path/to/project neo
+python scripts/extract-scss-variables.py /path/to/project neo
 
 # 2. Generate override
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/generate-color-override.sh \
+bash scripts/generate-color-override.sh \
   /path/to/project/Formats/WebWorks\ Reverb\ 2.0/Pages/sass/_colors.scss \
   --main-color "#0052CC" --main-text "#FFFFFF"
 

--- a/plugins/webworks-claude-skills/skills/reverb2/workflows/browser-testing.md
+++ b/plugins/webworks-claude-skills/skills/reverb2/workflows/browser-testing.md
@@ -14,15 +14,14 @@ Ensure Chrome and Node.js dependencies are available:
 
 ```bash
 # Detect Chrome installation
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/detect-chrome.sh
+bash scripts/detect-chrome.sh
 ```
 
 If Chrome not found, report to user with manual installation instructions.
 
 ```bash
 # Check/install Node dependencies
-cd skills/reverb
-npm install
+bash scripts/setup-dependencies.sh
 ```
 
 ## Step 2: Locate Reverb Entry Point
@@ -30,7 +29,7 @@ npm install
 Find the output location from the project file:
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/detect-entry-point.sh <project.wep>
+bash scripts/detect-entry-point.sh <project.wep>
 ```
 
 This returns JSON with:
@@ -44,7 +43,7 @@ If no project file provided, ask user for the path to the Reverb output's `index
 Execute the headless browser test:
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/browser-test.js "<chrome-path>" "<entry-url>" [format-settings-json]
+node scripts/browser-test.js "<chrome-path>" "<entry-url>" [format-settings-json]
 ```
 
 Arguments:

--- a/plugins/webworks-claude-skills/skills/reverb2/workflows/csh-analysis.md
+++ b/plugins/webworks-claude-skills/skills/reverb2/workflows/csh-analysis.md
@@ -11,7 +11,7 @@ Find the CSH mapping file in the Reverb output:
 
 ```bash
 # If project file available
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/detect-entry-point.sh <project.wep>
+bash scripts/detect-entry-point.sh <project.wep>
 # Then look for url_maps.xml in the output directory
 ```
 
@@ -24,7 +24,7 @@ If not found, ask user for the path to the Reverb output directory.
 Extract CSH topic information:
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/parse-url-maps.sh <url-maps-file> [format]
+python scripts/parse-url-maps.py <url-maps-file> [format]
 ```
 
 Format options:

--- a/plugins/webworks-claude-skills/skills/reverb2/workflows/generate-report.md
+++ b/plugins/webworks-claude-skills/skills/reverb2/workflows/generate-report.md
@@ -15,7 +15,7 @@ Collect inputs for the report:
 
 ```bash
 # Required: Project file path
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/detect-entry-point.sh <project.wep>
+bash scripts/detect-entry-point.sh <project.wep>
 ```
 
 This provides:
@@ -30,10 +30,10 @@ Execute browser testing to get runtime results:
 
 ```bash
 # Detect Chrome
-CHROME=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/detect-chrome.sh | jq -r '.path')
+CHROME=$(bash scripts/detect-chrome.sh | jq -r '.path')
 
 # Run test
-TEST_RESULTS=$(node ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/browser-test.js "$CHROME" "<entry-url>")
+TEST_RESULTS=$(node scripts/browser-test.js "$CHROME" "<entry-url>")
 ```
 
 Capture:
@@ -47,7 +47,7 @@ Capture:
 Extract Context Sensitive Help data:
 
 ```bash
-CSH_DATA=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/parse-url-maps.sh <output>/url_maps.xml json)
+CSH_DATA=$(python scripts/parse-url-maps.py <output>/url_maps.xml json)
 ```
 
 Capture:
@@ -60,7 +60,7 @@ Capture:
 Aggregate all results:
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/generate-report.sh <project.wep> \
+python scripts/generate-report.py <project.wep> \
   "$PROJECT_INFO" \
   "$CSH_DATA" \
   "$TEST_RESULTS"
@@ -119,10 +119,10 @@ If user requests, save report to file:
 
 ```bash
 # Text format
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/generate-report.sh ... > reverb-test-report.txt
+python scripts/generate-report.py ... > reverb-test-report.txt
 
 # JSON format (follows templates/test-results.json structure)
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/generate-report.sh ... --json > reverb-test-report.json
+python scripts/generate-report.py ... --json > reverb-test-report.json
 ```
 
 JSON output conforms to `../templates/test-results.json` for programmatic use.

--- a/plugins/webworks-claude-skills/skills/reverb2/workflows/scss-theming.md
+++ b/plugins/webworks-claude-skills/skills/reverb2/workflows/scss-theming.md
@@ -31,7 +31,7 @@ Ask user: "Apply to single target or all Reverb 2.0 targets?"
 Show existing theme configuration:
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/extract-scss-variables.sh <project-dir> neo
+python scripts/extract-scss-variables.py <project-dir> neo
 ```
 
 This displays the 6 "neo" quick-theming variables:
@@ -48,10 +48,10 @@ $neo_page_color: #fefefe;           // Page background
 For detailed exploration:
 ```bash
 # All categories
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/extract-scss-variables.sh <project-dir>
+python scripts/extract-scss-variables.py <project-dir>
 
 # Specific category
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/extract-scss-variables.sh <project-dir> [layout|toolbar|header|footer|menu|sizes]
+python scripts/extract-scss-variables.py <project-dir> [layout|toolbar|header|footer|menu|sizes]
 ```
 
 ## Step 4: Generate Color Override
@@ -59,7 +59,7 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/extract-scss-variables.sh <pro
 Create a `_colors.scss` override file with new brand colors:
 
 ```bash
-bash ${CLAUDE_PLUGIN_ROOT}/skills/reverb2/scripts/generate-color-override.sh <output-path> \
+bash scripts/generate-color-override.sh <output-path> \
   --main-color "#E63946" \
   --main-text "#FFFFFF" \
   --secondary-color "#F1FAEE" \


### PR DESCRIPTION
## Summary

- Replace all `${CLAUDE_PLUGIN_ROOT}/skills/<skill>/scripts/` references with relative paths (`scripts/foo.sh` for same-skill, skill delegation for cross-skill) to fix Windows backslash expansion breaking bash execution
- Fix 4 Python scripts documented with wrong `.sh` extensions and `bash` interpreter (parse-url-maps, extract-scss-variables, generate-report, parse-targets)
- Replace fragile `../automap/` cross-skill path traversal with skill delegation pattern
- Fix `cd skills/reverb` (wrong directory name) with `bash scripts/setup-dependencies.sh`
- Consolidate duplicated CI/CD sections and reduce `build="True"` explanation repetition
- Fix `./scripts/` prefix inconsistencies in CLAUDE.md, CONTRIBUTING.md, and job-file-guide.md
- Bump version to 2.5.2

## Test plan

- [x] Verified zero remaining `${CLAUDE_PLUGIN_ROOT}` references in skill files
- [x] Verified zero remaining wrong `.sh` extensions for Python scripts
- [x] Verified zero remaining `./scripts/` or `./parse-` patterns in docs
- [x] Verified zero remaining `cd skills/reverb` references
- [x] Validated relative path resolution works from user project directory (manual testing)
- [x] Test automap skill invocation from a project directory
- [x] Test reverb2 skill invocation (browser testing workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)