### PR TITLE
Closes #107: Add reconcile command to apply customization-audit findings (Phase 2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "webworks-agent-skills",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "owner": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/.claude-plugin/plugin.json
+++ b/plugins/webworks-agent-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webworks-agent-skills",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "author": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/skills/customization-audit/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/customization-audit/SKILL.md
@@ -17,7 +17,7 @@ Audit the advanced customizations (overrides) in a WebWorks ePublisher project a
 
 **Do not use training data for ePublisher.** This is proprietary software; training data is absent or inaccurate. Use this skill, the `epublisher` skill (resolver hierarchy, project parsing), the `reverb2` skill (SCSS conventions), and the format source files. Windows-only; XSLT 1.0 only.
 
-This is a **Phase-1, report-only** skill — it never writes to the project. Removal recommendations can be acted on aggressively because the first step of any migration is a baseline commit or folder copy: the original state is always recoverable.
+The audit commands (`enumerate`, `discover`, `audit`, `cleanup`, `drift`) are **read-only**. The `reconcile` command is the only writer: it is **dry-run by default** and writes only with `--apply`, backing up every changed/deleted file plus an undo manifest first. Removal and reconciliation can be acted on aggressively because the first step of any migration is a baseline commit or folder copy: the original state is always recoverable.
 </objective>
 
 <overview>
@@ -109,8 +109,9 @@ The two axes are independent. See `references/known-vs-unknown-baseline.md`.
 | `audit` | 2-way diff + three customization signals + SCSS missing-variable / partial-wiring / dangling-reference checks | The standard health check |
 | `cleanup` | Removal recommendations: retired / orphan / cruft / redundant | Pruning noise before/after upgrade |
 | `drift` | 3-way classifier (`--from-version` → `--to-version`): manual-merge / auto-mergeable / fast-forward / redundant / in-sync | Planning the reconciliation of a real upgrade |
+| `reconcile` | **Apply** the audit (dry-run default; `--apply` writes with backup): execute removals, 3-way-merge auto-mergeable overrides, write side-by-side artifacts for conflicts, re-point the locked `FormatVersion` | Performing the upgrade |
 
-Recommended order for an upgrade: `enumerate` → `cleanup` (prune first) → `discover` (establish baseline) → `drift` (plan the merge). Step-by-step with a worked customer example: `references/upgrade-audit-guide.md`.
+Recommended order for an upgrade: `enumerate` → `cleanup` (prune first) → `discover` (establish baseline) → `drift` (plan the merge) → `reconcile` (apply). Step-by-step with a worked customer example: `references/upgrade-audit-guide.md`; the apply workflow, safety model, and undo: `references/reconcile-guide.md`.
 </commands>
 
 <scripts>
