### PR TITLE
Refresh plugin-json learning and surface docs/solutions in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,3 +55,7 @@ The script updates both `plugin.json` and `marketplace.json` to keep versions sy
 2. Run `scripts/bump-version.sh <type>`
 3. Include the version bump in your PR
 4. Merge PR - version is already updated
+
+## Documented Solutions
+
+`docs/solutions/` — documented solutions to past problems (bugs, best practices, workflow patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in documented areas.

--- a/docs/solutions/integration-issues/plugin-json-location-skill-registration.md
+++ b/docs/solutions/integration-issues/plugin-json-location-skill-registration.md
@@ -119,20 +119,13 @@ Changed from simple string author to object format matching Claude Code's offici
 
 Updated `.claude-plugin/marketplace.json` version from 2.0.8 to 2.1.0 to match.
 
-### 4. Fix GitHub Actions Workflow (Secondary Issue)
+### 4. Fix Version-Bump Path References (Secondary Issue)
 
-After the plugin.json move, the version-bump workflow broke because it referenced the old path.
+After the plugin.json move, the version-bump tooling broke because it referenced the old path.
 
-**File:** `.github/workflows/version-bump.yml`
+At the time of this fix, version bumping ran through `.github/workflows/version-bump.yml`, which had three references to `plugins/webworks-claude-skills/plugin.json` that needed to be updated to `plugins/webworks-claude-skills/.claude-plugin/plugin.json`.
 
-Updated 3 path references:
-```yaml
-# Before
-plugins/webworks-claude-skills/plugin.json
-
-# After
-plugins/webworks-claude-skills/.claude-plugin/plugin.json
-```
+That workflow was later removed (commit `fd51c6e`) and replaced by a manual script: `scripts/bump-version.sh`. The script reads the same `.claude-plugin/plugin.json` path, so the principle still applies — when moving plugin config, audit every consumer (CI workflows, scripts, docs) that references the old location.
 
 ## Verification
 
@@ -169,7 +162,7 @@ Always document the correct plugin structure for new developers.
 
 - `plugins/webworks-claude-skills/.claude-plugin/plugin.json` - Plugin configuration
 - `.claude-plugin/marketplace.json` - Marketplace definition
-- `.github/workflows/version-bump.yml` - Version automation
+- `scripts/bump-version.sh` - Manual version-bump script (replaced the removed `.github/workflows/version-bump.yml`)
 - `plans/fix-plugin-structure-for-skill-registration.md` - Original investigation plan
 
 ## References


### PR DESCRIPTION
## Summary

- Refresh `docs/solutions/integration-issues/plugin-json-location-skill-registration.md`: section 4 referenced `.github/workflows/version-bump.yml`, which was deleted in `fd51c6e` and replaced by `scripts/bump-version.sh`. The core lesson (plugin.json must live in `.claude-plugin/`) is unchanged; only the secondary CI/CD reference was updated.
- Add a small **Documented Solutions** section to `CLAUDE.md` so fresh agents and new contributors discover `docs/solutions/` and its frontmatter conventions when implementing or debugging in documented areas.

## Refresh report

Scanned 5 learnings under `docs/solutions/`:

- **Kept (4)** — references valid, guidance still accurate:
  - `authoritative-skill-patterns.md`
  - `bash-syntax-errors-in-skill-tables.md` (substantively cited from `CONTRIBUTING.md`)
  - `gemini-pillow-marketing-images.md`
  - `plan-documents-workflow.md`
- **Updated (1)** — `integration-issues/plugin-json-location-skill-registration.md` (this PR)

No consolidations, replacements, deletions, or stale-marks.

## Test plan

- [ ] Confirm CLAUDE.md renders the new section as expected
- [ ] Confirm the updated learning still reads coherently end-to-end