### PR TITLE
Closes #112: document <MergeSettings> and the staging-folder output location in the automap skill

### DIFF
--- a/plugins/webworks-agent-skills/skills/automap/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/automap/SKILL.md
@@ -261,7 +261,10 @@ These options apply primarily to project files (.wep, .wrp). When used with job 
 | Option | Description |
 |--------|-------------|
 | `--verbose` | Show all build output (default: minimal) |
-| `--deployfolder PATH` | Override deployment destination |
+| `-d, --deployfolder PATH` | Override deployment destination (implies `--deploy`) |
+| `-s, --stagingdir DIR` | Override staging directory for job-file (`.waj`) builds; output lands at `DIR/<JobName>/Output/<target>/` |
+
+Any other option is passed through to the AutoMap executable (value-bearing pass-through options must use the `--flag=value` form).
 
 **For complete CLI reference with examples, see:** references/cli-reference.md
 </cli_reference>

--- a/plugins/webworks-agent-skills/skills/automap/references/cli-reference.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/cli-reference.md
@@ -100,7 +100,7 @@ bash scripts/automap-wrapper.sh [options] <project-file> [-t <target-name>]
 **`-n, --nodeploy`**
 - **Purpose**: Do not copy output to deployment location
 - **Use When**: Testing builds or using custom deployment
-- **Impact**: Output remains in project's Output folder only
+- **Impact**: Output remains in the project's Output folder only. For a Stationery-based job file (`.waj`), that folder is inside the Staging Folder — `<stagingDir>/<JobName>/Output/<target>/`, **not** next to the `.waj`. See [Staging Folder (Job Files)](#staging-folder-job-files).
 - **Example**: `-c -n project.wep`
 
 **`-l, --cleandeploy`**
@@ -138,6 +138,30 @@ bash scripts/automap-wrapper.sh [options] <project-file> [-t <target-name>]
 - **Impact**: Output copied to specified path instead of project default
 - **Example**: `--deployfolder "C:\Output" project.wep`
 - **Note**: Must have write permissions to deployment path
+
+### Staging Folder (Job Files)
+
+When AutoMap builds a Stationery-based job file (`.waj`), it stages a temporary Express project (`.wrp`) under the **Staging Folder** and builds there. The output lands at `<stagingDir>/<JobName>/Output/<target>/` — **not** next to the `.waj`. This is the most common reason "I can't find my output." (Project files — `.wep`/`.wrp` — build into their own Output folder.)
+
+- **Default Staging Folder**: `%USERPROFILE%\Documents\WebWorks ePublisher AutoMap\Staging` (an AutoMap preference).
+- **Job/target naming**: `<JobName>` is the `<Job name="...">` attribute; `<target>` is the target's `name`.
+
+**`-s <dir>`, `--stagingdir <dir>`**
+- **Purpose**: Override the staging directory for this build
+- **Use When**: Directing job-file output to a known location, or isolating builds
+- **Impact**: Staged project and output go under `<dir>/<JobName>/...`
+- **Forms**: `-s <dir>`, `--stagingdir <dir>`, or `--stagingdir=<dir>` (all equivalent)
+- **Examples**:
+  - Wrapper: `bash scripts/automap-wrapper.sh -t "WebWorks Reverb 2.0" --stagingdir "C:\automap\staging" merged-help.waj`
+  - Direct executable: `"path/to/WebWorks.Automap.exe" --stagingdir "C:\automap\staging" merged-help.waj`
+- **Note**: See the job file guide's [Output Location](./job-file-guide.md#output-location-staging-folder).
+
+### Pass-Through Options
+
+The wrapper intercepts only the options it transforms or applies safe defaults to (clean, deploy, reports, target selection, staging). **Any other option is forwarded to the AutoMap executable verbatim** — so native AutoMap flags work without the wrapper needing to know each one (for example `--nonotify` / `-f`, which suppresses the job-result notification).
+
+- A pass-through option that takes a value must use the `--flag=value` form. The space-separated form (`--flag value`) would let the wrapper mistake the value for the project file, since it cannot know an unrecognized flag's arity.
+- Genuinely unknown flags reach AutoMap, which reports its own "unknown option" error.
 
 ### Performance Options
 
