### PR TITLE
Add humanizer plugin as git submodule

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,6 +29,24 @@
         "single-sourcing"
       ],
       "strict": false
+    },
+    {
+      "name": "humanizer",
+      "description": "Remove signs of AI-generated writing from text. Detects and fixes 25 common AI writing patterns based on Wikipedia's Signs of AI writing guide.",
+      "author": {
+        "name": "blader",
+        "url": "https://github.com/blader"
+      },
+      "source": "./plugins/humanizer",
+      "category": "writing-tools",
+      "tags": [
+        "humanizer",
+        "ai-writing",
+        "editing",
+        "writing",
+        "text-quality"
+      ],
+      "strict": false
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "webworks-claude-skills",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "description": "Claude Code skills for WebWorks ePublisher platform: Markdown++ authoring, project management, AutoMap automation, and Reverb output testing",
   "owner": {
     "name": "Quadralay Corporation",

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plugins/humanizer/skills/humanizer"]
+	path = plugins/humanizer/skills/humanizer
+	url = https://github.com/blader/humanizer.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,8 @@ The script updates both version locations automatically:
 - `plugins/webworks-claude-skills/.claude-plugin/plugin.json`
 - `.claude-plugin/marketplace.json`
 
+**Note:** The `humanizer` plugin version in `plugins/humanizer/.claude-plugin/plugin.json` tracks the upstream [blader/humanizer](https://github.com/blader/humanizer) release and is **not** managed by this script.
+
 **When to bump:**
 
 | Type | Use For | Example |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,14 +10,20 @@
 ## Repository Structure
 
 ```
-plugins/webworks-claude-skills/
-├── plugin.json
-└── skills/
-    └── skill-name/
-        ├── SKILL.md           # Skill definition
-        ├── scripts/           # Helper scripts (optional)
-        │   └── lib/           # Shared Python modules
-        └── references/        # Reference documentation
+plugins/
+├── webworks-claude-skills/        # Native plugin (owned by this repo)
+│   ├── .claude-plugin/plugin.json
+│   └── skills/
+│       └── skill-name/
+│           ├── SKILL.md           # Skill definition
+│           ├── scripts/           # Helper scripts (optional)
+│           │   └── lib/           # Shared Python modules
+│           └── references/        # Reference documentation
+└── humanizer/                     # Submodule-backed plugin
+    ├── .claude-plugin/plugin.json # Plugin wrapper (owned by this repo)
+    └── skills/
+        └── humanizer/             # Git submodule → blader/humanizer
+            └── SKILL.md
 ```
 
 ## SKILL.md Authoring
@@ -71,6 +77,35 @@ The script updates both version locations automatically:
 | `major` | Breaking changes, major restructuring | 2.1.0 → 3.0.0 |
 
 **Note:** Claude Code is aware of this workflow via CLAUDE.md and will run the bump script when preparing PRs.
+
+## Git Submodules
+
+The `humanizer` plugin is backed by a git submodule pointing to [blader/humanizer](https://github.com/blader/humanizer). This repo does not have push access to the upstream — it only tracks a specific commit.
+
+**Cloning with submodules:**
+
+```bash
+git clone --recurse-submodules <repo-url>
+
+# Or if already cloned:
+git submodule update --init --recursive
+```
+
+**Updating to the latest upstream version:**
+
+```bash
+cd plugins/humanizer/skills/humanizer
+git pull origin main
+cd ../../../..
+git add plugins/humanizer/skills/humanizer
+git commit -m "Update humanizer submodule to latest"
+```
+
+**If you need to make changes to the skill:** Fork [blader/humanizer](https://github.com/blader/humanizer), then update the submodule URL:
+
+```bash
+git submodule set-url plugins/humanizer/skills/humanizer https://github.com/<your-fork>/humanizer.git
+```
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ All skills activate automatically based on your project context.
 | **epublisher** | ePublisher project knowledge, file resolver hierarchy, customization patterns |
 | **automap** | Automated publishing with AutoMap CLI |
 | **reverb** | Reverb 2.0 output testing, CSH analysis, SCSS theming |
+| **humanizer** | Remove signs of AI-generated writing from text ([submodule](https://github.com/blader/humanizer)) |
 
 ## Example Workflows
 
@@ -61,6 +62,7 @@ Claude: Guides you through SCSS variable overrides with proper cascade mappings
 | epublisher | Windows | ePublisher 2024.1+ |
 | automap | Windows | ePublisher + AutoMap |
 | reverb | Windows | ePublisher + browser |
+| humanizer | Any | Claude Code or Claude Desktop |
 
 ## Contributing
 

--- a/plugins/humanizer/.claude-plugin/plugin.json
+++ b/plugins/humanizer/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "humanizer",
+  "version": "2.3.0",
+  "description": "Remove signs of AI-generated writing from text. Detects and fixes 25 common AI writing patterns based on Wikipedia's Signs of AI writing guide.",
+  "author": {
+    "name": "blader",
+    "url": "https://github.com/blader"
+  },
+  "homepage": "https://github.com/blader/humanizer",
+  "repository": "https://github.com/blader/humanizer",
+  "license": "MIT",
+  "keywords": [
+    "humanizer",
+    "ai-writing",
+    "editing",
+    "writing",
+    "text-quality"
+  ]
+}

--- a/plugins/webworks-claude-skills/.claude-plugin/plugin.json
+++ b/plugins/webworks-claude-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webworks-claude-skills",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "description": "Claude Code skills for WebWorks ePublisher platform: Markdown++ authoring, project management, AutoMap automation, and Reverb output testing",
   "author": {
     "name": "Quadralay Corporation",


### PR DESCRIPTION
## Summary

- Add [blader/humanizer](https://github.com/blader/humanizer) as a submodule-backed plugin under `plugins/humanizer/`
- Plugin wrapper (`plugin.json`) owned by this repo; skill content tracked via git submodule
- Document submodule maintenance (clone, update, fork) in CONTRIBUTING.md
- Add humanizer to Skills and Requirements tables in README.md
- Bump version to 2.8.0

## Test plan

- [ ] Verify `git clone --recurse-submodules` pulls the humanizer submodule
- [ ] Verify `plugins/humanizer/skills/humanizer/SKILL.md` is present after submodule init
- [ ] Confirm plugin structure matches existing `webworks-claude-skills` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)