@@ -127,6 +128,7 @@ Per-command options:
 - `enumerate`, `audit`, `cleanup`: `--baseline-version` (override the derived baseline).
 - `audit`: `--annotation-pattern <regex>` (repeatable); `--theme-prefix <name>` (repeatable; auto-detected if omitted).
 - `drift`: `--to-version <ver>` (required); `--from-version <ver>` (default: the project's locked `FormatVersion`).
+- `reconcile`: `--to-version <ver>` (required); `--from-version <ver>`; `--apply` (write; default dry-run); `--backup-dir <dir>`; `--skip-removals` / `--skip-merge` / `--skip-lock-bump`.
 
 JSON mode emits structured findings for every command — use it to drive reconciliation tooling or reports.
 </scripts>
@@ -138,6 +140,7 @@ JSON mode emits structured findings for every command — use it to drive reconc
 - `references/upgrade-audit-guide.md` — end-to-end workflow, command sequence, and a worked 2024.1 → 2025.1 customer upgrade with output interpretation.
 - `references/known-vs-unknown-baseline.md` — lock state (Axis 1), Mode A/B (Axis 2), fork-point discovery, staleness depth, confidence taxonomy, retired/EOL policy, and Mode-B → Mode-A promotion recipes.
 - `references/classification-heuristics.md` — the three customization signals, the annotation test, positive vs negative drift, cruft/duplicate and redundant-override rules, and the CRLF normalization gotcha.
+- `references/reconcile-guide.md` — the `reconcile` apply workflow: verdict→action mapping, the 3-way merge engine, conflict artifacts, the backup/undo manifest, and the dry-run → apply safety model.
 </references>
 
 <common_tasks>
@@ -161,6 +164,10 @@ python audit-overrides.py audit --project "C:\proj\my.wep"
 
 # 5. Plan a real upgrade (3-way), e.g. locked 2024.1 -> 2025.1
 python audit-overrides.py drift --project "C:\proj\my.wep" --to-version 2025.1
+
+# 6. Apply it: preview first (dry-run), then write with a backup
+python audit-overrides.py reconcile --project "C:\proj\my.wep" --to-version 2025.1
+python audit-overrides.py reconcile --project "C:\proj\my.wep" --to-version 2025.1 --apply
 ```
 </common_tasks>
 
@@ -186,5 +193,6 @@ python audit-overrides.py drift --project "C:\proj\my.wep" --to-version 2025.1
 - SCSS missing-variable, partial-wiring, and dangling-reference checks run.
 - Removal recommendations produced (retired / orphan / cruft / redundant) without flagging referenced source.
 - For an upgrade: a 3-way verdict per surviving override (manual-merge / auto-mergeable / fast-forward / redundant / in-sync).
-- No writes to the project (Phase 1).
+- Audit commands make no writes; `reconcile` is dry-run unless `--apply`, and `--apply` always backs up first with an undo manifest.
+- `reconcile --apply` executes removals, clean 3-way merges, conflict artifacts, and the `FormatVersion` re-point, leaving the project upgraded and recoverable.
 </success_criteria>

--- a/plugins/webworks-agent-skills/skills/customization-audit/references/reconcile-guide.md
+++ b/plugins/webworks-agent-skills/skills/customization-audit/references/reconcile-guide.md
@@ -1,0 +1,68 @@
+# Reconcile Guide (Phase 2 — applying the audit)
+
+`reconcile` turns the audit findings into action: it removes noise, merges upstream changes into customized overrides, writes side-by-side artifacts where it cannot safely merge, and re-points the locked `FormatVersion`. It is the only command that writes.
+
+```bash
+# Preview (default — writes nothing):
+python audit-overrides.py reconcile --project "C:\proj\my.wep" --to-version 2025.1
+
+# Execute (backs up first):
+python audit-overrides.py reconcile --project "C:\proj\my.wep" --to-version 2025.1 --apply
+```
+
+## Safety model
+
+- **Dry-run by default.** Without `--apply`, `reconcile` prints the full action plan (real merge/conflict counts, computed via `git merge-file`) and writes nothing.
+- **`--apply` backs up first.** Every file it will change or delete — and the project file — is copied to `--backup-dir` (default `<project>/.reconcile-backup-<to-version>`) before any write, and a `reconcile-manifest.json` records every action with its backup path. The whole operation is recoverable by restoring from that directory.
+- **Aggressive is safe.** Migration step 1 is a baseline commit or folder copy, so even without the tool's backup the original is recoverable. Encourage users to commit/copy first, then let `reconcile` clear the noise.
+
+## Verdict → action mapping
+
+| Source finding | Action |
+|----------------|--------|
+| `cleanup`: retired-format / orphan (scope) | **delete the directory** |
+| `cleanup`: duplicate-backup (cruft) | **delete the file** |
+| `redundant` (cleanup or drift) | **delete the override** (patch fixed upstream) |
+| `drift`: `fast-forward` | **delete the override** so it resolves to the new baseline |
+| `drift`: `in-sync` | carry forward unchanged (no action) |
+| `drift`: `auto-mergeable` | **3-way merge** — apply upstream changes, keep customizations |
+| `drift`: `manual-merge` (or a merge that conflicts) | **side-by-side artifacts** for human resolution |
+| the upgrade itself | **re-point the locked `FormatVersion`** to `--to-version` |
+
+Files inside a directory slated for deletion, and overrides in retired formats, are skipped (the directory removal covers them). Disable categories with `--skip-removals`, `--skip-merge`, `--skip-lock-bump`.
+
+## The 3-way merge engine
+
+`reconcile` uses `git merge-file -p --diff3` (no git repository required — it operates on standalone files). The three inputs are:
+
+- **mine** — the override.
+- **base** — the fork-point baseline (`--from-version`, default the project's locked `FormatVersion`).
+- **new** — the upgrade target (`--to-version`).
+
+**Line endings are normalized to LF before merging.** A CRLF override against an LF baseline would otherwise make every line a conflict. Merged output is written back as LF.
+
+**`git merge-file` is authoritative.** A divergence classified `auto-mergeable` by the line-interval heuristic but that `git merge-file` reports as conflicting is **downgraded to conflict artifacts** — `reconcile` never silently overwrites a customization.
+
+> For a stale project (overrides forked well before the lock — see `discover` staleness depth), pass `--from-version <discovered-fork-point>` for a cleaner merge. Using the lock as the base inflates the "customization" diff with the un-received changes between the fork-point and the lock, producing more conflicts.
+
+## Conflict artifacts
+
+When a merge cannot be applied cleanly, the override is **left untouched** and four files are written beside it:
+
+```
+Footer.asp                       # original override — unchanged
+Footer.asp.reconcile-base        # fork-point baseline
+Footer.asp.reconcile-mine        # the override (normalized)
+Footer.asp.reconcile-new         # upgrade-target baseline
+Footer.asp.reconcile-merged      # 3-way merge with <<<<<<< / ||||||| / >>>>>>> markers
+```
+
+Resolve by editing `Footer.asp` using `.reconcile-merged` as a guide (or diffing `.mine` vs `.new`), then delete the four `.reconcile-*` files. `reconcile` lists every file needing manual resolution at the end of an apply run.
+
+## Undo
+
+Restore from the backup directory: copy each `backup` path in `reconcile-manifest.json` back to its `target`, re-create deleted directories from their backups, and (for `repoint-lock`) restore the backed-up project file. Then remove any `.reconcile-*` artifacts.
+
+## Worked example (continuing the 2024.1 → 2025.1 customer upgrade)
+
+`reconcile --to-version 2025.1 --apply` on the before-project produced 47 actions: 9 directory deletions (retired WWHelp 5.0 + Reverb 1.x targets/format), 17 file deletions (cruft + redundant + fast-forward drops), 4 clean 3-way merges (including `locales.xml` — the post-release CJK-search fix merged cleanly with the custom stopwords/synonyms), 16 conflict-artifact sets (the heavily customized Reverb templates), and the `FormatVersion` re-point to 2025.1 — taking the override surface from 144 files toward the reconciled set, with a full backup + manifest for undo.

--- a/plugins/webworks-agent-skills/skills/customization-audit/scripts/audit-overrides.py
+++ b/plugins/webworks-agent-skills/skills/customization-audit/scripts/audit-overrides.py
@@ -44,7 +44,10 @@ import argparse
 import difflib
 import json
 import re
+import shutil
+import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 from typing import Optional
@@ -1328,6 +1331,243 @@ def cmd_drift(args) -> int:
     return EXIT_SUCCESS
 
 
+# --------------------------------------------------------------------------- #
+# Phase 2: reconcile (apply the audit). Dry-run by default; --apply writes in
+# place after backing up every changed/deleted file + an undo manifest.
+# --------------------------------------------------------------------------- #
+def git_merge_file(mine: Path, base: Path, new: Path) -> tuple[str, int]:
+    """3-way merge via `git merge-file`. Returns (merged_text, conflict_count).
+    Inputs are normalized to LF first so a CRLF/LF mismatch does not turn every
+    line into a conflict."""
+    with tempfile.TemporaryDirectory() as td:
+        tdp = Path(td)
+        m, b, n = tdp / "mine", tdp / "base", tdp / "new"
+        m.write_bytes(("\n".join(read_lines(mine))).encode("utf-8"))
+        b.write_bytes(("\n".join(read_lines(base))).encode("utf-8"))
+        n.write_bytes(("\n".join(read_lines(new))).encode("utf-8"))
+        r = subprocess.run(["git", "merge-file", "-p", "--diff3", str(m), str(b), str(n)],
+                           capture_output=True, text=True, encoding="utf-8", errors="replace")
+        if r.returncode < 0 or r.returncode > 127:
+            raise RuntimeError(f"git merge-file failed ({r.returncode}): {r.stderr.strip()}")
+        return r.stdout, r.returncode
+
+
+def repoint_format_version(project_path: Path, to_ver: str) -> bool:
+    """Set the locked FormatVersion on the <Project> root, preserving file
+    bytes/EOL otherwise. Returns True if changed."""
+    data = project_path.read_bytes()
+    text = data.decode("utf-8")
+    new = re.sub(r'(<Project\b[^>]*?\bFormatVersion=")[^"]*(")',
+                 lambda mt: mt.group(1) + to_ver + mt.group(2), text, count=1)
+    if new == text:
+        return False
+    project_path.write_bytes(new.encode("utf-8"))
+    return True
+
+
+@dataclass
+class ReconcileAction:
+    op: str           # delete-file | delete-dir | merge | conflict | repoint-lock
+    target: str       # path relative to project dir (or project filename)
+    reason: str
+    abs_path: str = ""
+
+
+def _under_any(location: str, dirs: set[str]) -> bool:
+    return any(location == d or location.startswith(d + "/") for d in dirs)
+
+
+def plan_reconcile(project: ProjectInfo, overrides: list[Override], from_root: Path,
+                   to_root: Path, args) -> list[ReconcileAction]:
+    project_dir = project.path.parent
+    actions: list[ReconcileAction] = []
+    deleted_dirs: set[str] = set()
+    deleted_files: set[str] = set()
+
+    # 1) Removals (retired / orphan / cruft / redundant) from the cleanup engine.
+    if not args.skip_removals:
+        for f in detect_removals(overrides, project):
+            if f.kind == "scope":
+                actions.append(ReconcileAction("delete-dir", f.target, f.reason, str(project_dir / f.target)))
+                deleted_dirs.add(f.target)
+            else:
+                actions.append(ReconcileAction("delete-file", f.target, f.reason, str(project_dir / f.target)))
+                deleted_files.add(f.target)
+
+    # 2) Drift verdicts on surviving forked overrides.
+    for ov in overrides:
+        if not ov.is_text or ov.classification != "forked-copy" or is_retired_format(ov.format_name):
+            continue
+        location = f"{ov.level.capitalize()}s/{ov.scope_name}/{ov.rel_path}"
+        if location in deleted_files or _under_any(location, deleted_dirs):
+            continue
+        base_old = baseline_file_for(ov, from_root)
+        base_new = baseline_file_for(ov, to_root)
+        if not base_old or not base_old.is_file() or not base_new or not base_new.is_file():
+            continue
+        r = analyze_3way(location, ov.rel_path, ov.format_name,
+                         read_lines(base_old), read_lines(base_new), read_lines(ov.abs_path))
+        if r.verdict in ("redundant", "fast-forward"):
+            if r.verdict == "redundant" and args.skip_removals:
+                continue
+            why = ("identical to baseline -> drop" if r.verdict == "redundant"
+                   else "unmodified copy; baseline changed -> drop so it resolves to the new base")
+            actions.append(ReconcileAction("delete-file", location, why, str(ov.abs_path)))
+            deleted_files.add(location)
+        elif r.verdict == "auto-mergeable" and not args.skip_merge:
+            actions.append(ReconcileAction("merge", location, "3-way merge (disjoint regions)", str(ov.abs_path)))
+        elif r.verdict == "manual-merge" and not args.skip_merge:
+            actions.append(ReconcileAction("conflict", location, "customization overlaps upstream change -> side-by-side artifacts", str(ov.abs_path)))
+        # in-sync -> no action (carried forward)
+
+    # 3) Re-point the locked FormatVersion to the target.
+    if not args.skip_lock_bump and project.lock_state == "locked":
+        actions.append(ReconcileAction("repoint-lock", project.path.name,
+                                       f"bump locked FormatVersion -> {args.to_version}", str(project.path)))
+    return actions
+
+
+def _backup(abs_path: Path, project_dir: Path, backup_dir: Path) -> Optional[str]:
+    try:
+        rel = abs_path.relative_to(project_dir)
+    except ValueError:
+        rel = Path(abs_path.name)
+    dest = backup_dir / rel
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if abs_path.is_dir():
+        shutil.copytree(abs_path, dest, dirs_exist_ok=True)
+    else:
+        shutil.copy2(abs_path, dest)
+    return str(dest)
+
+
+def execute_reconcile(actions: list[ReconcileAction], project: ProjectInfo,
+                      to_ver: str, backup_dir: Path) -> list[dict]:
+    project_dir = project.path.parent
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    manifest: list[dict] = []
+    for a in actions:
+        p = Path(a.abs_path)
+        entry = {"op": a.op, "target": a.target}
+        if a.op in ("delete-file", "delete-dir"):
+            if p.exists():
+                entry["backup"] = _backup(p, project_dir, backup_dir)
+                if p.is_dir():
+                    shutil.rmtree(p)
+                else:
+                    p.unlink()
+        elif a.op == "merge":
+            merged, conflicts = a_merge_payload[a.target]
+            entry["backup"] = _backup(p, project_dir, backup_dir)
+            if conflicts == 0:
+                p.write_bytes(merged.encode("utf-8"))
+                entry["result"] = "merged-clean"
+            else:
+                _write_conflict_artifacts(p, a.target, merged)
+                entry["result"] = f"unexpected-conflict({conflicts})->artifacts"
+        elif a.op == "conflict":
+            merged, _ = a_merge_payload[a.target]
+            _write_conflict_artifacts(p, a.target, merged)
+            entry["result"] = "artifacts-written"
+        elif a.op == "repoint-lock":
+            entry["backup"] = _backup(p, project_dir, backup_dir)
+            repoint_format_version(p, to_ver)
+            entry["result"] = f"FormatVersion={to_ver}"
+        manifest.append(entry)
+    (backup_dir / "reconcile-manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return manifest
+
+
+def _write_conflict_artifacts(override: Path, location: str, merged_with_markers: str) -> None:
+    """Leave the override untouched; write .reconcile-{base,mine,new,merged}."""
+    payload = _conflict_sources[location]
+    override.with_name(override.name + ".reconcile-base").write_bytes(payload["base"].encode("utf-8"))
+    override.with_name(override.name + ".reconcile-mine").write_bytes(payload["mine"].encode("utf-8"))
+    override.with_name(override.name + ".reconcile-new").write_bytes(payload["new"].encode("utf-8"))
+    override.with_name(override.name + ".reconcile-merged").write_bytes(merged_with_markers.encode("utf-8"))
+
+
+# Populated by cmd_reconcile before execute (keeps merge content out of the
+# lightweight action records and avoids re-running git for dry-run).
+a_merge_payload: dict[str, tuple[str, int]] = {}
+_conflict_sources: dict[str, dict[str, str]] = {}
+
+
+def cmd_reconcile(args) -> int:
+    project = parse_project(Path(args.project))
+    install_root = Path(args.install_root)
+    from_ver = args.from_version or project.base_format_version
+    to_ver = args.to_version
+    from_root, to_root = install_root / from_ver, install_root / to_ver
+    if not from_root.is_dir():
+        print(f"[ERROR] from-version baseline not installed: {from_root} (try `discover`)", file=sys.stderr)
+        return EXIT_NOT_FOUND
+    if not to_root.is_dir():
+        print(f"[ERROR] to-version baseline not installed: {to_root}", file=sys.stderr)
+        return EXIT_NOT_FOUND
+
+    overrides = enumerate_overrides(project)
+    classify_overrides(overrides, from_root)
+    actions = plan_reconcile(project, overrides, from_root, to_root, args)
+
+    # Pre-compute merge content for merge/conflict actions (authoritative via git).
+    a_merge_payload.clear()
+    _conflict_sources.clear()
+    for a in actions:
+        if a.op not in ("merge", "conflict"):
+            continue
+        ov = next(o for o in overrides
+                  if f"{o.level.capitalize()}s/{o.scope_name}/{o.rel_path}" == a.target)
+        base_old, base_new = baseline_file_for(ov, from_root), baseline_file_for(ov, to_root)
+        merged, conflicts = git_merge_file(ov.abs_path, base_old, base_new)
+        a_merge_payload[a.target] = (merged, conflicts)
+        _conflict_sources[a.target] = {
+            "base": "\n".join(read_lines(base_old)),
+            "mine": "\n".join(read_lines(ov.abs_path)),
+            "new": "\n".join(read_lines(base_new)),
+        }
+        # Authoritative reclassification: an "auto-merge" that actually conflicts
+        # becomes a conflict (never silently overwrite a customization).
+        if a.op == "merge" and conflicts > 0:
+            a.op, a.reason = "conflict", f"git reports {conflicts} conflict(s) -> side-by-side artifacts"
+
+    counts: dict[str, int] = {}
+    for a in actions:
+        counts[a.op] = counts.get(a.op, 0) + 1
+
+    if args.format == "json":
+        emit_json({"project": project, "fromVersion": from_ver, "toVersion": to_ver,
+                   "apply": bool(args.apply), "counts": counts, "actions": actions})
+        if args.apply:
+            backup_dir = Path(args.backup_dir) if args.backup_dir else project.path.parent / f".reconcile-backup-{to_ver}"
+            execute_reconcile(actions, project, to_ver, backup_dir)
+        return EXIT_SUCCESS
+
+    mode = "APPLY" if args.apply else "DRY-RUN (no changes written)"
+    print(f"reconcile [{mode}]: {project.path.name}   {from_ver} -> {to_ver}")
+    print("  " + " | ".join(f"{op}: {n}" for op, n in sorted(counts.items())))
+    print()
+    labels = {"delete-dir": "DELETE DIR", "delete-file": "DELETE", "merge": "MERGE",
+              "conflict": "CONFLICT", "repoint-lock": "REPOINT"}
+    for a in sorted(actions, key=lambda x: x.op):
+        print(f"  {labels.get(a.op, a.op):<11} {a.target}")
+        print(f"        {a.reason}")
+    print()
+    if not args.apply:
+        print("  Dry-run only. Re-run with --apply to execute.")
+        print("  Safety: --apply backs up every changed/deleted file + an undo manifest first.")
+        return EXIT_SUCCESS
+
+    backup_dir = Path(args.backup_dir) if args.backup_dir else project.path.parent / f".reconcile-backup-{to_ver}"
+    manifest = execute_reconcile(actions, project, to_ver, backup_dir)
+    print(f"  Applied {len(manifest)} action(s).")
+    print(f"  Backup + undo manifest: {backup_dir}")
+    conflicts = [m for m in manifest if str(m.get('result', '')).startswith(('artifacts', 'unexpected'))]
+    if conflicts:
+        print(f"  {len(conflicts)} file(s) need manual resolution -> see .reconcile-merged artifacts.")
+    return EXIT_SUCCESS
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Audit ePublisher advanced customizations (overrides) for upstream drift.",
@@ -1360,6 +1600,17 @@ def build_parser() -> argparse.ArgumentParser:
     p_drift.add_argument("--to-version", required=True, help="Upgrade-target format version (e.g. 2025.1).")
     p_drift.add_argument("--from-version", help="Fork-point/base version (default: project's locked FormatVersion).")
     p_drift.set_defaults(func=cmd_drift)
+
+    p_rec = sub.add_parser("reconcile", help="Phase 2: apply the audit (dry-run default; --apply writes).")
+    add_common(p_rec)
+    p_rec.add_argument("--to-version", required=True, help="Upgrade-target format version (e.g. 2025.1).")
+    p_rec.add_argument("--from-version", help="Fork-point/base version (default: project's locked FormatVersion).")
+    p_rec.add_argument("--apply", action="store_true", help="Write changes (default: dry-run). Backs up first.")
+    p_rec.add_argument("--backup-dir", help="Backup destination (default: <project>/.reconcile-backup-<to>).")
+    p_rec.add_argument("--skip-removals", action="store_true", help="Do not delete retired/orphan/cruft/redundant.")
+    p_rec.add_argument("--skip-merge", action="store_true", help="Do not 3-way merge or write conflict artifacts.")
+    p_rec.add_argument("--skip-lock-bump", action="store_true", help="Do not re-point the locked FormatVersion.")
+    p_rec.set_defaults(func=cmd_reconcile)
 
     p_aud = sub.add_parser("audit", help="Full audit pass (classification + drift summary).")
     add_common(p_aud)


### PR DESCRIPTION
Closes #107. Phase 2 of the `customization-audit` skill (Phase 1: #105 / #106).

Adds a **`reconcile`** subcommand that applies the audit findings to perform an upgrade. It is the only command that writes — **dry-run by default**, `--apply` writes in place after backing up every changed/deleted file (and the project file) to a backup dir plus a `reconcile-manifest.json` undo manifest.

## Actions

| Finding | Action |
|---|---|
| retired-format / orphan (scope) | delete directory |
| duplicate-backup (cruft) | delete file |
| redundant | delete override |
| `fast-forward` | delete override (resolves to new baseline) |
| `in-sync` | carry forward |
| `auto-mergeable` | 3-way merge (keep customizations, apply upstream) |
| `manual-merge` / merge-that-conflicts | side-by-side artifacts |
| the upgrade | re-point locked `FormatVersion` |

## Design notes

- **3-way merge:** `git merge-file -p --diff3` (no git repo needed); inputs LF-normalized so a CRLF/LF mismatch doesn't make every line a conflict. `git merge-file` is authoritative — an `auto-mergeable` that actually conflicts is **downgraded to artifacts**, never silently overwriting a customization.
- **Conflicts:** `.reconcile-base` / `.reconcile-mine` / `.reconcile-new` / `.reconcile-merged` (with markers) written beside the untouched override; each listed for manual resolution.
- **Scope flags:** `--skip-removals`, `--skip-merge`, `--skip-lock-bump`. For stale projects, `--from-version <discovered-fork-point>` gives a cleaner merge base than the lock.

## Validation

Dry-run plan, then `--apply` on a **copy** of the real customer before-project (2024.1→2025.1):
- 47 actions: 9 dir deletes, 17 file deletes, **4 clean merges**, 16 conflict-artifact sets, FormatVersion → 2025.1.
- `locales.xml` merged cleanly (post-release CJK-search fix + custom stopwords — the `auto-mergeable` case from `drift`; confirmed changed, no markers).
- 144 → 33 files; 116 backed up; **0 backup artifacts missing** (full undo).
- design.wep (tracking project): no lock-bump, as expected.

## Files

- `scripts/audit-overrides.py` — `reconcile` subcommand (sixth)
- `references/reconcile-guide.md` — apply workflow, safety model, merge engine, conflict artifacts, undo
- `SKILL.md` — sixth command, read-only-audit vs writer framing, success criteria
- plugin bumped 3.1.0 → **3.2.0**

Conformance: SKILL.md 198 lines (< 500), no forbidden backtick-table sequences, script compiles. Fixed a UTF-8 decode bug in the `git merge-file` subprocess call found during validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