@@ -505,5 +529,5 @@ When adding a new AutoMap CLI option to this skill, update these locations:
 ---
 
 **Version**: 2.5.0
-**Last Updated**: 2026-03-19
+**Last Updated**: 2026-06-08
 **Target**: ePublisher 2024.1+ AutoMap CLI (--skip-reports requires 2025.1+, --version requires 2025.1 build 4652+)

--- a/plugins/webworks-agent-skills/skills/automap/references/job-file-guide.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/job-file-guide.md
@@ -7,8 +7,10 @@
 - [Stationery Inheritance](#stationery-inheritance)
 - [XML Structure](#xml-structure)
 - [Element Reference](#element-reference)
+- [Output Location (Staging Folder)](#output-location-staging-folder)
 - [Creating Job Files](#creating-job-files)
 - [Target Configuration](#target-configuration)
+- [Merge Settings (Multivolume / Merged TOC)](#merge-settings-multivolume--merged-toc)
 - [Common Patterns](#common-patterns)
 - [Troubleshooting](#troubleshooting)
 
@@ -252,6 +254,78 @@ Container for format setting overrides.
 | `name` | Setting name (must exist in Stationery) |
 | `value` | Setting value |
 
+### `<MergeSettings>` Element
+
+Optional child of `<Target>`. Defines a multivolume / merged TOC for Reverb-family formats. Maps to the project's `<FormatConfiguration><MergeSettings>`. See [Merge Settings (Multivolume / Merged TOC)](#merge-settings-multivolume--merged-toc).
+
+| Attribute | Required | Description | Example |
+|-----------|----------|-------------|---------|
+| `title` | No | Title of the merged master TOC | `"MasterTOC"` |
+
+Contains `<TOC>` and/or `<Group>` child nodes, in document order, describing the TOC layout.
+
+### `<TOC>` Element (within `<MergeSettings>`)
+
+A custom container (a TOC folder) that groups parcels under a labeled node. Nestable.
+
+| Attribute | Required | Description | Example |
+|-----------|----------|-------------|---------|
+| `name` | Yes | Container display name | `"Layer1"` |
+
+Contains nested `<TOC>` and/or `<Group>` nodes.
+
+### `<Group>` Element (within `<MergeSettings>`)
+
+Places a document group as a parcel (a volume) in the merged TOC. **Distinct from the `<Group>` under `<Files>`**: here it is a reference *by name* to a `<Files>` group, not a container of `<Document>` elements.
+
+| Attribute | Required | Description | Example |
+|-----------|----------|-------------|---------|
+| `name` | Yes | Name of a **top-level** `<Files>` group to place | `"Group1"` |
+| `title` | No | Display-title override for this parcel | `"Group One"` |
+| `context` | No | Context (CSH) value for this parcel | `"admin"` |
+
+**Resolution**: Groups are referenced by name. AutoMap resolves each name to the staged project's GroupID — you never write GroupIDs by hand — so only top-level `<Files>` groups can be placed. This maps to the project's `<MergeGroup GroupID Title>`.
+
+---
+
+## Output Location (Staging Folder)
+
+When AutoMap builds a Stationery-based job file (`.waj`), it does **not** build in place next to the `.waj`. It stages a temporary Express project (`.wrp`) under the **Staging Folder** and builds there:
+
+```
+<stagingDir>/<JobName>/<JobName>.wrp        ← staged project
+<stagingDir>/<JobName>/Output/<TargetName>/ ← built output
+```
+
+`<JobName>` is the `name` attribute of the `<Job>` root element; `<TargetName>` is the target's `name`.
+
+**Default Staging Folder** (an AutoMap preference, set in the AutoMap Administrator):
+
+```
+%USERPROFILE%\Documents\WebWorks ePublisher AutoMap\Staging
+```
+
+**Override per run** with `-s` / `--stagingdir` (accepted by the AutoMap executable and exposed by the wrapper):
+
+| Option | Description |
+|--------|-------------|
+| `-s <dir>`, `--stagingdir <dir>` | Use `<dir>` as the staging directory for this build |
+
+```bash
+# Via the wrapper
+bash scripts/automap-wrapper.sh -t "WebWorks Reverb 2.0" --stagingdir "C:\automap\staging" merged-help.waj
+
+# Directly
+"path/to/WebWorks.Automap.exe" --stagingdir "C:\automap\staging" merged-help.waj
+
+# Output -> C:\automap\staging\merged-help\Output\WebWorks Reverb 2.0\
+```
+
+**Notes**:
+
+- The staged project (and its `Output/`) persists after the build by default (the AutoMap "Remove temporary files" preference is off), which is why output can be retrieved from the Staging Folder. Deployment (`-d`/`--deployfolder`, or a `deployTarget`) copies output elsewhere; without it, the Staging Folder is the only place output lands.
+- This staging behavior applies to Stationery-based jobs. A `.waj` that references a `.wep`/`.wrp` master project instead builds into that project's own `Output/` folder.
+
 ---
 
 ## Creating Job Files
@@ -361,6 +435,82 @@ Settings override format-level configuration from Stationery:
 ```bash
 python scripts/parse-stationery.py stationery.wxsp
 ```
+
+---
+
+## Merge Settings (Multivolume / Merged TOC)
+
+Reverb-family formats can combine several document groups into one output with a single, multivolume table of contents. Each top-level `<Files>` group becomes a **parcel** (a volume); `<MergeSettings>` defines how those parcels are titled and arranged in the master TOC.
+
+`<MergeSettings>` is an optional child of `<Target>`. The AutoMap Administrator's Merge Settings dialog generates it, and it can be authored by hand.
+
+### Structure
+
+- `<MergeSettings title="...">` — the merged master TOC (optional title).
+  - `<TOC name="...">` — a custom container (TOC folder); nestable.
+  - `<Group name="..." title="..." />` — places a `<Files>` group as a parcel, with an optional display-title override.
+
+Groups are referenced **by name** (matching a top-level `<Files>` group). AutoMap resolves each name to that group's GroupID in the staged project, so you never write GroupIDs by hand.
+
+### Worked Example
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Job name="merged-help" version="1.0">
+  <Project path="stationery\main.wxsp" />
+
+  <!-- Each top-level group is a parcel (a volume in the merged TOC) -->
+  <Files>
+    <Group name="Group1">
+      <Document path="Source\admin\admin-guide.md" />
+    </Group>
+    <Group name="Group2">
+      <Document path="Source\user\user-guide.md" />
+    </Group>
+  </Files>
+
+  <Targets>
+    <Target name="WebWorks Reverb 2.0"
+            format="WebWorks Reverb 2.0"
+            formatType="Application"
+            build="True"
+            deployTarget=""
+            cleanOutput="False">
+
+      <!-- Define the merged TOC: title, containers, and parcel placement -->
+      <MergeSettings title="MasterTOC">
+        <TOC name="Layer1">
+          <Group name="Group1" title="Group One" />
+        </TOC>
+        <Group name="Group2" title="Group Two" />
+      </MergeSettings>
+    </Target>
+  </Targets>
+</Job>
+```
+
+This yields a master TOC titled "MasterTOC" containing:
+
+- **Layer1** (container)
+  - **Group One** (parcel, from `Group1`)
+- **Group Two** (parcel, from `Group2`)
+
+### How It Maps to the Project
+
+The inline job `<MergeSettings>` is applied onto the staged project's `<FormatConfiguration>`:
+
+| Job file (`.waj`) | Project (`.wrp` / `.wep`) |
+|-------------------|---------------------------|
+| `<MergeSettings title="MasterTOC">` | `<MergeSettings Title="MasterTOC">` |
+| `<TOC name="Layer1">` | `<TOC Name="Layer1">` |
+| `<Group name="Group1" title="Group One" />` | `<MergeGroup GroupID="..." Title="Group One" />` |
+
+### Skeleton Master Pattern
+
+A **skeleton master** is a job whose groups carry only minimal stub content, built solely to produce the merged master TOC and the output shell (parcel containers + titles). The real content is built separately — one or more "satellite" parcel jobs — then joined to the master **by group name**. This supports updating individual parcels without rebuilding the whole merged output (the Reverb merge-settings / deploy-set workflow).
+
+- Give each group at least one stub document. An empty group fails group verification and produces no TOC entry; empty containers are pruned.
+- The master is authoritative for the TOC hierarchy and the title overrides — both live only in `<MergeSettings>`. A standalone parcel build cannot reproduce them.
 
 ---
 
@@ -487,6 +637,26 @@ fi
 1. Verify setting name exactly matches Stationery
 2. Check that setting is valid for this format
 3. List available settings: `python scripts/parse-stationery.py stationery.wxsp`
+
+### Can't Find Build Output
+
+**Issue**: Built a `.waj` but there's no `Output/` next to the job file.
+
+**Explanation**: Stationery-based job files build into the **Staging Folder**, not next to the `.waj`. Look in `<stagingDir>/<JobName>/Output/<TargetName>/` — by default `<My Documents>\WebWorks ePublisher AutoMap\Staging\<JobName>\Output\<TargetName>\`.
+
+**Solutions**:
+1. Check the Staging Folder (see [Output Location (Staging Folder)](#output-location-staging-folder))
+2. Set the staging location explicitly with `-s` / `--stagingdir`
+3. Deploy the output to a known location with `-d` / `--deployfolder`
+
+### Merge Settings Group Not Appearing
+
+**Issue**: A `<Group>` listed in `<MergeSettings>` doesn't show in the merged TOC.
+
+**Solutions**:
+1. The `name` must match a **top-level** group in `<Files>` (nested/child groups cannot be placed)
+2. The referenced group must contain at least one document (empty groups are dropped)
+3. Group names are matched exactly
 
 ---
 

--- a/plugins/webworks-agent-skills/skills/automap/scripts/automap-wrapper.sh
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/automap-wrapper.sh
@@ -44,6 +44,8 @@ TARGET=""
 TARGET_MULTI=""
 ALL_TARGETS=false
 DEPLOY_FOLDER=""
+STAGING_DIR=""
+PASSTHROUGH_ARGS=()
 VERBOSE=false
 
 # Color codes for output
@@ -262,8 +264,14 @@ BUILD OPTIONS (safe defaults - opt out as needed):
 
 OTHER OPTIONS:
     -d, --deployfolder=PATH  Override deployment destination (implies --deploy)
+    -s, --stagingdir=DIR     Override staging directory for job-file (.waj) builds
+                             [default: AutoMap "Staging" preference folder].
+                             Output lands at DIR/<JobName>/Output/<target>/
     --verbose                Show all build output (default: minimal)
     --help                   Show this help message
+
+    Any other option is passed through to the AutoMap executable. A
+    pass-through option that takes a value must use the --flag=value form.
 
 ENVIRONMENT:
     AUTOMAP_EXE_PATH       Path to AutoMap executable (bypasses auto-detection)
@@ -401,6 +409,19 @@ build_automap_command() {
     # Add skip reports flag (2025.1+)
     if [ "$SKIP_REPORTS" = true ]; then
         cmd="$cmd --skip-reports"
+    fi
+
+    # Add staging directory if specified (job files stage under <dir>/<JobName>/)
+    if [ -n "$STAGING_DIR" ]; then
+        cmd="$cmd --stagingdir=\"$STAGING_DIR\""
+    fi
+
+    # Add any pass-through AutoMap options (forwarded verbatim)
+    if [ "${#PASSTHROUGH_ARGS[@]}" -gt 0 ]; then
+        local passthrough_arg
+        for passthrough_arg in "${PASSTHROUGH_ARGS[@]}"; do
+            cmd="$cmd \"$passthrough_arg\""
+        done
     fi
 
     # Add project file (always last)
@@ -604,6 +625,28 @@ while [[ $# -gt 0 ]]; do
             NO_DEPLOY=false  # Deployfolder implies deployment enabled
             shift
             ;;
+        -s)
+            if [ -z "${2:-}" ]; then
+                log_error "Missing DIR argument for -s"
+                usage
+                exit 2
+            fi
+            STAGING_DIR="$2"
+            shift 2
+            ;;
+        --stagingdir)
+            if [ -z "${2:-}" ]; then
+                log_error "Missing DIR argument for --stagingdir"
+                usage
+                exit 2
+            fi
+            STAGING_DIR="$2"
+            shift 2
+            ;;
+        --stagingdir=*)
+            STAGING_DIR="${1#--stagingdir=}"
+            shift
+            ;;
         --skip-reports)
             SKIP_REPORTS=true
             shift
@@ -633,9 +676,14 @@ while [[ $# -gt 0 ]]; do
             exit 0
             ;;
         -*)
-            log_error "Unknown option: $1"
-            usage
-            exit 2
+            # Pass through any other AutoMap option. The wrapper only intercepts
+            # the flags it transforms or applies safe defaults to (clean, deploy,
+            # reports, target selection, staging); everything else is forwarded to
+            # the executable verbatim. A value-bearing option that the wrapper does
+            # not parse explicitly must use the --flag=value form, otherwise its
+            # value would be mistaken for the project file.
+            PASSTHROUGH_ARGS+=("$1")
+            shift
             ;;
         *)
             if [ -n "$PROJECT_FILE" ]; then


### PR DESCRIPTION
Implements #112.

## Summary

Documents AutoMap's inline `<MergeSettings>` (multivolume / merged TOC) and the **Staging Folder** output location in the automap skill's job-file guide, and — following the same theme — makes the wrapper actually **expose** the staging-directory override instead of rejecting it.

All documented behavior was verified against the AutoMap source (`MergeNodeList.Deserialize`, `AutomapCLI.AddMergeSettings`, `TOCNode.cs`, `JobXmlElements.cs`, `AutomapPreferences.cs`, `CommandParser.cs`), not assumed.

## Changes

**`references/job-file-guide.md`**
- Element Reference entries for `<MergeSettings>`, `<TOC>`, and the merge-context `<Group>` — the latter explicitly distinguished from the `<Files>` `<Group>` (a by-name reference, not a `<Document>` container).
- New **Merge Settings (Multivolume / Merged TOC)** section: complete worked example, the `.waj` → project `<MergeGroup GroupID Title>` mapping, and the skeleton-master pattern.
- New **Output Location (Staging Folder)** section: `.waj` stages a `.wrp` and builds to `<stagingDir>/<JobName>/Output/<target>/`, default folder, `-s`/`--stagingdir` override, persistence-by-default, and the `.wep`/`.wrp`-master exception. Two troubleshooting entries ("Can't Find Build Output", "Merge Settings Group Not Appearing").

**`references/cli-reference.md`**
- Fixed the misleading `-n, --nodeploy` "output remains in the project's Output folder" note that the issue flagged as the source of confusion.
- Documented `-s`/`--stagingdir` (all forms) and added a **Pass-Through Options** subsection.

**`scripts/automap-wrapper.sh`**
- Exposes `-s` / `--stagingdir` (`-s DIR`, `--stagingdir DIR`, `--stagingdir=DIR`), with a missing-value guard, emitted as `--stagingdir="DIR"`.
- Converts the `-*)` hard "unknown option" error into a **pass-through**: the wrapper now intercepts only the flags it transforms/safe-defaults (clean, deploy, reports, target selection, staging) and forwards everything else to the AutoMap executable. Value-bearing pass-through flags must use `--flag=value` (the wrapper can't know an unknown flag's arity); verified via `CommandParser.cs` that AutoMap accepts `--name=value`, `--name value`, and `-x value`.

**`SKILL.md`**
- Added `-s, --stagingdir` (and `-d, --deployfolder`) to the Wrapper Options table plus a pass-through note.

## Verification
- End-to-end parsing test with a fake AutoMap exe: `-s`, `--stagingdir`, `--stagingdir=`, space-bearing values, `--nonotify` pass-through, combined staging+passthrough, and the missing-value guard — all correct, project file stays last.
- Existing test suite: **12 passed, 0 failed**; `bash -n` clean; empty-`PASSTHROUGH_ARGS` safe under `set -u`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)