### PR TITLE
Closes #105: Add customization-audit skill for upgrade override audits

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "webworks-agent-skills",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "owner": {
     "name": "Quadralay Corporation",

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ All skills activate automatically based on your project context.
 | **markdown-integration** | ePublisher integration patterns for Markdown++ sources (variable resolution, style mapping to Stationery, per-target conditions) |
 | **automap** | Automated publishing with AutoMap CLI |
 | **reverb2** | Reverb 2.0 output testing, CSH analysis, SCSS theming |
+| **customization-audit** | Audit advanced customizations (overrides) on upgrade — drift detection, fork-point discovery, and removal of retired/orphan/cruft/redundant overrides |
 | **claude-md-audit** | Audit and shrink `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` to behaviorally-focused entries the agent can't self-discover |
 | **humanizer** | Remove signs of AI-generated writing from text — [vendored from blader/humanizer](plugins/humanizer/README.md) with planned divergence for agent-readable input |
 
@@ -76,6 +77,7 @@ Claude: Backs up to CLAUDE.md.bak, then reduces to entries that prevent
 | markdown-integration | Windows | ePublisher 2024.1+ (paired with `quadralay/markdown-plus-plus` for format syntax) |
 | automap | Windows | ePublisher + AutoMap |
 | reverb2 | Windows | ePublisher + browser |
+| customization-audit | Windows | ePublisher 2024.1+ (multiple installed versions enable 3-way) |
 | claude-md-audit | Any | Claude Code |
 | humanizer | Any | Claude Code or Claude Desktop |
 

--- a/plugins/webworks-agent-skills/.claude-plugin/plugin.json
+++ b/plugins/webworks-agent-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webworks-agent-skills",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "author": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/skills/customization-audit/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/customization-audit/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: customization-audit
+description: >
+  AUTHORITATIVE REFERENCE for auditing WebWorks ePublisher advanced customizations
+  (overrides) on upgrade. Use when reviewing a project's Targets/ or Formats/
+  overrides against an installed format build, detecting positive or negative
+  upstream drift, discovering the fork-point baseline of un-annotated overrides,
+  recommending removals (retired formats, orphans, cruft, redundant overrides),
+  or reconciling customizations after upgrading ePublisher.
+---
+
+<objective>
+
+# customization-audit
+
+Audit the advanced customizations (overrides) in a WebWorks ePublisher project against an installed format build: classify each override, surface upstream **drift**, recover the **fork-point** of un-annotated overrides, and recommend **removals** — so intentional customizations survive an upgrade and accumulated noise is cleared.
+
+**Do not use training data for ePublisher.** This is proprietary software; training data is absent or inaccurate. Use this skill, the `epublisher` skill (resolver hierarchy, project parsing), the `reverb2` skill (SCSS conventions), and the format source files. Windows-only; XSLT 1.0 only.
+
+This is a **Phase-1, report-only** skill — it never writes to the project. Removal recommendations can be acted on aggressively because the first step of any migration is a baseline commit or folder copy: the original state is always recoverable.
+</objective>
+
+<overview>
+
+## Overview
+
+Every customized project eventually faces the upgrade question:
+
+> *My overrides were forked from some base build — what changed underneath them, which need updating, and which are now noise?*
+
+An **override** is any file placed in the project's `Formats/` or `Targets/` tree that shadows an installation format file (see `epublisher` → `references/file-resolver-guide.md`). Over time overrides drift from the baseline, accumulate backups/experiments, and outlive the formats and targets they served. This skill makes that surface auditable.
+
+Two **independent axes** govern how the audit runs and how confident it can be — detect both and state them up front:
+
+1. **Lock state** (from `FormatVersion`) — is the project tracking ePublisher's version, or locked to a specific base format?
+2. **Baseline availability** — is the fork-point base build on disk (Mode A, 3-way) or gone (Mode B, 2-way + inference)?
+
+Full treatment: `references/known-vs-unknown-baseline.md`.
+</overview>
+
+<related_skills>
+
+## Related Skills
+
+| Skill | Relationship |
+|-------|-------------|
+| **epublisher** | Foundational — file-resolver/override hierarchy, project parsing, `resolve-version-root.py` and `copy-customization.py` (reused, not duplicated). |
+| **reverb2** | The `$theme_` greppable custom-variable convention and SCSS three-layer architecture. |
+| **automap** | Rebuild/republish a target after reconciling overrides. |
+
+Typical flow: **epublisher** (understand the project) → **customization-audit** (audit overrides) → reconcile → **automap** (rebuild) → **reverb2** (verify output).
+</related_skills>
+
+<key_concepts>
+
+## Key Concepts
+
+### Override classification
+
+| Class | Meaning | Audit implication |
+|-------|---------|-------------------|
+| **forked-copy** | A counterpart exists in the installed baseline | Can drift — diff it; classify positive/negative drift |
+| **net-new** | No baseline counterpart (custom partials, third-party assets, cruft) | Cannot drift — run compatibility, wiring, and cruft checks |
+
+### Three customization signals
+
+A customization is recognized even when the author used none of the others:
+
+1. **Annotation markers** — a stable comment tag (`EPUB####`, `WEBWORKS`, a project/company code). Configurable.
+2. **Greppable variable prefix** — SCSS custom variables under a project prefix (`$theme_`, or a company abbreviation). The prefix is **per-user and auto-detected** from the override-minus-baseline variable set — never hardcoded.
+3. **Fork-point fingerprinting** — when neither marker nor prefix is present, recover the true fork-point baseline and diff against it to reveal intent.
+
+Details and the annotation test: `references/classification-heuristics.md`.
+
+### Drift has two directions
+
+- **Positive drift** — the baseline *added* something the override lacks (missed upstream fix/feature).
+- **Negative drift** — the baseline *removed* something the override still carries (obsolete code left behind). The signature is an **unannotated** reference to something the current baseline no longer defines.
+
+### Lock state and baseline availability
+
+- `FormatVersion="{Current}"` → project **tracks** ePublisher's version; auto-upgrade-safe only when no advanced customizations exist.
+- `FormatVersion="2025.1"` (specific) → project is **locked**; will not auto-upgrade even with zero customizations.
+- **Mode A** (3-way): the fork-point base build is installed → drift and customization separate cleanly.
+- **Mode B** (2-way): fork-point gone (improper earlier upgrade, or a patched/early-release build) → classification is inferred; promote toward Mode A via fork-point discovery.
+
+The two axes are independent. See `references/known-vs-unknown-baseline.md`.
+
+### Retired formats and EOL versions
+
+- **Retired formats** (e.g. WebWorks Help 5.0, WebWorks Reverb 1.x) → recommend wholesale removal; do not compute drift (not useful).
+- **EOL format versions** — older than `2022.1` today (moves to `2023.1` when 2026.1 ships). Installable via the optional EOL installer; encourage moving forward.
+
+### Removal categories (aggressive by design)
+
+`retired-format` · `orphan-target` / `orphan-format` · `duplicate-backup` (cruft) · `redundant-override` (identical to baseline — a local patch since fixed upstream). Cruft is flagged only when it both looks like a duplicate/backup **and** is unreferenced; referenced custom source is never flagged. See `references/classification-heuristics.md`.
+</key_concepts>
+
+<commands>
+
+## Subcommands
+
+`scripts/audit-overrides.py <command> --project <path.wep> [--install-root <dir>] [--format text|json]`
+
+| Command | Purpose | When to use |
+|---------|---------|-------------|
+| `enumerate` | List + classify every override (lock state, target→format resolution) | First look at the override surface |
+| `discover` | Per-format fork-point + **staleness depth** vs the lock (retired-aware, plateau-aware) | Mode B, or to find overrides never re-synced to their own lock |
+| `audit` | 2-way diff + three customization signals + SCSS missing-variable / partial-wiring / dangling-reference checks | The standard health check |
+| `cleanup` | Removal recommendations: retired / orphan / cruft / redundant | Pruning noise before/after upgrade |
+| `drift` | 3-way classifier (`--from-version` → `--to-version`): manual-merge / auto-mergeable / fast-forward / redundant / in-sync | Planning the reconciliation of a real upgrade |
+
+Recommended order for an upgrade: `enumerate` → `cleanup` (prune first) → `discover` (establish baseline) → `drift` (plan the merge). Step-by-step with a worked customer example: `references/upgrade-audit-guide.md`.
+</commands>
+
+<scripts>
+
+## Scripts
+
+### audit-overrides.py
+
+Single entry point for all five subcommands. Python 3; reuses `epublisher` conventions (project parsing, version-root resolution).
+
+Common options: `--project` (required), `--install-root` (default `C:\Program Files\WebWorks\ePublisher`), `--format text|json`.
+
+Per-command options:
+- `enumerate`, `audit`, `cleanup`: `--baseline-version` (override the derived baseline).
+- `audit`: `--annotation-pattern <regex>` (repeatable); `--theme-prefix <name>` (repeatable; auto-detected if omitted).
+- `drift`: `--to-version <ver>` (required); `--from-version <ver>` (default: the project's locked `FormatVersion`).
+
+JSON mode emits structured findings for every command — use it to drive reconciliation tooling or reports.
+</scripts>
+
+<references>
+
+## Reference Files
+
+- `references/upgrade-audit-guide.md` — end-to-end workflow, command sequence, and a worked 2024.1 → 2025.1 customer upgrade with output interpretation.
+- `references/known-vs-unknown-baseline.md` — lock state (Axis 1), Mode A/B (Axis 2), fork-point discovery, staleness depth, confidence taxonomy, retired/EOL policy, and Mode-B → Mode-A promotion recipes.
+- `references/classification-heuristics.md` — the three customization signals, the annotation test, positive vs negative drift, cruft/duplicate and redundant-override rules, and the CRLF normalization gotcha.
+</references>
+
+<common_tasks>
+
+## Common Tasks
+
+```bash
+cd scripts
+
+# 1. Inventory + classify the override surface
+python audit-overrides.py enumerate --project "C:\proj\my.wep"
+
+# 2. Prune noise (retired formats, orphans, cruft, redundant overrides)
+python audit-overrides.py cleanup --project "C:\proj\my.wep"
+
+# 3. Find each format's fork-point and how stale it is vs the lock
+python audit-overrides.py discover --project "C:\proj\my.wep"
+
+# 4. Health check: drift + customization signals + SCSS/wiring/dangling checks
+python audit-overrides.py audit --project "C:\proj\my.wep"
+
+# 5. Plan a real upgrade (3-way), e.g. locked 2024.1 -> 2025.1
+python audit-overrides.py drift --project "C:\proj\my.wep" --to-version 2025.1
+```
+</common_tasks>
+
+<common_mistakes>
+
+## Common Mistakes
+
+- **Hardcoding the custom-variable prefix.** It is per-user (`$theme_`, `$acme_`, a company code). Always auto-detect from the override-minus-baseline variable set; only pass `--theme-prefix` to *declare* an expected one and flag deviations.
+- **Reading override-only changes as customizations.** In Mode B a 2-way diff cannot tell a customization from negative drift. The disambiguator is the **annotation test**: unannotated divergence is probable drift.
+- **Computing drift for retired formats.** Not useful — recommend wholesale removal instead.
+- **Treating CRLF differences as changes.** Always normalize line endings before diffing/fingerprinting (the script does this); a raw diff of a CRLF override vs an LF baseline reads as 100% changed.
+- **Hesitating to remove noise.** Migration step 1 is a baseline commit/copy, so removals are recoverable. Be aggressive: retired formats, orphans, duplicates, and redundant overrides should go.
+- **Flagging referenced custom source as cruft.** A custom `.js`/`.scss`/image referenced by an override is intentional source, never cruft — the reference set (including project FormatSettings) protects it.
+</common_mistakes>
+
+<success_criteria>
+
+## Success Criteria
+
+- Project lock state and baseline mode (A/B) reported up front.
+- Every override classified (forked-copy vs net-new) with target→format resolution.
+- Forked overrides classified for positive/negative drift; customizations surfaced via annotation, prefix, or fork-point.
+- SCSS missing-variable, partial-wiring, and dangling-reference checks run.
+- Removal recommendations produced (retired / orphan / cruft / redundant) without flagging referenced source.
+- For an upgrade: a 3-way verdict per surviving override (manual-merge / auto-mergeable / fast-forward / redundant / in-sync).
+- No writes to the project (Phase 1).
+</success_criteria>

--- a/plugins/webworks-agent-skills/skills/customization-audit/references/classification-heuristics.md
+++ b/plugins/webworks-agent-skills/skills/customization-audit/references/classification-heuristics.md
@@ -1,0 +1,84 @@
+# Classification Heuristics
+
+How the audit decides what a given divergence *means*: intentional customization, positive drift, negative drift, cruft, or redundant. These heuristics are what make a 2-way audit useful and a 3-way audit precise.
+
+## The three customization signals
+
+A customization is recognized if **any** of these fire — authors rarely use all three, and many use none.
+
+### 1. Annotation markers (comment-based)
+
+A stable comment tag marks an intentional change: `EPUB####` (ticket), `WEBWORKS`, or a project/company code like `DICAD`. One grep per tag finds every deliberate deviation. Comments survive reflows and edits where structure does not, so this is the convention for non-SCSS files (ASP, XSL, XML).
+
+- Configurable via `--annotation-pattern <regex>` (repeatable).
+- The **annotation test** is the primary disambiguator (below).
+
+### 2. Greppable variable prefix (identifier-based, SCSS)
+
+SCSS achieves the same locatability without comments cluttering the cascade: custom variables share a project prefix — canonically `$theme_`, but often a company abbreviation (`$acme_`, `$webworks_`). A single grep for the prefix enumerates every custom variable.
+
+**The prefix is per-user and must be auto-detected, never hardcoded.** Standard Reverb variables (toolbar, menu, page, …) dominate any raw frequency count, so the prefix cannot be found by frequency. It is found by **set difference**: the variables present in the override but absent from the baseline *are* the customizations, and their dominant prefix is the project's convention.
+
+- `--theme-prefix <name>` *declares* an expected prefix so custom variables falling outside it are flagged as "less greppable"; omit it to auto-detect.
+- A custom variable with no consistent prefix is a maintainability smell — recommend adopting the project prefix.
+
+### 3. Fork-point fingerprinting (diff-based)
+
+When neither marker nor prefix is present — the common real-world case — recover the fork-point baseline (`discover`) and diff the override against it. Whatever differs *is* the customization, regardless of annotation. This is the fallback that makes un-annotated overrides auditable, and the bridge from Mode B toward Mode A (see `known-vs-unknown-baseline.md`).
+
+## The annotation test
+
+> An **annotated** divergence is an intentional customization. An **unannotated** divergence is probable drift — in either direction — and warrants review.
+
+This is decisive in Mode B, where a 2-way diff cannot otherwise tell "the override added this" (customization) from "the baseline removed this" (negative drift). Absence of a marker is the first clue it is drift, not intent. Corroborate with git blame and code shape.
+
+## Drift directions
+
+Diff orientation: baseline (`base`) vs override (`mine`).
+
+| Signal | Lines | Likely meaning |
+|--------|-------|----------------|
+| **Positive drift** | present in `base`, absent from `mine` | Upstream added a fix/feature the override lacks (forked before it landed) |
+| **Negative drift** | present in `mine`, absent from `base`, **unannotated**, and references something `base` no longer defines | Obsolete code removed upstream but retained in the override |
+| **Customization** | present in `mine`, absent from `base`, **annotated** or under the project prefix | Intentional |
+
+A large baseline-only delta on a forked-copy is a **positive-drift suspect**; confirm with `discover` + a 3-way diff. A **dangling reference** — a `wwpage:attribute-*` binding (or class/template) the current baseline defines nowhere and the project did not define either — is the signature of **negative drift** when unannotated.
+
+## 3-way verdicts (the `drift` command)
+
+With `base-old`, `base-new`, and `mine`, each forked override gets a verdict by comparing the *regions* changed by the customization against the *regions* changed upstream:
+
+| Verdict | Condition |
+|---------|-----------|
+| `redundant` | No upstream change **and** no customization (identical to baseline) |
+| `in-sync` | No upstream change; customizations carry forward as-is |
+| `fast-forward` | No customization; baseline changed → adopt new baseline |
+| `auto-mergeable` | Customized and upstream-changed regions are **disjoint** |
+| `manual-merge` | Customized regions **overlap** upstream-changed regions |
+
+## Removal heuristics (the `cleanup` command)
+
+Aggressive by design — migration step 1 is always a baseline commit/copy, so removals are recoverable.
+
+### Retired formats and orphans
+
+- **retired-format** — override belongs to a retired format (WebWorks Help 5.0, Reverb 1.x): remove wholesale, no drift analysis.
+- **orphan-target** — a `Targets/<name>/` override folder with no matching target in the project.
+- **orphan-format** — a `Formats/<name>/` override for a format no target uses (`Shared` excepted).
+
+### Cruft / duplicate-backup (two-gate)
+
+A net-new file is flagged **only when both** conditions hold:
+
+1. It **looks like a duplicate/backup** — either a backup/experiment filename (`orig`, `_old`, `_original`, `copy`, `_with_version`, `good_`, `blurry`, date-stamps, `NG`-prefixed) **or** a decorated variant of an existing override (affix-stripping then prefix match: `Footer_orig.asp` → `Footer.asp`, `good_sizes.scss` → `_sizes.scss`, `splash_2019.gif` → `splash.gif`).
+2. It is **not referenced** by any override or by project FormatSettings.
+
+The reference set includes filenames cited in override templates/styles, SCSS `@import` names, **and asset paths configured in the project file** (logo/splash settings live there, not in templates). This protects legitimate custom source — a custom `.js`/`.scss`/image referenced by an override is never cruft. Variant matching uses affix-stripping plus prefix-with-separator, *not* loose substring, so a distinct asset like `CompanyColorLogo.png` is not mistaken for `logo.jpg`.
+
+### Redundant overrides
+
+A forked-copy whose content is **identical to its baseline** (after CRLF normalization) does nothing but add maintenance noise — often a local patch since fixed upstream. Always recommend removal.
+
+## The CRLF gotcha
+
+Always normalize line endings (CRLF/CR → LF) before diffing, fingerprinting, or comparing. A CRLF override against an LF baseline otherwise reads as 100% changed and destroys every similarity and drift metric. The script normalizes on read; preserve this in any extension.

--- a/plugins/webworks-agent-skills/skills/customization-audit/references/known-vs-unknown-baseline.md
+++ b/plugins/webworks-agent-skills/skills/customization-audit/references/known-vs-unknown-baseline.md
@@ -1,0 +1,78 @@
+# Known vs. Unknown Baseline
+
+How the audit establishes its baseline, how confident it can be, and how to recover a baseline when the fork-point build is gone. Two **independent** axes govern this — detect both and report them up front.
+
+## Axis 1 — Project lock state (from `FormatVersion`)
+
+`FormatVersion` records whether the project is pinned to *ePublisher's* version or **locked** to a specific base format.
+
+| `FormatVersion` | Meaning | Upgrade behavior |
+|-----------------|---------|------------------|
+| `{Current}` (with e.g. `RuntimeVersion="2026.1"`) | Tracks ePublisher's own version | **Auto-upgrade-safe when no advanced customizations exist.** When customizations are present, this audit decides whether they carry forward safely. |
+| `2025.1` (a specific version) | **Locked** to that base format | **Will not auto-upgrade, even with zero customizations.** Upgrading means consciously re-pointing the project and re-validating. |
+
+The effective **base format version** is `RuntimeVersion` when tracking, else the pinned `FormatVersion`. Report the lock state first — it determines whether "just upgrade it" is even on the table before customizations enter the picture.
+
+## Axis 2 — Reference-version availability
+
+A precise drift audit wants three inputs: `base-old` (the version the override was forked from), `base-new` (the upgrade target), and `mine` (the override).
+
+### Mode A — 3-way (the normal case)
+
+Upgrades usually run with **both** the current and upgrade-to format versions installed side by side, so all three inputs exist:
+
+- `base-old → base-new` is **exactly** the upstream drift (positive and negative).
+- `base-old → mine` is **exactly** the customization (annotated or not).
+
+Cleanly separable, precise, and the basis for a real 3-way merge. Use whenever both builds are available — this is what the `drift` command does with `--from-version` (default: the lock) and `--to-version`.
+
+### Mode B — 2-way + inference (the exception)
+
+Only `base-new` and `mine` exist; the fork-point base is gone. This does **not** happen on a clean upgrade — it signals either an **earlier upgrade that was never properly completed** or a **patched / early-release build** no longer installed. A 2-way diff conflates customizations and drift in the same hunks, so classification falls back to inference (see `classification-heuristics.md`): the annotation test, git history, code-shape heuristics, and embedded version strings.
+
+In Mode B the audit must **label classifications as inferred, not proven**, and report reduced confidence.
+
+> `FormatVersion="{Current}"` does **not** imply Mode B. Lock state and baseline availability are independent — a `{Current}` project usually has its base on disk (Mode A). A project is only Mode B when its specific fork-point build is missing.
+
+## Fork-point discovery (promoting Mode B → Mode A)
+
+The `discover` command fingerprints each forked override against **every installed version** and, per format, finds the version that maximizes a size-weighted line-similarity — the most likely fork-point. This often recovers a usable `base-old` even in Mode B.
+
+### Per-format, not project-wide
+
+A project may span several formats forked at different times and evolving at different rates. A single project-wide fork-point is misleading; `discover` reports one per format. (In the worked customer case, `Shared` resolved to the current lock while `Reverb 2.0` resolved six releases older.)
+
+### Staleness depth
+
+For each non-retired format, `discover` compares the discovered fork-point against the project's lock:
+
+- fork-point **== lock** → current.
+- fork-point **< lock** → the overrides derive from an older base than the lock claims, by *N releases* — they were never re-synced when the lock was bumped. This is hidden, unreconciled drift.
+- fork-point **> lock** → usually an artifact of heavy customization skewing the match; reported with a caveat.
+
+### Confidence taxonomy
+
+| Confidence | When | How to read it |
+|------------|------|----------------|
+| **high** | Strong cross-file agreement and a clear score margin | Trust the fork-point |
+| **medium** | Partial agreement or a modest margin | Likely correct; corroborate |
+| **low** | Plateau (many versions match near-equally) or scattered votes | Indeterminate from fingerprinting alone; lean on the lock and companion files |
+
+A **plateau** (top candidates within a small epsilon) means the file barely changed across those versions — the fork-point is genuinely indeterminate from that file, not wrong. Heavy customization also pulls a single file's match older; the size-weighted cross-file aggregate is more robust than any one file's vote.
+
+### Same-family limit
+
+If the fork-point resolves to the same version family as the installed base (e.g. both `2026.1`), discovery cannot separate build-level differences within that family (a patched/early build shares the version folder). That residual is real drift but is not recoverable from disk — note it and rely on the per-file residual and the annotation test.
+
+## Recovering a true baseline
+
+Ranked best-to-worst:
+
+1. **Install the fork-point build.** If `discover` (or the pinned `FormatVersion`) names a version, install it (EOL installer if needed) for a true 3-way.
+2. **Recover from version control.** If the project is in git/SVN, the pristine fork-point file may be in history.
+3. **Accept the installed build as the sole baseline.** Run 2-way and rely on inference; label confidence accordingly.
+
+## Retired formats and EOL versions
+
+- **Retired formats** — WebWorks Help 5.0, WebWorks Reverb 1.x (and older help formats). Their overrides should be removed wholesale; computing drift for them is not useful. `discover` marks them and skips fork-point analysis; `cleanup` recommends wholesale removal. Users are often afraid to delete retired formats — help them move forward confidently.
+- **EOL format versions** — older than **2022.1** today; this moves to **2023.1** when 2026.1 ships. EOL versions are installable via the optional EOL installer for legacy/upgrade work, but encourage moving forward rather than staying on them.

--- a/plugins/webworks-agent-skills/skills/customization-audit/references/upgrade-audit-guide.md
+++ b/plugins/webworks-agent-skills/skills/customization-audit/references/upgrade-audit-guide.md
@@ -1,0 +1,102 @@
+# Upgrade Audit Guide
+
+End-to-end workflow for auditing a project's advanced customizations (overrides) on upgrade, with a worked example from a real customer upgrade.
+
+All commands are `python scripts/audit-overrides.py <command> --project <path.wep>`. The audit is **report-only** — it never writes to the project.
+
+## When to run this
+
+- Before or after bumping a project's ePublisher version.
+- When inheriting a customized project of unknown provenance.
+- When an override "isn't taking effect" or output looks wrong after an upgrade.
+- Periodically, to keep the override surface lean.
+
+## Recommended sequence
+
+Prune first, then analyze what survives — there is no point computing drift for files you are about to delete.
+
+```
+enumerate   ->   cleanup   ->   discover   ->   audit   ->   drift
+(inventory)     (prune)        (baseline)      (health)     (plan merge)
+```
+
+### 1. `enumerate` — inventory and classify
+
+Establishes the lock state, resolves every target to its format, and classifies each override as **forked-copy** (has a baseline counterpart) or **net-new**.
+
+```bash
+python audit-overrides.py enumerate --project "C:\proj\my.wep"
+```
+
+Read the header first: `lock=tracking|locked`, the base format version, and whether that baseline is on disk. A `locked` project will not auto-upgrade; a missing baseline means Mode B (see `known-vs-unknown-baseline.md`).
+
+### 2. `cleanup` — remove the noise
+
+Recommends removals in four categories: **retired-format**, **orphan-target/format**, **duplicate-backup** (cruft), **redundant-override**. Aggressive by design — migration step 1 is a baseline commit/copy, so anything removed is recoverable.
+
+```bash
+python audit-overrides.py cleanup --project "C:\proj\my.wep"
+```
+
+Act on the high-confidence removals before continuing; they shrink everything downstream.
+
+### 3. `discover` — establish the fork-point baseline
+
+Fingerprints each forked override against every installed version and reports a **per-format** fork-point plus **staleness depth** (how many releases behind the project's lock the overrides actually derive from). Retired formats are marked and skipped.
+
+```bash
+python audit-overrides.py discover --project "C:\proj\my.wep"
+```
+
+Use this to (a) confirm the baseline in Mode B, and (b) spot formats whose overrides were never re-synced to their own lock.
+
+### 4. `audit` — health check
+
+2-way diff of each forked override against the resolved baseline, plus the three customization signals and the SCSS missing-variable, partial-wiring, and dangling-reference checks.
+
+```bash
+python audit-overrides.py audit --project "C:\proj\my.wep"
+```
+
+Watch for: `POSITIVE DRIFT suspect` (large baseline-only delta), `UNANNOTATED` override changes (run `discover` to recover intent), `BUILD-BREAK RISK` (missing SCSS variable), `INCOMPLETE TEMPLATE` (custom partial not imported), and `NEGATIVE DRIFT` (dangling reference).
+
+### 5. `drift` — plan the reconciliation
+
+3-way classifier: fork-point/lock (`--from-version`) → upgrade target (`--to-version`) → override. Assigns each surviving forked override a verdict.
+
+```bash
+python audit-overrides.py drift --project "C:\proj\my.wep" --to-version 2025.1
+```
+
+| Verdict | Meaning | Action |
+|---------|---------|--------|
+| `in-sync` | Baseline unchanged between versions | Carry the override forward as-is |
+| `fast-forward` | Override is an unmodified copy; baseline changed | Adopt the new baseline (or drop the override) |
+| `auto-mergeable` | Customizations and upstream changes touch disjoint regions | Copy new baseline, re-apply customizations |
+| `manual-merge` | Customized regions also changed upstream | Hand-merge and re-test |
+| `redundant` | Identical to baseline, no upstream change | Remove |
+
+## Worked example — a real 2024.1 → 2025.1 upgrade
+
+A customer project running on the 2026.1 runtime but **locked** to `FormatVersion="2024.1"`, being moved to `2025.1`. Both 2024.1 and 2025.1 base formats were installed (Mode A). The override tree spanned **5 formats** and **12 targets** — 144 override files.
+
+**`enumerate`** reported `lock=locked, base=2024.1`, resolved all 12 targets to their formats (including the subtlety that one test target used the retired Reverb 1.x while others used Reverb 2.0), and classified 65 forked-copy / 79 net-new. The inflated net-new count was the first cruft signal.
+
+**`cleanup`** recommended removing **111 of 144** files:
+- 9 scopes as **retired-format** (94 files): the entire WebWorks Help 5.0 format and every target bound to it, plus the Reverb 1.x test target.
+- 11 **duplicate-backup** files: `*_orig.*`, `*_with_version.*`, `Good_*`, date-stamped pages, `_old` images, alternate splash variants — each an unreferenced duplicate of an existing override.
+- 6 **redundant-override** files identical to the 2024.1 baseline.
+
+This matched the customer's own manual reconciliation (they pruned 144 → 24) almost exactly. The only divergences were appropriate: the tool did **not** auto-remove a valid Reverb 2.0 target the customer chose to retire as a business decision (it flagged only that target's cruft), and it flagged one extra dated splash variant the customer had conservatively kept.
+
+**`discover`** showed the per-format truth that a single project-wide number would have hidden:
+- `Shared` — fork-point 2024.1, **current** (matches lock).
+- `WebWorks Reverb 2.0` — fork-point ~2019.1, **6 releases behind** the 2024.1 lock: the overrides were never re-synced when the lock was bumped (low confidence, because heavy customization skews the match — reported honestly).
+- `PDF - XSL-FO` — fork-point ~2021.1, 3 behind.
+- The two retired formats — marked RETIRED, no fork-point.
+
+**`audit`** surfaced the `locales.xml` story: heavy upstream change (a post-release CJK-search bugfix and new strings) plus substantial custom stopwords/synonyms — auto-mergeable because they sit in disjoint regions.
+
+**`drift --to-version 2025.1`** classified the survivors: `PDF Body.asp` **in-sync** (no upstream change), `locales.xml` **auto-mergeable**, `uilocales.xml` **fast-forward** (unmodified copy), several Reverb 2.0 templates **manual-merge**, and `Unsupported_Browser.asp` flagged **dropped upstream** (removed in 2025.1). The handful of manual-merges on the surviving target was the entire real reconciliation workload — exactly what the customer hand-merged.
+
+**Takeaway:** prune aggressively first (`cleanup` removed ~77% of the surface), then the drift work that remains is small and well-scoped (`drift` named the few files needing a hand-merge).

--- a/plugins/webworks-agent-skills/skills/customization-audit/scripts/audit-overrides.py
+++ b/plugins/webworks-agent-skills/skills/customization-audit/scripts/audit-overrides.py
@@ -1,0 +1,1389 @@
+#!/usr/bin/env python3
+"""
+audit-overrides.py
+
+Audit the advanced customizations (overrides) in a WebWorks ePublisher project
+against an installed format build, and surface UPSTREAM DRIFT so customizations
+can be reconciled on upgrade.
+
+Three subcommands:
+
+    enumerate   List every override and classify it (forked-copy vs net-new).
+    discover    "Sub-audit": fingerprint each forked-copy override against ALL
+                installed ePublisher versions to find the most likely fork-point
+                baseline, corroborated across companion files. Promotes an
+                unknown-baseline (Mode B) project toward a known one (Mode A).
+    audit       Full pass: lock state, classification, and per-file drift summary
+                using the resolved-or-discovered baseline.
+
+Key concepts (see issue quadralay/webworks-agent-skills#105):
+
+  Lock state (FormatVersion):
+    {Current}        -> project tracks ePublisher's version; auto-upgrade-safe
+                        only when no advanced customizations are present.
+    <specific ver>   -> project is LOCKED to that base format; no auto-upgrade.
+
+  Reference-version availability:
+    Mode A (3-way)   -> the fork-point base build is on disk; drift and
+                        customization separate cleanly.
+    Mode B (2-way)   -> fork-point base is gone (improper earlier upgrade, or a
+                        patched/early-release build). Classification is inferred.
+
+  Annotation test (primary disambiguator):
+    An annotated divergence (e.g. EPUB#### / WEBWORKS marker) is an intentional
+    customization. An UNANNOTATED divergence is probable drift -- positive
+    (baseline added it, override lacks it) or negative (baseline removed it,
+    override still carries it). Because users often fail to annotate their
+    intentions, the `discover` sub-audit recovers the true fork-point so the
+    override-vs-fork-point diff reveals those intentions regardless of markers.
+
+This is a Phase-1 (report-only) prototype. It makes no writes to the project.
+"""
+
+import argparse
+import difflib
+import json
+import re
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Optional
+
+try:
+    import defusedxml.ElementTree as ET
+except ImportError:  # pragma: no cover - fallback for minimal environments
+    import xml.etree.ElementTree as ET  # type: ignore
+
+DEFAULT_INSTALL_ROOT = Path(r"C:\Program Files\WebWorks\ePublisher")
+
+# Default annotation markers. Projects annotate customizations differently;
+# override/extend with --annotation-pattern. These two cover the design.wep
+# fixture (a ticket-style marker and a house keyword).
+DEFAULT_ANNOTATION_PATTERNS = [r"\bEPUB\d+\b", r"\bWEBWORKS\b"]
+
+# Folders inside a project that hold overrides.
+OVERRIDE_CONTAINERS = ("Formats", "Targets")
+
+# SCSS/text extensions we treat as text for diffing/fingerprinting.
+TEXT_SUFFIXES = {
+    ".asp", ".xsl", ".scss", ".css", ".js", ".fti", ".xml", ".html",
+    ".htm", ".json", ".txt", ".config", ".aspx", ".master",
+}
+
+EXIT_SUCCESS = 0
+EXIT_NOT_FOUND = 1
+EXIT_INVALID_ARGS = 2
+
+
+# --------------------------------------------------------------------------- #
+# Small helpers (intentionally inlined; factor into a shared lib/ when the
+# skill graduates from prototype -- see issue #105 anatomy note).
+# --------------------------------------------------------------------------- #
+def version_key(version: str) -> tuple[int, ...]:
+    """'2024.1' -> (2024, 1) for deterministic version sorting."""
+    return tuple(int(part) for part in re.findall(r"\d+", version))
+
+
+def local_name(tag: str) -> str:
+    """Strip an XML namespace: '{urn:...}Format' -> 'Format'."""
+    return tag.rsplit("}", 1)[-1]
+
+
+def is_text_file(path: Path) -> bool:
+    return path.suffix.lower() in TEXT_SUFFIXES
+
+
+def read_lines(path: Path) -> list[str]:
+    """Read a text file, normalizing line endings (CRLF/CR -> LF) so a pure
+    line-ending difference does not read as a 100% change."""
+    data = path.read_bytes()
+    text = data.decode("utf-8", errors="replace")
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    return text.split("\n")
+
+
+def similarity(a_lines: list[str], b_lines: list[str]) -> float:
+    """Line-level similarity ratio in [0,1] (1.0 == identical)."""
+    sm = difflib.SequenceMatcher(a=a_lines, b=b_lines, autojunk=False)
+    return sm.ratio()
+
+
+def diff_counts(base_lines: list[str], ovr_lines: list[str]) -> tuple[int, int]:
+    """Return (added_in_override, removed_from_base) line counts."""
+    added = removed = 0
+    for line in difflib.unified_diff(base_lines, ovr_lines, n=0, lineterm=""):
+        if line.startswith("+") and not line.startswith("+++"):
+            added += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            removed += 1
+    return added, removed
+
+
+# --------------------------------------------------------------------------- #
+# Project model
+# --------------------------------------------------------------------------- #
+@dataclass
+class ProjectInfo:
+    path: Path
+    runtime_version: str
+    format_version: str          # raw attribute, e.g. "{Current}" or "2025.1"
+    lock_state: str              # "tracking" | "locked"
+    base_format_version: str     # effective version: RuntimeVersion if tracking
+    target_to_format: dict[str, str] = field(default_factory=dict)
+    format_names: list[str] = field(default_factory=list)
+
+
+def parse_project(project_path: Path) -> ProjectInfo:
+    root = ET.parse(str(project_path)).getroot()
+    runtime = (root.get("RuntimeVersion") or "").strip()
+    fmt = (root.get("FormatVersion") or "").strip()
+
+    if not fmt or fmt == "{Current}":
+        lock_state = "tracking"
+        base = runtime
+    else:
+        lock_state = "locked"
+        base = fmt
+
+    target_to_format: dict[str, str] = {}
+    format_names: list[str] = []
+    for el in root.iter():
+        if local_name(el.tag) != "Format":
+            continue
+        target_name = (el.get("TargetName") or "").strip()
+        format_name = (el.get("Name") or "").strip()
+        if target_name and format_name:
+            target_to_format[target_name] = format_name
+        if format_name and format_name not in format_names:
+            format_names.append(format_name)
+
+    return ProjectInfo(
+        path=project_path,
+        runtime_version=runtime,
+        format_version=fmt or "{Current}",
+        lock_state=lock_state,
+        base_format_version=base,
+        target_to_format=target_to_format,
+        format_names=format_names,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Override enumeration + classification
+# --------------------------------------------------------------------------- #
+@dataclass
+class Override:
+    abs_path: Path
+    level: str          # "format" | "target"
+    scope_name: str     # format name or target name
+    format_name: str    # resolved format (== scope_name for level=format)
+    rel_path: str       # path under the format structure, POSIX style
+    is_text: bool
+    classification: str = "unknown"   # "forked-copy" | "net-new"
+    baseline_path: Optional[Path] = None
+
+
+def enumerate_overrides(project: ProjectInfo) -> list[Override]:
+    project_dir = project.path.parent
+    overrides: list[Override] = []
+
+    for container in OVERRIDE_CONTAINERS:
+        base_dir = project_dir / container
+        if not base_dir.is_dir():
+            continue
+        for scope_dir in sorted(base_dir.iterdir()):
+            if not scope_dir.is_dir():
+                continue
+            scope_name = scope_dir.name
+            # .base folders are packaged defaults (level 3), not customizations.
+            if scope_name.endswith(".base"):
+                continue
+            if container == "Formats":
+                level = "format"
+                format_name = scope_name
+            else:
+                level = "target"
+                format_name = project.target_to_format.get(scope_name, "")
+            for f in sorted(scope_dir.rglob("*")):
+                if not f.is_file():
+                    continue
+                rel = f.relative_to(scope_dir).as_posix()
+                overrides.append(
+                    Override(
+                        abs_path=f,
+                        level=level,
+                        scope_name=scope_name,
+                        format_name=format_name,
+                        rel_path=rel,
+                        is_text=is_text_file(f),
+                    )
+                )
+    return overrides
+
+
+def baseline_file_for(ov: Override, install_version_dir: Path) -> Optional[Path]:
+    """Where this override's counterpart lives in an installed version."""
+    if not ov.format_name:
+        return None
+    candidate = install_version_dir / "Formats" / ov.format_name / ov.rel_path
+    return candidate
+
+
+def classify_overrides(overrides: list[Override], baseline_root: Path) -> None:
+    for ov in overrides:
+        base = baseline_file_for(ov, baseline_root)
+        if base and base.is_file():
+            ov.classification = "forked-copy"
+            ov.baseline_path = base
+        else:
+            ov.classification = "net-new"
+
+
+# --------------------------------------------------------------------------- #
+# Installed-version discovery
+# --------------------------------------------------------------------------- #
+def list_installed_versions(install_root: Path) -> list[str]:
+    if not install_root.is_dir():
+        return []
+    versions = []
+    for child in install_root.iterdir():
+        if child.is_dir() and re.fullmatch(r"\d+(\.\d+)+", child.name):
+            versions.append(child.name)
+    return sorted(versions, key=version_key)
+
+
+# --------------------------------------------------------------------------- #
+# Sub-audit: fork-point fingerprinting
+# --------------------------------------------------------------------------- #
+@dataclass
+class FileFingerprint:
+    rel_path: str
+    format_name: str
+    override_lines: int
+    per_version: dict[str, float]      # version -> similarity ratio
+    best_version: Optional[str]
+    best_ratio: float
+    runner_up: Optional[str]
+    runner_up_ratio: float
+
+
+def fingerprint_file(ov: Override, install_root: Path, versions: list[str]) -> Optional[FileFingerprint]:
+    if not ov.is_text:
+        return None
+    try:
+        ovr_lines = read_lines(ov.abs_path)
+    except OSError:
+        return None
+
+    per_version: dict[str, float] = {}
+    for ver in versions:
+        base_path = baseline_file_for(ov, install_root / ver)
+        if not base_path or not base_path.is_file():
+            continue
+        try:
+            base_lines = read_lines(base_path)
+        except OSError:
+            continue
+        per_version[ver] = round(similarity(base_lines, ovr_lines), 6)
+
+    if not per_version:
+        return None
+
+    ranked = sorted(per_version.items(), key=lambda kv: kv[1], reverse=True)
+    best_version, best_ratio = ranked[0]
+    runner_up, runner_up_ratio = (ranked[1] if len(ranked) > 1 else (None, 0.0))
+
+    return FileFingerprint(
+        rel_path=ov.rel_path,
+        format_name=ov.format_name,
+        override_lines=len(ovr_lines),
+        per_version=per_version,
+        best_version=best_version,
+        best_ratio=round(best_ratio, 4),
+        runner_up=runner_up,
+        runner_up_ratio=round(runner_up_ratio, 4),
+    )
+
+
+def weighted_aggregate(fingerprints: list[FileFingerprint]) -> dict[str, float]:
+    """Size-weighted similarity per version: sum(ratio*lines)/sum(lines)."""
+    num: dict[str, float] = {}
+    den: dict[str, float] = {}
+    for fp in fingerprints:
+        for ver, ratio in fp.per_version.items():
+            num[ver] = num.get(ver, 0.0) + ratio * fp.override_lines
+            den[ver] = den.get(ver, 0.0) + fp.override_lines
+    return {ver: round(num[ver] / den[ver], 6) for ver in num if den.get(ver)}
+
+
+def confidence_for(agreement: float, margin: float) -> str:
+    if margin < 0.005:
+        return "low"          # plateau: many versions tie -> indeterminate
+    if agreement >= 0.75 and margin >= 0.02:
+        return "high"
+    if agreement >= 0.5 or margin >= 0.01:
+        return "medium"
+    return "low"
+
+
+def releases_between(versions_sorted: list[str], lo: str, hi: str) -> int:
+    """Count installed releases strictly after `lo` and up to/including `hi`."""
+    klo, khi = version_key(lo), version_key(hi)
+    return sum(1 for v in versions_sorted if klo < version_key(v) <= khi)
+
+
+@dataclass
+class FormatDiscovery:
+    format_name: str
+    retired: bool
+    file_count: int
+    best_version: Optional[str]
+    best_score: float
+    runner_up: Optional[str]
+    runner_up_score: float
+    margin: float
+    agreement: float
+    confidence: str
+    locked_version: str
+    staleness_releases: Optional[int]
+    note: str
+
+
+@dataclass
+class DiscoveryResult:
+    versions_considered: list[str]
+    locked_version: str
+    per_format: list[FormatDiscovery]
+    overall_best: Optional[str]
+    overall_score: float
+    per_file: list[FileFingerprint]
+
+
+def _discover_one(fingerprints: list[FileFingerprint], format_name: str,
+                  retired: bool, locked: str, versions: list[str]) -> FormatDiscovery:
+    agg = weighted_aggregate(fingerprints)
+    ranked = sorted(agg.items(), key=lambda kv: kv[1], reverse=True)
+    best, best_s = (ranked[0] if ranked else (None, 0.0))
+    ru, ru_s = (ranked[1] if len(ranked) > 1 else (None, 0.0))
+    margin = round(best_s - ru_s, 6)
+    votes: dict[str, int] = {}
+    for fp in fingerprints:
+        if fp.best_version:
+            votes[fp.best_version] = votes.get(fp.best_version, 0) + 1
+    agreement = round(votes.get(best, 0) / len(fingerprints), 3) if fingerprints else 0.0
+    confidence = confidence_for(agreement, margin)
+
+    staleness: Optional[int] = None
+    if retired:
+        note = "retired format -> remove wholesale (see `cleanup`); fork-point not meaningful"
+    elif best and locked:
+        if version_key(best) < version_key(locked):
+            staleness = releases_between(versions, best, locked)
+            note = (f"fork-point {best} is {staleness} release(s) behind the project lock {locked} "
+                    f"-> overrides were never re-synced to their own baseline")
+        elif version_key(best) > version_key(locked):
+            staleness = 0
+            note = f"fork-point {best} is NEWER than the lock {locked} (heavy customization may skew this)"
+        else:
+            staleness = 0
+            note = f"fork-point {best} matches the lock {locked} (current)"
+        if confidence == "low":
+            note += "  [low confidence: files match several versions near-equally]"
+    else:
+        note = "indeterminate"
+
+    return FormatDiscovery(
+        format_name=format_name, retired=retired, file_count=len(fingerprints),
+        best_version=best, best_score=round(best_s, 4),
+        runner_up=ru, runner_up_score=round(ru_s, 4), margin=round(margin, 4),
+        agreement=agreement, confidence=confidence,
+        locked_version=locked, staleness_releases=staleness, note=note)
+
+
+def discover_baseline(overrides: list[Override], install_root: Path,
+                      versions: list[str], project: ProjectInfo) -> DiscoveryResult:
+    forked_text = [ov for ov in overrides
+                   if ov.classification == "forked-copy" and ov.is_text]
+
+    fingerprints: list[FileFingerprint] = []
+    for ov in forked_text:
+        fp = fingerprint_file(ov, install_root, versions)
+        if fp is not None:
+            fingerprints.append(fp)
+
+    by_fmt: dict[str, list[FileFingerprint]] = {}
+    for fp in fingerprints:
+        by_fmt.setdefault(fp.format_name, []).append(fp)
+
+    locked = project.base_format_version
+    per_format = [
+        _discover_one(items, fmt, is_retired_format(fmt), locked, versions)
+        for fmt, items in sorted(by_fmt.items())
+    ]
+
+    overall = weighted_aggregate(fingerprints)
+    ranked = sorted(overall.items(), key=lambda kv: kv[1], reverse=True)
+    overall_best, overall_score = (ranked[0] if ranked else (None, 0.0))
+
+    return DiscoveryResult(
+        versions_considered=versions,
+        locked_version=locked,
+        per_format=per_format,
+        overall_best=overall_best,
+        overall_score=round(overall_score, 4),
+        per_file=fingerprints,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Annotation + drift (basic, uses a single baseline)
+# --------------------------------------------------------------------------- #
+def compile_annotation_patterns(patterns: list[str]) -> list[re.Pattern]:
+    return [re.compile(p) for p in patterns]
+
+
+def annotation_hits(lines: list[str], patterns: list[re.Pattern]) -> int:
+    count = 0
+    for line in lines:
+        if any(p.search(line) for p in patterns):
+            count += 1
+    return count
+
+
+@dataclass
+class FileAudit:
+    rel_path: str
+    classification: str
+    baseline_version: Optional[str]
+    added_in_override: int
+    removed_from_base: int
+    annotated_override_lines: int
+    note: str = ""
+
+
+def audit_file(ov: Override, baseline_path: Optional[Path],
+               baseline_version: Optional[str],
+               ann_patterns: list[re.Pattern]) -> FileAudit:
+    if ov.classification == "net-new" or baseline_path is None or not baseline_path.is_file():
+        ovr_lines = read_lines(ov.abs_path) if ov.is_text else []
+        return FileAudit(
+            rel_path=ov.rel_path,
+            classification=ov.classification,
+            baseline_version=None,
+            added_in_override=len(ovr_lines),
+            removed_from_base=0,
+            annotated_override_lines=annotation_hits(ovr_lines, ann_patterns) if ov.is_text else 0,
+            note="net-new (no baseline counterpart); verify referenced hooks still exist",
+        )
+
+    base_lines = read_lines(baseline_path)
+    ovr_lines = read_lines(ov.abs_path)
+    added, removed = diff_counts(base_lines, ovr_lines)
+    ann = annotation_hits(ovr_lines, ann_patterns)
+    notes = []
+    if removed >= 25 and removed > added:
+        notes.append("baseline has many lines absent from override -> POSITIVE DRIFT suspect "
+                     "(base added since fork, or override deleted); confirm via discover + 3-way")
+    if added and ann == 0:
+        notes.append("override-only changes are UNANNOTATED -> run `discover` and diff vs fork-point to recover intent")
+    note = "; ".join(notes)
+    return FileAudit(
+        rel_path=ov.rel_path,
+        classification=ov.classification,
+        baseline_version=baseline_version,
+        added_in_override=added,
+        removed_from_base=removed,
+        annotated_override_lines=ann,
+        note=note,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Static checks (issue #105 "C"): SCSS variables + prefix convention,
+# custom-partial wiring, dangling references (negative drift).
+# --------------------------------------------------------------------------- #
+SCSS_VAR_DEF = re.compile(r"^\s*(\$[A-Za-z0-9_-]+)\s*:\s*(.*?)\s*(?:!default\s*)?;", re.MULTILINE)
+SCSS_IMPORT = re.compile(r'@(?:import|use)\s+["\']([^"\']+)["\']')
+SCSS_BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+SCSS_LINE_COMMENT = re.compile(r"//[^\n]*")
+# Reverb setting/trait reference inside an ASP/HTML/XSL template.
+WWPAGE_ATTR_REF = re.compile(r'wwpage:attribute-[A-Za-z0-9-]+="([^"]+)"')
+FTI_NAME_DEF = re.compile(r'name="([^"]+)"')
+
+# Canonical custom-variable prefix (reverb2 skill). Projects substitute their
+# own company abbreviation (e.g. webworks_, dicad_); we auto-detect it rather
+# than assume. This is only the default seed for reporting.
+CANONICAL_PREFIX = "theme"
+
+
+def parse_scss_vars(path: Path) -> dict[str, str]:
+    """Map $name -> value-string for top-level variable definitions."""
+    try:
+        text = "\n".join(read_lines(path))
+    except OSError:
+        return {}
+    out: dict[str, str] = {}
+    for m in SCSS_VAR_DEF.finditer(text):
+        out[m.group(1)] = m.group(2).split("//")[0].strip()
+    return out
+
+
+def prefix_of(var_name: str) -> str:
+    """'$theme_primary' -> 'theme'; '$foo' -> 'foo'."""
+    stem = var_name.lstrip("$")
+    return stem.split("_", 1)[0] if "_" in stem else stem
+
+
+def strip_scss_comments(text: str) -> str:
+    """Drop /* */ and // comments so commented-out code (e.g. an @import in a
+    file header that documents the wiring step) is not mistaken for real code."""
+    text = SCSS_BLOCK_COMMENT.sub("", text)
+    text = SCSS_LINE_COMMENT.sub("", text)
+    return text
+
+
+@dataclass
+class ScssAnalysis:
+    rel_path: str
+    baseline_present: bool
+    missing_vars: list[str]          # in baseline, absent from override -> build-break risk
+    added_vars: list[str]            # in override, absent from baseline -> customization
+    changed_vars: list[str]          # same name, different value -> customization
+    added_prefixes: dict[str, int]   # prefix histogram of added vars
+    annotation_hits: int
+
+
+def analyze_scss(ov: Override, baseline_path: Optional[Path],
+                 ann_patterns: list[re.Pattern]) -> ScssAnalysis:
+    ovr_vars = parse_scss_vars(ov.abs_path)
+    base_vars = parse_scss_vars(baseline_path) if (baseline_path and baseline_path.is_file()) else {}
+    base_present = bool(base_vars)
+
+    missing = sorted(set(base_vars) - set(ovr_vars))
+    added = sorted(set(ovr_vars) - set(base_vars))
+    changed = sorted(n for n in (set(ovr_vars) & set(base_vars)) if ovr_vars[n] != base_vars[n])
+
+    hist: dict[str, int] = {}
+    for name in added:
+        p = prefix_of(name)
+        hist[p] = hist.get(p, 0) + 1
+
+    return ScssAnalysis(
+        rel_path=ov.rel_path,
+        baseline_present=base_present,
+        missing_vars=missing,
+        added_vars=added,
+        changed_vars=changed,
+        added_prefixes=hist,
+        annotation_hits=annotation_hits(read_lines(ov.abs_path), ann_patterns),
+    )
+
+
+def detect_project_prefix(analyses: list[ScssAnalysis],
+                          declared: Optional[list[str]]) -> tuple[Optional[str], dict[str, int]]:
+    """Aggregate added-var prefixes across all SCSS overrides to find the
+    project's de-facto custom-variable convention. Standard Reverb variables
+    are never in the added set, so the dominant prefix here is the real one."""
+    agg: dict[str, int] = {}
+    for a in analyses:
+        for p, n in a.added_prefixes.items():
+            agg[p] = agg.get(p, 0) + n
+    if declared:
+        # Honor an explicitly-declared prefix if it appears at all.
+        for d in declared:
+            d = d.rstrip("_")
+            if d in agg:
+                return d, agg
+        return declared[0].rstrip("_"), agg
+    if not agg:
+        return None, agg
+    best = max(agg.items(), key=lambda kv: kv[1])
+    return best[0], agg
+
+
+@dataclass
+class WiringFinding:
+    partial: str            # e.g. "_custom-webworks.scss"
+    import_name: str        # e.g. "custom-webworks"
+    wired: bool
+    imported_by: Optional[str]
+    reason: str
+
+
+# Conventional entry point for the two skill-template partials.
+PARTIAL_ENTRY_POINT = {
+    "custom-skin": "skin.scss",
+    "custom-webworks": "webworks.scss",
+}
+
+
+def check_partial_wiring(overrides: list[Override]) -> list[WiringFinding]:
+    """Net-new SCSS partials take effect only if an OVERRIDE entry point
+    @imports them (the base entry points can't know about a net-new partial)."""
+    sass_overrides = [o for o in overrides if o.rel_path.endswith(".scss")]
+    overridden_files = {Path(o.rel_path).name for o in sass_overrides}
+
+    # Collect every partial imported by an override .scss file (ignoring
+    # comments, and ignoring a file that "imports" itself).
+    imported: dict[str, str] = {}     # import_name -> importing file
+    for o in sass_overrides:
+        text = strip_scss_comments("\n".join(read_lines(o.abs_path)))
+        importer = Path(o.rel_path).name
+        self_name = importer[1:-5] if importer.startswith("_") and importer.endswith(".scss") else None
+        for m in SCSS_IMPORT.finditer(text):
+            name = Path(m.group(1)).name.lstrip("_")
+            if name.endswith(".scss"):
+                name = name[:-5]
+            if name == self_name:
+                continue
+            imported[name] = importer
+
+    findings: list[WiringFinding] = []
+    for o in sass_overrides:
+        fname = Path(o.rel_path).name
+        if not fname.startswith("_"):
+            continue
+        if o.classification != "net-new":
+            continue  # standard partials are imported by base entry points
+        import_name = fname[1:-5] if fname.endswith(".scss") else fname[1:]
+        if import_name in imported:
+            findings.append(WiringFinding(fname, import_name, True, imported[import_name], "imported by an override entry point"))
+        else:
+            entry = PARTIAL_ENTRY_POINT.get(import_name)
+            if entry and entry not in overridden_files:
+                reason = (f"no override imports it; its conventional entry point '{entry}' "
+                          f"is not in the override set -> INCOMPLETE TEMPLATE (takes no effect)")
+            else:
+                reason = "no override @import found -> dead partial (takes no effect)"
+            findings.append(WiringFinding(fname, import_name, False, None, reason))
+    return findings
+
+
+@dataclass
+class DanglingFinding:
+    setting: str
+    referenced_in: list[str]
+    annotated: bool
+    verdict: str            # "negative-drift" | "undefined-custom"
+
+
+def build_baseline_corpus(baseline_root: Optional[Path], format_name: str,
+                          overrides: list[Override]) -> str:
+    parts: list[str] = []
+    if baseline_root and format_name:
+        fmt_dir = baseline_root / "Formats" / format_name
+        if fmt_dir.is_dir():
+            for f in fmt_dir.rglob("*"):
+                if f.is_file() and is_text_file(f):
+                    try:
+                        parts.append(f.read_text(encoding="utf-8", errors="replace"))
+                    except OSError:
+                        continue
+    # Include override-defined traits (e.g. a custom pages.fti option).
+    for o in overrides:
+        if o.rel_path.endswith(".fti"):
+            parts.append("\n".join(read_lines(o.abs_path)))
+    return "\n".join(parts)
+
+
+def check_dangling_references(overrides: list[Override], baseline_root: Optional[Path],
+                              format_name: str, ann_patterns: list[re.Pattern]) -> list[DanglingFinding]:
+    corpus = build_baseline_corpus(baseline_root, format_name, overrides)
+    refs: dict[str, list[str]] = {}
+    ref_annotated: dict[str, bool] = {}
+    for o in overrides:
+        if Path(o.rel_path).suffix.lower() not in (".asp", ".html", ".htm", ".xsl"):
+            continue
+        lines = read_lines(o.abs_path)
+        for line in lines:
+            for m in WWPAGE_ATTR_REF.finditer(line):
+                val = m.group(1)
+                refs.setdefault(val, [])
+                if o.rel_path not in refs[val]:
+                    refs[val].append(o.rel_path)
+                if any(p.search(line) for p in ann_patterns):
+                    ref_annotated[val] = True
+
+    findings: list[DanglingFinding] = []
+    for val, where in sorted(refs.items()):
+        # Defined or used anywhere in the baseline (covers built-in resolvers
+        # and standard settings) or in an override-defined trait? Then fine.
+        if val in corpus:
+            continue
+        annotated = ref_annotated.get(val, False)
+        verdict = "undefined-custom" if annotated else "negative-drift"
+        findings.append(DanglingFinding(val, where, annotated, verdict))
+    return findings
+
+
+# --------------------------------------------------------------------------- #
+# Removal recommendations (issue #105): retired formats, orphaned overrides,
+# and cruft/duplicate files. Aggressive by design -- migration step 1 is a
+# baseline commit/copy, so the original state is always recoverable.
+# --------------------------------------------------------------------------- #
+# Formats no longer supported. Their overrides should be removed wholesale;
+# computing drift for them is not useful. (Maintained list.)
+RETIRED_FORMATS = {
+    "WebWorks Help 5.0",
+    "WebWorks Help",
+    "WebWorks Reverb",        # Reverb 1.x (Reverb 2.0 is current)
+    "WebWorks Help 4.0",
+    "WebWorks Help 3.0",
+}
+
+# Format versions older than this are End-Of-Life (installable via the optional
+# EOL installer, but users are encouraged to move forward). Bumps to 2023.1
+# when 2026.1 ships.
+EOL_BEFORE_VERSION = "2022.1"
+
+# Filename signals of a backup/experiment/duplicate copy.
+CRUFT_NAME_PATTERNS = [
+    re.compile(r"orig", re.I),
+    re.compile(r"_old\b|_old[._]", re.I),
+    re.compile(r"_original", re.I),
+    re.compile(r"backup|bak\b", re.I),
+    re.compile(r"\bcopy\b|_copy", re.I),
+    re.compile(r"with_version", re.I),
+    re.compile(r"\bgood[_A-Z]", re.I),
+    re.compile(r"blurry", re.I),
+    re.compile(r"_x{1,2}\.|_xx\b", re.I),
+    re.compile(r"\d{4,}"),          # date-stamped: 0728, 071618, 10_31_18
+    re.compile(r"\bNG[A-Z]"),       # NGPage.asp -> "next-gen" experiment
+]
+
+# Filenames an override might reference (assets/sources to protect from cruft).
+REF_FILE = re.compile(r'''["'\(]([^"'\)\s]+\.(?:gif|jpe?g|png|svg|ico|js|css|scss|asp|html?|xml|json))["'\)]''', re.I)
+
+
+def is_retired_format(format_name: str) -> bool:
+    return format_name in RETIRED_FORMATS
+
+
+def build_reference_set(overrides: list[Override], project: ProjectInfo) -> set[str]:
+    """Basenames + SCSS import names referenced by any override template/style,
+    PLUS asset filenames referenced in the project file's settings (logo/splash
+    paths live there, not in templates). A file appearing here is intentional
+    source, never cruft."""
+    refs: set[str] = set()
+
+    def harvest(text: str, scss: bool = False) -> None:
+        for m in REF_FILE.finditer(text):
+            refs.add(Path(m.group(1)).name.lower())
+        if scss:
+            for m in SCSS_IMPORT.finditer(strip_scss_comments(text)):
+                base = Path(m.group(1)).name.lstrip("_")
+                base_noext = base[:-5] if base.endswith(".scss") else base
+                refs.add(base.lower())
+                refs.add(f"_{base_noext}.scss".lower())
+                refs.add(f"{base_noext}.scss".lower())
+
+    for o in overrides:
+        suf = Path(o.rel_path).suffix.lower()
+        if suf not in (".asp", ".html", ".htm", ".xsl", ".scss", ".css", ".js"):
+            continue
+        harvest("\n".join(read_lines(o.abs_path)), scss=(suf == ".scss"))
+
+    # Project file: logo/splash/asset paths configured in FormatSettings.
+    try:
+        harvest(project.path.read_text(encoding="utf-8", errors="replace"))
+    except OSError:
+        pass
+    return refs
+
+
+def _stem(name: str) -> str:
+    return Path(name).stem.lstrip("_").lower()
+
+
+CRUFT_PREFIX_AFFIXES = ("orig_", "good_", "old_", "backup_", "copy_", "ng")
+CRUFT_SUFFIX_AFFIXES = ("_orig", "_original", "_old", "_copy", "_backup", "_with_version", "_x", "_xx")
+
+
+def _strip_cruft_affixes(stem: str) -> set[str]:
+    """Yield plausible 'real' stems by removing backup/experiment decoration."""
+    cands = {stem,
+             re.sub(r"[_-]?\d+$", "", stem),   # trailing date/number: page071618 -> page
+             re.sub(r"\d+", "", stem)}         # embedded digits: 071618page -> page
+    for c in list(cands):
+        for p in CRUFT_PREFIX_AFFIXES:
+            if c.startswith(p) and len(c) > len(p):
+                cands.add(c[len(p):])
+        for s in CRUFT_SUFFIX_AFFIXES:
+            if c.endswith(s) and len(c) > len(s):
+                cands.add(c[:-len(s)])
+    cands.discard(stem)
+    return {c for c in cands if c}
+
+
+def looks_like_variant(name: str, sibling_names: list[str]) -> Optional[str]:
+    """If `name` is a decorated variant of a sibling override, return that
+    sibling. Uses affix-stripping (precise) then prefix+separator (catches
+    dated variants like splash_Cohu2019.gif of splash.gif). Avoids loose
+    substring matches that would treat CohuStandardColorLogo as 'logo'."""
+    s = _stem(name)
+    sib_stems = {sib: _stem(sib) for sib in sibling_names if sib != name and _stem(sib)}
+    # 1) affix-stripped equality with an existing sibling
+    stripped_forms = _strip_cruft_affixes(s)
+    for sib, ss in sib_stems.items():
+        if ss != s and ss in stripped_forms:
+            return sib
+    # 2) prefix + separator (decorated longer form of a shorter sibling)
+    for sib, ss in sib_stems.items():
+        if len(ss) >= 4 and s != ss and s.startswith(ss) and len(s) > len(ss) and s[len(ss)] in "_-.0123456789":
+            return sib
+    return None
+
+
+@dataclass
+class RemovalFinding:
+    kind: str               # "scope" | "file"
+    target: str             # scope dir or file rel path
+    category: str           # "retired-format" | "orphan-target" | "orphan-format" | "duplicate-backup"
+    reason: str
+    confidence: str         # "high" | "medium"
+    file_count: int = 1
+
+
+def detect_removals(overrides: list[Override], project: ProjectInfo) -> list[RemovalFinding]:
+    findings: list[RemovalFinding] = []
+    ref_set = build_reference_set(overrides, project)
+
+    # Group overrides by (level, scope) for scope-level findings + sibling lists.
+    by_scope: dict[tuple[str, str], list[Override]] = {}
+    for o in overrides:
+        by_scope.setdefault((o.level, o.scope_name), []).append(o)
+
+    retired_scopes: set[tuple[str, str]] = set()
+    orphan_scopes: set[tuple[str, str]] = set()
+
+    for (level, scope), items in by_scope.items():
+        fmt = items[0].format_name
+        # Retired format (format-level dir, or any target bound to a retired format).
+        if is_retired_format(scope if level == "format" else fmt):
+            retired_scopes.add((level, scope))
+            findings.append(RemovalFinding(
+                kind="scope", target=f"{level.capitalize()}s/{scope}",
+                category="retired-format",
+                reason=f"format '{fmt or scope}' is retired -> remove overrides wholesale (no drift analysis)",
+                confidence="high", file_count=len(items)))
+            continue
+        # Orphaned target (no matching target in the project).
+        if level == "target" and scope not in project.target_to_format:
+            orphan_scopes.add((level, scope))
+            findings.append(RemovalFinding(
+                kind="scope", target=f"Targets/{scope}", category="orphan-target",
+                reason="no target with this name exists in the project -> orphaned override",
+                confidence="high", file_count=len(items)))
+            continue
+        # Orphaned format-level dir (format used by no target; 'Shared' is special).
+        if level == "format" and scope != "Shared" and scope not in project.format_names:
+            orphan_scopes.add((level, scope))
+            findings.append(RemovalFinding(
+                kind="scope", target=f"Formats/{scope}", category="orphan-format",
+                reason="no target uses this format -> orphaned override",
+                confidence="high", file_count=len(items)))
+
+    # Cruft/duplicate files (skip scopes already slated for wholesale removal).
+    for (level, scope), items in by_scope.items():
+        if (level, scope) in retired_scopes or (level, scope) in orphan_scopes:
+            continue
+        # Sibling basenames per directory within this scope.
+        dir_files: dict[str, list[str]] = {}
+        for o in items:
+            d = str(Path(o.rel_path).parent)
+            dir_files.setdefault(d, []).append(Path(o.rel_path).name)
+        for o in items:
+            if o.classification != "net-new":
+                continue
+            name = Path(o.rel_path).name
+            if name.lower() in ref_set:
+                continue  # referenced source -> protect
+            siblings = dir_files.get(str(Path(o.rel_path).parent), [])
+            variant_of = looks_like_variant(name, siblings)
+            name_cruft = any(p.search(name) for p in CRUFT_NAME_PATTERNS)
+            if variant_of and name_cruft:
+                conf, why = "high", f"backup/experiment name and duplicates existing override '{variant_of}'"
+            elif variant_of:
+                conf, why = "high", f"duplicates existing override '{variant_of}' (unreferenced)"
+            elif name_cruft:
+                conf, why = "medium", "backup/experiment filename, unreferenced by any override"
+            else:
+                continue
+            findings.append(RemovalFinding(
+                kind="file", target=f"{level.capitalize()}s/{scope}/{o.rel_path}",
+                category="duplicate-backup", reason=why, confidence=conf))
+
+    # Redundant overrides: a forked-copy identical to its baseline. Often a local
+    # patch that has since been fixed upstream -> the override no longer does
+    # anything but add maintenance noise.
+    for (level, scope), items in by_scope.items():
+        if (level, scope) in retired_scopes or (level, scope) in orphan_scopes:
+            continue
+        for o in items:
+            if o.classification != "forked-copy" or not o.baseline_path or not o.baseline_path.is_file():
+                continue
+            try:
+                if o.is_text:
+                    same = read_lines(o.abs_path) == read_lines(o.baseline_path)
+                else:
+                    same = o.abs_path.read_bytes() == o.baseline_path.read_bytes()
+            except OSError:
+                continue
+            if same:
+                findings.append(RemovalFinding(
+                    kind="file", target=f"{level.capitalize()}s/{scope}/{o.rel_path}",
+                    category="redundant-override",
+                    reason="identical to the baseline (local patch now fixed upstream, or never changed) -> remove to reduce noise",
+                    confidence="high"))
+    return findings
+
+
+# --------------------------------------------------------------------------- #
+# 3-way drift classifier (issue #105 "A"): base-old (fork-point / locked
+# version) -> base-new (upgrade target) -> override. Separates the user's
+# customizations from upstream drift and flags merge conflicts.
+# --------------------------------------------------------------------------- #
+@dataclass
+class ThreeWayResult:
+    location: str            # Targets/<name>/... or Formats/<name>/... (disambiguates)
+    rel_path: str
+    format_name: str
+    upstream_change: int     # lines changed base_old -> base_new (the drift)
+    customization: int       # lines changed base_old -> override (user intent)
+    conflict_regions: int    # customized regions that upstream also changed
+    verdict: str
+    note: str = ""
+
+
+def _changed_intervals(a: list[str], b: list[str]) -> list[tuple[int, int]]:
+    """Intervals in `a`'s index space that differ in `b`."""
+    ivs: list[tuple[int, int]] = []
+    for tag, i1, i2, _j1, _j2 in difflib.SequenceMatcher(a=a, b=b, autojunk=False).get_opcodes():
+        if tag == "equal":
+            continue
+        ivs.append((i1, i2) if i2 > i1 else (i1, i1 + 1))  # widen pure inserts
+    return ivs
+
+
+def _changed_size(a: list[str], b: list[str]) -> int:
+    n = 0
+    for tag, i1, i2, j1, j2 in difflib.SequenceMatcher(a=a, b=b, autojunk=False).get_opcodes():
+        if tag != "equal":
+            n += (i2 - i1) + (j2 - j1)
+    return n
+
+
+def _overlap_count(a_ivs: list[tuple[int, int]], b_ivs: list[tuple[int, int]]) -> int:
+    count = 0
+    for a1, a2 in a_ivs:
+        if any(a1 < b2 and b1 < a2 for b1, b2 in b_ivs):
+            count += 1
+    return count
+
+
+def analyze_3way(location: str, rel_path: str, format_name: str,
+                 base_old: list[str], base_new: list[str], ovr: list[str]) -> ThreeWayResult:
+    upstream = _changed_size(base_old, base_new)
+    custom = _changed_size(base_old, ovr)
+    cust_ivs = _changed_intervals(base_old, ovr)
+    up_ivs = _changed_intervals(base_old, base_new)
+    conflicts = _overlap_count(cust_ivs, up_ivs)
+
+    if upstream == 0 and custom == 0:
+        verdict, note = "redundant", "identical to baseline (no upstream change, no customization); safe to remove"
+    elif upstream == 0:
+        verdict, note = "in-sync", "no upstream change between the two versions; customizations carry forward as-is"
+    elif custom == 0:
+        verdict, note = "fast-forward", "override is an unmodified copy; adopt the new baseline (or drop the override)"
+    elif conflicts == 0:
+        verdict, note = "auto-mergeable", "customizations and upstream changes touch disjoint regions"
+    else:
+        verdict, note = "manual-merge", f"{conflicts} customized region(s) also changed upstream -> review"
+    return ThreeWayResult(location, rel_path, format_name, upstream, custom, conflicts, verdict, note)
+
+
+# --------------------------------------------------------------------------- #
+# Output
+# --------------------------------------------------------------------------- #
+def emit_json(obj) -> None:
+    def default(o):
+        if isinstance(o, Path):
+            return str(o)
+        if hasattr(o, "__dataclass_fields__"):
+            return asdict(o)
+        raise TypeError(repr(o))
+    print(json.dumps(obj, indent=2, default=default))
+
+
+# --------------------------------------------------------------------------- #
+# Subcommands
+# --------------------------------------------------------------------------- #
+def resolve_baseline_root(project: ProjectInfo, install_root: Path,
+                          override_version: Optional[str]) -> tuple[Optional[Path], Optional[str]]:
+    ver = override_version or project.base_format_version
+    root = install_root / ver
+    if root.is_dir():
+        return root, ver
+    return None, ver
+
+
+def cmd_enumerate(args) -> int:
+    project = parse_project(Path(args.project))
+    install_root = Path(args.install_root)
+    baseline_root, baseline_ver = resolve_baseline_root(project, install_root, args.baseline_version)
+    overrides = enumerate_overrides(project)
+    if baseline_root:
+        classify_overrides(overrides, baseline_root)
+
+    if args.format == "json":
+        emit_json({
+            "project": project,
+            "baselineVersion": baseline_ver,
+            "baselineAvailable": baseline_root is not None,
+            "overrides": overrides,
+        })
+        return EXIT_SUCCESS
+
+    forked = [o for o in overrides if o.classification == "forked-copy"]
+    netnew = [o for o in overrides if o.classification == "net-new"]
+    unknown = [o for o in overrides if o.classification == "unknown"]
+    print(f"Project: {project.path.name}")
+    print(f"  Lock state : {project.lock_state}  (RuntimeVersion={project.runtime_version}, FormatVersion={project.format_version})")
+    print(f"  Base format: {project.base_format_version}")
+    print(f"  Baseline   : {baseline_ver} ({'available' if baseline_root else 'NOT on disk -> Mode B'})")
+    print(f"  Overrides  : {len(overrides)} total | {len(forked)} forked-copy | {len(netnew)} net-new"
+          + (f" | {len(unknown)} unclassified" if unknown else ""))
+    print()
+    print(f"  {'CLASS':<12} {'LEVEL':<7} {'REL PATH'}")
+    print(f"  {'-'*12} {'-'*7} {'-'*40}")
+    for o in overrides:
+        print(f"  {o.classification:<12} {o.level:<7} {o.format_name}/{o.rel_path}")
+    return EXIT_SUCCESS
+
+
+def cmd_discover(args) -> int:
+    project = parse_project(Path(args.project))
+    install_root = Path(args.install_root)
+    versions = list_installed_versions(install_root)
+    if not versions:
+        print(f"No installed versions found under {install_root}", file=sys.stderr)
+        return EXIT_NOT_FOUND
+
+    # classify against the newest installed version so we know which files are
+    # forked-copies worth fingerprinting.
+    newest = install_root / versions[-1]
+    overrides = enumerate_overrides(project)
+    classify_overrides(overrides, newest)
+
+    result = discover_baseline(overrides, install_root, versions, project)
+
+    if args.format == "json":
+        emit_json(result)
+        return EXIT_SUCCESS
+
+    print(f"Fork-point discovery for {project.path.name}   (project lock: {result.locked_version})")
+    print(f"  {len(result.versions_considered)} installed versions considered "
+          f"({result.versions_considered[0]} .. {result.versions_considered[-1]})")
+    print(f"  Overall project fork-point: {result.overall_best} (score={result.overall_score})")
+    print()
+    print("  Per-format fork-point + staleness vs the project lock:")
+    print(f"    {'FORK-POINT':<11} {'SCORE':<7} {'CONF':<7} {'FILES':>5}  {'FORMAT'}")
+    print(f"    {'-'*11} {'-'*7} {'-'*7} {'-'*5}  {'-'*30}")
+    for fd in sorted(result.per_format, key=lambda f: f.format_name):
+        fp_disp = "RETIRED" if fd.retired else str(fd.best_version)
+        score = "-" if fd.retired else f"{fd.best_score}"
+        print(f"    {fp_disp:<11} {score:<7} {fd.confidence:<7} {fd.file_count:>5}  {fd.format_name}")
+        print(f"        -> {fd.note}")
+    print()
+    print("  Lowest per-file ratios (most customized or most drifted):")
+    print(f"    {'BEST':<8} {'RATIO':<7}  {'FILE'}")
+    print(f"    {'-'*8} {'-'*7}  {'-'*40}")
+    for fp in sorted(result.per_file, key=lambda f: f.best_ratio)[:12]:
+        print(f"    {str(fp.best_version):<8} {fp.best_ratio:<7}  {fp.format_name}/{fp.rel_path}")
+    return EXIT_SUCCESS
+
+
+def cmd_audit(args) -> int:
+    project = parse_project(Path(args.project))
+    install_root = Path(args.install_root)
+    baseline_root, baseline_ver = resolve_baseline_root(project, install_root, args.baseline_version)
+    overrides = enumerate_overrides(project)
+    if not baseline_root:
+        print(f"Baseline {baseline_ver} not on disk; classifying against newest installed.", file=sys.stderr)
+        versions = list_installed_versions(install_root)
+        if versions:
+            baseline_root = install_root / versions[-1]
+            baseline_ver = versions[-1]
+    if baseline_root:
+        classify_overrides(overrides, baseline_root)
+
+    ann_patterns = compile_annotation_patterns(args.annotation_pattern or DEFAULT_ANNOTATION_PATTERNS)
+    audits = [
+        audit_file(ov, ov.baseline_path, baseline_ver if ov.classification == "forked-copy" else None, ann_patterns)
+        for ov in overrides
+    ]
+
+    # --- Static checks (C) ---
+    format_name = next((o.format_name for o in overrides if o.format_name), "")
+    scss_overrides = [o for o in overrides if o.rel_path.endswith(".scss")]
+    scss_analyses = [analyze_scss(o, o.baseline_path, ann_patterns) for o in scss_overrides]
+    project_prefix, prefix_hist = detect_project_prefix(
+        scss_analyses, [p.rstrip("_") for p in (args.theme_prefix or [])] or None)
+    wiring = check_partial_wiring(overrides)
+    dangling = check_dangling_references(overrides, baseline_root, format_name, ann_patterns)
+
+    # Pair each SCSS analysis with its override for prefix-coverage reporting.
+    scss_by_path = {o.rel_path: a for o, a in zip(scss_overrides, scss_analyses)}
+
+    if args.format == "json":
+        emit_json({
+            "project": project,
+            "baselineVersion": baseline_ver,
+            "modeNote": "2-way vs installed baseline; run `discover` for fork-point (Mode B promotion)",
+            "files": audits,
+            "scss": {
+                "detectedProjectPrefix": project_prefix,
+                "addedPrefixHistogram": prefix_hist,
+                "perFile": scss_analyses,
+            },
+            "partialWiring": wiring,
+            "danglingReferences": dangling,
+        })
+        return EXIT_SUCCESS
+
+    print(f"Audit: {project.path.name}  (lock={project.lock_state}, baseline={baseline_ver})")
+    print()
+    print(f"  {'CLASS':<12} {'+OVR':>5} {'-BASE':>6} {'ANNOT':>6}  {'FILE'}")
+    print(f"  {'-'*12} {'-'*5} {'-'*6} {'-'*6}  {'-'*40}")
+    for a in audits:
+        print(f"  {a.classification:<12} {a.added_in_override:>5} {a.removed_from_base:>6} "
+              f"{a.annotated_override_lines:>6}  {a.rel_path}")
+        if a.note:
+            print(f"               -> {a.note}")
+
+    # --- SCSS variables + prefix convention ---
+    print()
+    print("SCSS variables & custom-prefix convention")
+    if project_prefix:
+        canon = " (canonical)" if project_prefix == CANONICAL_PREFIX else " (project-specific)"
+        print(f"  Detected custom-variable prefix: ${project_prefix}_*{canon}   "
+              f"[added-var prefixes: " + ", ".join(f"{p}:{n}" for p, n in sorted(prefix_hist.items(), key=lambda kv: -kv[1])) + "]")
+        print(f"  -> grep '\\${project_prefix}_' finds every custom variable without relying on comments")
+    else:
+        print("  No custom variables added by any SCSS override (variable-value overrides only).")
+    print()
+    print(f"  {'+VARS':>6} {'~VALS':>6} {'!MISSING':>8} {'OFF-PREFIX':>10}  {'FILE'}")
+    print(f"  {'-'*6} {'-'*6} {'-'*8} {'-'*10}  {'-'*32}")
+    for a in scss_analyses:
+        off = [v for v in a.added_vars if prefix_of(v) != project_prefix] if project_prefix else []
+        print(f"  {len(a.added_vars):>6} {len(a.changed_vars):>6} {len(a.missing_vars):>8} {len(off):>10}  {a.rel_path}")
+        if a.missing_vars:
+            shown = ", ".join(a.missing_vars[:6]) + (" ..." if len(a.missing_vars) > 6 else "")
+            print(f"      !! BUILD-BREAK RISK -- baseline vars absent from override: {shown}")
+        if off:
+            shown = ", ".join(off[:6]) + (" ..." if len(off) > 6 else "")
+            print(f"      ~  custom vars outside ${project_prefix}_ (less greppable): {shown}")
+
+    # --- Custom-partial wiring ---
+    print()
+    print("Custom-partial wiring (net-new SCSS partials)")
+    if not wiring:
+        print("  No net-new SCSS partials.")
+    for w in wiring:
+        mark = "OK " if w.wired else "XX "
+        print(f"  {mark} {w.partial}: {w.reason}" + (f" [{w.imported_by}]" if w.imported_by else ""))
+
+    # --- Dangling references (negative drift) ---
+    print()
+    print("Dangling references (negative-drift / undefined-custom detector)")
+    if not dangling:
+        print("  None -- every wwpage:attribute binding resolves against the baseline or an override trait.")
+    for d in dangling:
+        tag = "NEGATIVE DRIFT" if d.verdict == "negative-drift" else "UNDEFINED CUSTOM"
+        print(f"  [{tag}] '{d.setting}' referenced in {', '.join(d.referenced_in)} "
+              f"but defined nowhere in baseline/override"
+              + ("" if d.annotated else "  (unannotated -> likely obsolete code removed upstream)"))
+    return EXIT_SUCCESS
+
+
+def cmd_cleanup(args) -> int:
+    project = parse_project(Path(args.project))
+    install_root = Path(args.install_root)
+    baseline_root, baseline_ver = resolve_baseline_root(project, install_root, args.baseline_version)
+    overrides = enumerate_overrides(project)
+    classify_root = baseline_root
+    if not classify_root:
+        versions = list_installed_versions(install_root)
+        classify_root = (install_root / versions[-1]) if versions else None
+    if classify_root:
+        classify_overrides(overrides, classify_root)
+
+    findings = detect_removals(overrides, project)
+    total_files = len(overrides)
+    removable_files = sum(f.file_count for f in findings)
+
+    if args.format == "json":
+        emit_json({
+            "project": project,
+            "baselineVersion": baseline_ver,
+            "overrideFileCount": total_files,
+            "removableFileCount": removable_files,
+            "findings": findings,
+        })
+        return EXIT_SUCCESS
+
+    cats = {
+        "retired-format": "Retired formats (remove wholesale)",
+        "orphan-target": "Orphaned targets (no matching target in project)",
+        "orphan-format": "Orphaned formats (used by no target)",
+        "duplicate-backup": "Duplicate / backup / experiment files",
+        "redundant-override": "Redundant overrides (identical to baseline)",
+    }
+    print(f"Cleanup recommendations: {project.path.name}  (lock={project.lock_state}, base={baseline_ver})")
+    print(f"  {removable_files} of {total_files} override files recommended for removal.")
+    print("  (Safe to be aggressive: migration step 1 is a baseline commit/copy.)")
+    for cat, title in cats.items():
+        group = [f for f in findings if f.category == cat]
+        if not group:
+            continue
+        n = sum(f.file_count for f in group)
+        print()
+        print(f"  {title}  [{n} file(s)]")
+        for f in group:
+            scope = " (whole dir)" if f.kind == "scope" else ""
+            print(f"    - {f.target}{scope}  [{f.confidence}]")
+            print(f"        {f.reason}")
+    if not findings:
+        print("  Nothing to remove -- override tree is clean.")
+    return EXIT_SUCCESS
+
+
+def cmd_drift(args) -> int:
+    project = parse_project(Path(args.project))
+    install_root = Path(args.install_root)
+    from_ver = args.from_version or project.base_format_version
+    to_ver = args.to_version
+    from_root = install_root / from_ver
+    to_root = install_root / to_ver
+    if not from_root.is_dir():
+        print(f"[ERROR] from-version baseline not installed: {from_root}", file=sys.stderr)
+        return EXIT_NOT_FOUND
+    if not to_root.is_dir():
+        print(f"[ERROR] to-version baseline not installed: {to_root}", file=sys.stderr)
+        return EXIT_NOT_FOUND
+
+    overrides = enumerate_overrides(project)
+    classify_overrides(overrides, from_root)
+
+    results: list[ThreeWayResult] = []
+    skipped_retired = 0
+    dropped_upstream: list[str] = []
+    for ov in overrides:
+        if not ov.is_text or ov.classification != "forked-copy":
+            continue
+        if is_retired_format(ov.format_name):
+            skipped_retired += 1
+            continue
+        base_old_file = baseline_file_for(ov, from_root)
+        base_new_file = baseline_file_for(ov, to_root)
+        if not base_old_file or not base_old_file.is_file():
+            continue
+        if not base_new_file or not base_new_file.is_file():
+            dropped_upstream.append(f"{ov.format_name}/{ov.rel_path}")
+            continue
+        location = f"{ov.level.capitalize()}s/{ov.scope_name}/{ov.rel_path}"
+        results.append(analyze_3way(
+            location, ov.rel_path, ov.format_name,
+            read_lines(base_old_file), read_lines(base_new_file), read_lines(ov.abs_path)))
+
+    if args.format == "json":
+        emit_json({
+            "project": project, "fromVersion": from_ver, "toVersion": to_ver,
+            "skippedRetired": skipped_retired, "droppedUpstream": dropped_upstream,
+            "results": results,
+        })
+        return EXIT_SUCCESS
+
+    order = {"manual-merge": 0, "auto-mergeable": 1, "fast-forward": 2, "redundant": 3, "in-sync": 4}
+    results.sort(key=lambda r: (order.get(r.verdict, 9), -r.conflict_regions, -r.customization))
+    print(f"3-way drift: {project.path.name}   {from_ver} -> {to_ver}")
+    counts: dict[str, int] = {}
+    for r in results:
+        counts[r.verdict] = counts.get(r.verdict, 0) + 1
+    print("  " + " | ".join(f"{v}: {counts.get(v,0)}" for v in order))
+    if skipped_retired:
+        print(f"  ({skipped_retired} forked files in retired formats skipped -> see `cleanup`)")
+    print()
+    print(f"  {'VERDICT':<14} {'UPSTREAM':>8} {'CUSTOM':>7} {'CONFL':>6}  {'OVERRIDE'}")
+    print(f"  {'-'*14} {'-'*8} {'-'*7} {'-'*6}  {'-'*44}")
+    for r in results:
+        print(f"  {r.verdict:<14} {r.upstream_change:>8} {r.customization:>7} {r.conflict_regions:>6}  {r.location}")
+        if r.verdict in ("manual-merge", "redundant"):
+            print(f"        -> {r.note}")
+    if dropped_upstream:
+        print()
+        print(f"  Dropped upstream (file/format gone in {to_ver}) -- verify still needed:")
+        for d in dropped_upstream:
+            print(f"    - {d}")
+    return EXIT_SUCCESS
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Audit ePublisher advanced customizations (overrides) for upstream drift.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def add_common(p):
+        p.add_argument("--project", required=True, help="Path to .wep/.wrp/.wxsp project file.")
+        p.add_argument("--install-root", default=str(DEFAULT_INSTALL_ROOT),
+                       help=f"ePublisher install root (default: {DEFAULT_INSTALL_ROOT}).")
+        p.add_argument("--format", choices=["text", "json"], default="text", help="Output format.")
+
+    p_enum = sub.add_parser("enumerate", help="List and classify overrides.")
+    add_common(p_enum)
+    p_enum.add_argument("--baseline-version", help="Force a baseline version (default: derived from project).")
+    p_enum.set_defaults(func=cmd_enumerate)
+
+    p_disc = sub.add_parser("discover", help="Fingerprint overrides to find the fork-point baseline.")
+    add_common(p_disc)
+    p_disc.set_defaults(func=cmd_discover)
+
+    p_clean = sub.add_parser("cleanup", help="Recommend removals: retired formats, orphans, cruft/duplicates.")
+    add_common(p_clean)
+    p_clean.add_argument("--baseline-version", help="Force a baseline version (default: derived from project).")
+    p_clean.set_defaults(func=cmd_cleanup)
+
+    p_drift = sub.add_parser("drift", help="3-way drift classification (from-version -> to-version).")
+    add_common(p_drift)
+    p_drift.add_argument("--to-version", required=True, help="Upgrade-target format version (e.g. 2025.1).")
+    p_drift.add_argument("--from-version", help="Fork-point/base version (default: project's locked FormatVersion).")
+    p_drift.set_defaults(func=cmd_drift)
+
+    p_aud = sub.add_parser("audit", help="Full audit pass (classification + drift summary).")
+    add_common(p_aud)
+    p_aud.add_argument("--baseline-version", help="Force a baseline version (default: derived from project).")
+    p_aud.add_argument("--annotation-pattern", action="append",
+                       help="Regex marking an intentional customization (repeatable). "
+                            f"Default: {DEFAULT_ANNOTATION_PATTERNS}")
+    p_aud.add_argument("--theme-prefix", action="append",
+                       help="Custom SCSS variable prefix signalling a customization, e.g. 'theme' "
+                            "or a company abbreviation like 'webworks' (repeatable). "
+                            "If omitted, the prefix is auto-detected from override-added variables.")
+    p_aud.set_defaults(func=cmd_audit)
+
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        return args.func(args)
+    except FileNotFoundError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return EXIT_NOT_FOUND
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #105.

Adds a new **`customization-audit`** skill that audits a project's advanced customizations (overrides) against an installed format build — so intentional customizations survive an upgrade and accumulated noise is cleared. Phase 1 (report-only); no writes to the project.

## What's included

- `plugins/webworks-agent-skills/skills/customization-audit/SKILL.md` (190 lines)
- `scripts/audit-overrides.py` — five subcommands
- 3 reference docs: `upgrade-audit-guide.md`, `known-vs-unknown-baseline.md`, `classification-heuristics.md`
- `README.md` updated (both skill tables); plugin bumped to **3.1.0**

## Subcommands

| Command | Purpose |
|---|---|
| `enumerate` | classify overrides (lock state, target→format resolution, forked-copy vs net-new) |
| `discover` | per-format fork-point + staleness depth vs the lock; retired-aware; plateau/confidence |
| `audit` | 2-way diff + 3 customization signals + SCSS missing-var / partial-wiring / dangling-reference checks |
| `cleanup` | removal recs: retired-format · orphan · duplicate-backup (cruft) · redundant-override |
| `drift` | 3-way classifier (`--from`→`--to`): manual-merge / auto-mergeable / fast-forward / redundant / in-sync |

## Key design

- **Three customization signals** — annotation markers, an auto-detected per-user `$prefix_` (e.g. `$theme_`, `$company_`; never hardcoded), and fork-point fingerprinting.
- **Two axes** — lock state (`FormatVersion`) and baseline availability (Mode A 3-way vs Mode B 2-way).
- **Positive vs negative drift**, disambiguated by the annotation test.
- **Aggressive removals** (safe: migration step 1 is a baseline commit/copy) with two-gate cruft detection and a settings-aware reference set that protects referenced custom source.
- **Retired-format / EOL policy** (WWHelp 5.0 + Reverb 1.x retired; EOL < 2022.1).

## Validation

- **`design.wep`** (Mode B, `{Current}`): reproduced positive drift (`assistant.js`), negative drift (`highlight-require-whitespace`), incomplete template (`_custom-webworks.scss`); prefix auto-detected `$webworks_` (trial fixture: `$theme_`); cleanup 0/15 on the clean project.
- **Real customer 2024.1→2025.1** (Mode A, gold ground truth): `cleanup` 111/144 matching the manual 144→24 prune; `discover` found Reverb 2.0 overrides 6 releases behind their lock; `drift` classified `locales.xml` auto-mergeable (CJK-search post-release fix, disjoint from custom stopwords) and flagged `Unsupported_Browser.asp` dropped-upstream; found 7 noise files even in the gold reconciliation.

Conformance: SKILL.md frontmatter convention, < 500 lines, no forbidden backtick-table sequences, script compiles, skills auto-discovered.

## Follow-up

Phase 2 (automated reconciliation — apply `drift` verdicts and `cleanup` removals behind explicit confirmation) tracked in #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
