### PR TITLE
Closes #109: validate Reverb load via the preload signal (browser-test.js)

### DIFF
--- a/plugins/webworks-agent-skills/skills/reverb2/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/SKILL.md
@@ -94,7 +94,7 @@ When investigating a runtime issue — a theme override that didn't apply, a bro
 
 | Feature | Script | Description |
 |---------|--------|-------------|
-| Browser Testing | `browser-test.js` | Load output in headless Chrome, check for errors |
+| Browser Testing | `browser-test.js` | Load output in headless Chrome; pass/fail on the `preload` load signal (`--vanilla` for no-bypass file:// mode) |
 | CSH Analysis | `parse-url-maps.py` | Extract topic mappings from url_maps.xml |
 | SCSS Theming | `extract-scss-variables.py` | Read current theme values |
 | Entry Detection | `detect-entry-point.sh` | Find output location from project |
@@ -109,20 +109,34 @@ When investigating a runtime issue — a theme override that didn't apply, a bro
 ### Run Test
 
 ```bash
-node scripts/browser-test.js <chrome-path> <entry-url> [format-settings-json]
+node scripts/browser-test.js <chrome-path> <entry-url> [format-settings-json] [--vanilla]
 ```
+
+### Pass/Fail Signal (read this first)
+
+**Primary signal — the only reliable one:** a load succeeded when the **`preload` class is removed from `<body id="connect_body">`**. `connect.js` removes it only in its `page_load_complete` handler, which fires when the **first content page** actually renders inside `page_iframe`.
+
+- **Loaded OK** → `preloadCleared: true` (spinner cleared, first page rendered) → `success: true`, exit 0.
+- **Broken / stuck** → `preload` still present after the load settles → `preloadCleared: false` → `success: false`, exit 1.
+
+**Do not gate on `Parcels.loaded_all` or "no console errors."** `connect.js` catches exceptions internally, so a broken build can report `Parcels.loaded_all === true` (or fail silently) while the page is stuck on the spinner with no content. These are recorded only as **secondary diagnostics** (`parcelsLoadedAll`, `errors`, `warnings`, `components`).
+
+### Vanilla (no-bypass) mode
+
+By default `browser-test.js` launches Chrome with `--disable-web-security --allow-file-access-from-files`. Those flags let the parent read cross-origin iframe DOM that a real double-click cannot, so they **mask `file://`-only breakage** — the test can pass on output that is broken for users opening it from disk.
+
+Pass `--vanilla` (or set `VANILLA=1`) to launch **without** the bypass flags and reproduce exactly what a user gets double-clicking `index.html`. Use it to catch `file://`-only regressions. The preload signal works in both modes because it reads the top-level `body#connect_body`, which is always same-origin.
 
 ### What It Checks
 
-- Reverb runtime loads (`Parcels.loaded_all === true`)
-- Console errors and warnings
-- Component presence (toolbar, header, footer, TOC, content)
-- FormatSettings validation
+- **Primary:** `preload` removed from `body#connect_body` (`preloadCleared`)
+- Secondary diagnostics: `Parcels.loaded_all`, console errors/warnings, component presence (toolbar, header, footer, TOC, content), FormatSettings validation
 
 ### DOM Component IDs
 
 | Component | DOM ID | Presence Check |
 |-----------|--------|----------------|
+| **Load signal** | `body#connect_body` | **`preload` class absent** (primary pass/fail) |
 | Toolbar | `#toolbar_div` | `childNodes.length > 0` |
 | Header | `#header_div` | `childNodes.length > 0` |
 | Footer | `#footer_div` | `childNodes.length > 0` OR `#ww_skin_footer` exists |
@@ -134,8 +148,18 @@ node scripts/browser-test.js <chrome-path> <entry-url> [format-settings-json]
 ```json
 {
   "success": true,
+  "preloadCleared": true,
   "reverbLoaded": true,
+  "vanillaMode": false,
   "loadTime": 1039,
+  "parcelsLoadedAll": true,
+  "diagnostics": {
+    "bodyId": "connect_body",
+    "hasPreloadClass": false,
+    "parcelsLoadedAll": true,
+    "firstPageLoaded": true,
+    "readyState": "complete"
+  },
   "errors": [],
   "warnings": [],
   "components": {
@@ -147,6 +171,8 @@ node scripts/browser-test.js <chrome-path> <entry-url> [format-settings-json]
   }
 }
 ```
+
+`success`, `preloadCleared`, and `reverbLoaded` all reflect the same primary signal. `parcelsLoadedAll` is the secondary, **unreliable** diagnostic — never treat it as the pass condition.
 </browser_testing>
 
 <csh_analysis>
@@ -350,15 +376,15 @@ python scripts/extract-scss-variables.py /path/to/project neo
 2. Set `CHROME_PATH` environment variable
 3. Edge Chromium can be used as fallback
 
-### "Timeout waiting for Reverb to load"
+### "Reverb never finished loading: 'preload' class still present"
 
-**Cause:** Reverb output failed to initialize within timeout.
+**Cause:** The `preload` class was never removed from `body#connect_body` within the timeout — the first content page never rendered, so the spinner is stuck. This is a genuine broken-load signal, **not** a flaky timeout. Note that `parcelsLoadedAll: true` and an empty `errors` array can both still appear here — that is exactly the false-"passed" case this signal exists to catch.
 
 **Solutions:**
-1. Increase timeout: `TIMEOUT=60000 node browser-test.js ...`
-2. Check for JavaScript errors in output
-3. Verify output was built successfully
-4. Try loading output manually in browser
+1. Inspect `diagnostics` (`firstPageLoaded`, `parcelsLoadedAll`, `readyState`) and the saved screenshot (`SCREENSHOT_PATH`) — a stuck spinner confirms the broken load.
+2. Re-run with `--vanilla` to check whether the breakage is `file://`-only (the default bypass flags can hide it).
+3. If the build is large/slow, increase the timeout: `TIMEOUT=60000 node browser-test.js ...` — but a truly stuck build will still fail at any timeout.
+4. Check the format source (`Pages/scripts/connect.js`, parcel manifest) and rebuild.
 
 ### "url_maps.xml not found"
 
@@ -385,8 +411,8 @@ python scripts/extract-scss-variables.py /path/to/project neo
 
 ## Success Criteria
 
-- Reverb output loads without JavaScript errors
-- All expected components present in DOM
+- Reverb output fully loads — `preload` removed from `body#connect_body` (`preloadCleared: true`)
+- All expected components present in DOM (secondary diagnostic)
 - CSH links validate against url_maps.xml
 - Theme changes compile without SCSS errors
 </success_criteria>

--- a/plugins/webworks-agent-skills/skills/reverb2/scripts/browser-test.js
+++ b/plugins/webworks-agent-skills/skills/reverb2/scripts/browser-test.js
@@ -6,21 +6,39 @@
  * Loads Reverb in headless Chrome, monitors console errors, inspects components,
  * and returns structured test results as JSON.
  *
+ * PRIMARY pass/fail signal: the `preload` class is REMOVED from
+ * <body id="connect_body">. Reverb's connect.js removes it only in its
+ * page_load_complete handler, which fires when the FIRST content page actually
+ * renders inside page_iframe. So preload-removed == fully loaded; preload-still-
+ * present == stuck on the spinner / broken. `Parcels.loaded_all` and "no console
+ * errors" are NOT reliable — connect.js catches exceptions internally, so a
+ * broken load can still report loaded_all === true (or fail silently). Those are
+ * kept only as secondary diagnostics.
+ *
  * Usage:
- *   node browser-test.js <chrome-path> <entry-url> [format-settings-json]
+ *   node browser-test.js <chrome-path> <entry-url> [format-settings-json] [--vanilla]
  *
  * Arguments:
  *   chrome-path           - Path to Chrome/Chromium executable
- *   entry-url             - file:// URL to Reverb entry point
+ *   entry-url             - file:// URL to Reverb entry point (the output index.html)
  *   format-settings-json  - Optional JSON string with FormatSettings
  *
+ * Flags:
+ *   --vanilla        - No-bypass mode: launch Chrome WITHOUT
+ *                      --disable-web-security / --allow-file-access-from-files so
+ *                      the test sees exactly what a user gets double-clicking the
+ *                      file from disk. The default (bypass) mode masks
+ *                      vanilla-file:// breakage. Also settable via VANILLA=1.
+ *
  * Output:
- *   JSON with test results including errors, warnings, and component analysis
+ *   JSON with test results including the primary preload signal, secondary
+ *   diagnostics, errors, warnings, and component analysis
  *
  * Environment Variables:
  *   TIMEOUT          - Page load timeout in milliseconds (default: 30000)
  *   DEBUG            - Enable verbose logging (1 or 0, default: 0)
  *   SCREENSHOT_PATH  - Optional path to save screenshot
+ *   VANILLA          - Set to 1 for no-bypass mode (same as --vanilla)
  */
 
 const puppeteer = require('puppeteer-core');
@@ -50,16 +68,21 @@ const logger = {
  * Parse command-line arguments
  */
 function parseArguments() {
-  const args = process.argv.slice(2);
+  const raw = process.argv.slice(2);
 
-  if (args.length < 2) {
-    console.error('Usage: browser-test.js <chrome-path> <entry-url> [format-settings-json]');
+  // Separate flags (--foo) from positional arguments so the flag can appear anywhere.
+  const flags = raw.filter((a) => a.startsWith('--'));
+  const positional = raw.filter((a) => !a.startsWith('--'));
+  const vanilla = flags.includes('--vanilla') || process.env.VANILLA === '1';
+
+  if (positional.length < 2) {
+    console.error('Usage: browser-test.js <chrome-path> <entry-url> [format-settings-json] [--vanilla]');
     process.exit(EXIT_ERROR);
   }
 
-  const chromePath = args[0];
-  const entryUrl = args[1];
-  const formatSettingsJson = args[2] || '{}';
+  const chromePath = positional[0];
+  const entryUrl = positional[1];
+  const formatSettingsJson = positional[2] || '{}';
 
   let formatSettings = {};
   try {
@@ -69,7 +92,7 @@ function parseArguments() {
     process.exit(EXIT_ERROR);
   }
 
-  return { chromePath, entryUrl, formatSettings };
+  return { chromePath, entryUrl, formatSettings, vanilla };
 }
 
 /**
@@ -80,7 +103,13 @@ class TestResults {
     this.errors = [];
     this.warnings = [];
     this.infos = [];
-    this.reverbLoaded = false;
+    // PRIMARY signal: preload removed from body#connect_body (first page rendered).
+    this.preloadCleared = false;
+    // SECONDARY diagnostic: Parcels.loaded_all (unreliable — see file header). null = unknown.
+    this.parcelsLoadedAll = null;
+    // Raw read of the primary signal and supporting state, for debugging failures.
+    this.diagnostics = {};
+    this.vanillaMode = false;
     this.loadTime = 0;
     this.components = {};
     this.formatSettingsMismatches = [];
@@ -100,9 +129,16 @@ class TestResults {
 
   toJSON() {
     return {
-      success: this.errors.length === 0,
-      reverbLoaded: this.reverbLoaded,
+      // PRIMARY pass/fail: the preload class was removed from body#connect_body.
+      success: this.preloadCleared,
+      preloadCleared: this.preloadCleared,
+      // Backward-compatible alias of the primary signal (was Parcels-based).
+      reverbLoaded: this.preloadCleared,
+      vanillaMode: this.vanillaMode,
       loadTime: this.loadTime,
+      // SECONDARY diagnostic only — do NOT gate on this (connect.js catches exceptions).
+      parcelsLoadedAll: this.parcelsLoadedAll,
+      diagnostics: this.diagnostics,
       errors: this.errors,
       warnings: this.warnings,
       infos: this.infos,
@@ -116,20 +152,36 @@ class TestResults {
 
 /**
  * Launch browser and create page
+ *
+ * @param {string}  chromePath  Path to the Chrome/Chromium executable.
+ * @param {boolean} vanilla     When true, omit the web-security bypass flags so
+ *                              the runtime is exercised exactly as a user double-
+ *                              clicking the file from disk would see it. When
+ *                              false (default), the bypass flags are added — they
+ *                              let the parent read cross-origin iframe DOM and so
+ *                              can MASK vanilla-file:// breakage.
  */
-async function launchBrowser(chromePath) {
-  logger.debug('Launching browser:', chromePath);
+async function launchBrowser(chromePath, vanilla) {
+  logger.debug('Launching browser:', chromePath, vanilla ? '(vanilla / no-bypass)' : '(bypass)');
+
+  // Harness/sandbox flags — unrelated to web-origin behavior, kept in both modes.
+  const args = [
+    '--no-sandbox',
+    '--disable-setuid-sandbox',
+    '--disable-dev-shm-usage',
+  ];
+
+  if (!vanilla) {
+    // Bypass flags: convenient for headless testing but they relax file:// origin
+    // rules, so a build that is broken for real users can still appear to load.
+    args.push('--disable-web-security');
+    args.push('--allow-file-access-from-files');
+  }
 
   const browser = await puppeteer.launch({
     executablePath: chromePath,
     headless: true,
-    args: [
-      '--no-sandbox',
-      '--disable-setuid-sandbox',
-      '--disable-dev-shm-usage',
-      '--disable-web-security', // Allow file:// access
-      '--allow-file-access-from-files',
-    ],
+    args,
   });
 
   logger.debug('Browser launched successfully');
@@ -167,44 +219,120 @@ function setupConsoleMonitoring(page, results) {
 }
 
 /**
- * Load Reverb output and wait for initialization
+ * Predicate (runs in the page) for the PRIMARY load signal: the entry shell is
+ * body#connect_body and the `preload` class has been removed from it. connect.js
+ * removes preload only after the first content page renders, so this is the one
+ * reliable "fully loaded" signal.
+ */
+function preloadClearedInPage() {
+  var body = document.body;
+  return !!body && body.id === 'connect_body' && !body.classList.contains('preload');
+}
+
+/**
+ * Read the primary load signal and supporting diagnostics from the page, on both
+ * the pass and fail paths, and set results.preloadCleared accordingly. This is
+ * the single source of truth for the pass/fail decision.
+ */
+async function capturePrimarySignal(page, results) {
+  try {
+    const signal = await page.evaluate(() => {
+      var body = document.body;
+      var parcels = (typeof Parcels !== 'undefined' && Parcels !== null) ? Parcels : null;
+      var connect = (typeof Connect !== 'undefined' && Connect !== null) ? Connect : null;
+      return {
+        bodyId: body ? body.id : null,
+        hasPreloadClass: body ? body.classList.contains('preload') : null,
+        parcelsDefined: parcels !== null,
+        parcelsLoadedAll: parcels ? (parcels.loaded_all === true) : null,
+        firstPageLoaded: connect ? (connect.first_page_loaded === true) : null,
+        readyState: document.readyState,
+      };
+    });
+
+    results.diagnostics = signal;
+    results.parcelsLoadedAll = signal.parcelsLoadedAll;
+
+    if (signal.bodyId !== 'connect_body') {
+      // Not the Reverb shell — the preload signal does not apply, so we cannot
+      // confirm a successful load. Fail safe rather than risk a false pass.
+      results.preloadCleared = false;
+      results.addWarning(
+        "Entry page is not a Reverb shell (body#connect_body not found) -- the 'preload' " +
+          'load signal cannot be evaluated. Verify the entry URL points at the Reverb ' +
+          "output's index.html.",
+        { bodyId: signal.bodyId }
+      );
+    } else {
+      results.preloadCleared = signal.hasPreloadClass === false;
+    }
+  } catch (error) {
+    results.preloadCleared = false;
+    results.addError('Failed to read primary load signal (preload class on body#connect_body)', {
+      error: error.message,
+    });
+  }
+}
+
+/**
+ * Load Reverb output and wait for the primary load signal (preload cleared).
  */
 async function loadReverbOutput(page, entryUrl, results) {
   logger.info('Loading Reverb output:', entryUrl);
 
   const startTime = Date.now();
 
+  // Navigate. Use 'domcontentloaded' (not 'networkidle2') because in vanilla
+  // file:// mode blocked cross-origin requests may never let the network go idle;
+  // the preload signal below — not network quiescence — is the real completion gate.
   try {
     await page.goto(entryUrl, {
-      waitUntil: 'networkidle2',
+      waitUntil: 'domcontentloaded',
       timeout: TIMEOUT,
     });
-
-    logger.debug('Page loaded, waiting for Reverb runtime...');
-
-    // Wait for Reverb runtime to initialize (Parcels.loaded_all === true)
-    await page.waitForFunction(
-      () => (typeof Parcels !== 'undefined' && Parcels.loaded_all === true) || document.readyState === 'complete',
-      { timeout: TIMEOUT }
-    );
-
-    const endTime = Date.now();
-    results.loadTime = endTime - startTime;
-    results.reverbLoaded = true;
-
-    logger.info(`Reverb loaded successfully in ${results.loadTime}ms`);
   } catch (error) {
-    const endTime = Date.now();
-    results.loadTime = endTime - startTime;
-
+    results.loadTime = Date.now() - startTime;
     if (error.name === 'TimeoutError') {
-      results.addError('Timeout waiting for Reverb to load', {
+      results.addError('Timeout navigating to entry URL', {
         timeout: TIMEOUT,
+        entryUrl,
         suggestion: 'Try increasing TIMEOUT environment variable',
       });
     } else {
-      results.addError('Failed to load Reverb output', { error: error.message });
+      results.addError('Failed to navigate to entry URL', { error: error.message, entryUrl });
     }
+    await capturePrimarySignal(page, results);
+    return;
+  }
+
+  logger.debug('Page loaded, waiting for preload to clear (first content page render)...');
+
+  // PRIMARY wait: spinner clears == preload removed from body#connect_body.
+  try {
+    await page.waitForFunction(preloadClearedInPage, { timeout: TIMEOUT });
+    logger.info('preload cleared -- Reverb fully loaded');
+  } catch (error) {
+    if (error.name === 'TimeoutError') {
+      results.addError(
+        "Reverb never finished loading: 'preload' class still present on body#connect_body " +
+          '(spinner never cleared -- the first content page did not render). This is the broken-' +
+          'load case that Parcels.loaded_all and "no console errors" can miss.',
+        { timeout: TIMEOUT, vanillaMode: results.vanillaMode }
+      );
+    } else {
+      results.addError('Error while waiting for preload signal', { error: error.message });
+    }
+  }
+
+  results.loadTime = Date.now() - startTime;
+
+  // Read the final state (sets preloadCleared) regardless of pass/fail.
+  await capturePrimarySignal(page, results);
+
+  if (results.preloadCleared) {
+    logger.info(`Reverb loaded successfully in ${results.loadTime}ms`);
+  } else {
+    logger.warn(`Reverb did not fully load (preload not cleared) after ${results.loadTime}ms`);
   }
 }
 
@@ -312,7 +440,13 @@ async function validateFormatSettings(page, formatSettings, results) {
 
   logger.debug('Validating FormatSettings against DOM...');
 
-  const { components } = results;
+  // Default each sub-object so validation is null-safe even when component
+  // analysis did not populate results.components (e.g. a failed/stuck load).
+  const components = results.components || {};
+  components.toolbar = components.toolbar || {};
+  components.header = components.header || {};
+  components.footer = components.footer || {};
+  components.toc = components.toc || {};
 
   // Validate toolbar-generate
   if (formatSettings['toolbar-generate'] === 'false' && components.toolbar.present) {
@@ -375,32 +509,28 @@ async function captureScreenshot(page, screenshotPath) {
  * Main test execution
  */
 async function runTests() {
-  const { chromePath, entryUrl, formatSettings } = parseArguments();
+  const { chromePath, entryUrl, formatSettings, vanilla } = parseArguments();
   const results = new TestResults();
+  results.vanillaMode = vanilla;
 
   let browser = null;
 
   try {
     // Launch browser
-    browser = await launchBrowser(chromePath);
+    browser = await launchBrowser(chromePath, vanilla);
     const page = await browser.newPage();
 
     // Setup monitoring
     setupConsoleMonitoring(page, results);
 
-    // Load Reverb output
+    // Load Reverb output (sets the primary preload signal)
     await loadReverbOutput(page, entryUrl, results);
 
-    if (results.reverbLoaded) {
-      // Analyze components
-      await analyzeComponents(page, results);
-
-      // Validate FormatSettings
-      await validateFormatSettings(page, formatSettings, results);
-
-      // Capture screenshot if requested
-      await captureScreenshot(page, SCREENSHOT_PATH);
-    }
+    // Secondary diagnostics — run regardless of pass/fail so a failing report
+    // still shows what rendered (and the screenshot captures the stuck spinner).
+    await analyzeComponents(page, results);
+    await validateFormatSettings(page, formatSettings, results);
+    await captureScreenshot(page, SCREENSHOT_PATH);
   } catch (error) {
     results.addError('Unexpected error during test execution', { error: error.message, stack: error.stack });
   } finally {
@@ -413,8 +543,8 @@ async function runTests() {
   // Output results as JSON
   console.log(JSON.stringify(results.toJSON(), null, 2));
 
-  // Exit with appropriate code
-  process.exit(results.errors.length === 0 ? EXIT_SUCCESS : EXIT_ERROR);
+  // Exit code follows the PRIMARY signal (preload cleared), not console errors.
+  process.exit(results.preloadCleared ? EXIT_SUCCESS : EXIT_ERROR);
 }
 
 // Run tests

--- a/plugins/webworks-agent-skills/skills/reverb2/scripts/generate-report.py
+++ b/plugins/webworks-agent-skills/skills/reverb2/scripts/generate-report.py
@@ -69,18 +69,33 @@ def print_browser_test_results(test_results: dict) -> None:
     print(f"{BOLD}{'═' * 75}{NC}")
     print()
 
-    reverb_loaded = safe_get(test_results, 'reverbLoaded', default=False)
+    # Primary signal: preload removed from body#connect_body. Fall back to the
+    # legacy reverbLoaded key for older result payloads.
+    preload_cleared = safe_get(test_results, 'preloadCleared',
+                               default=safe_get(test_results, 'reverbLoaded', default=False))
+    parcels_loaded_all = safe_get(test_results, 'parcelsLoadedAll', default=None)
+    vanilla_mode = safe_get(test_results, 'vanillaMode', default=False)
     load_time = safe_get(test_results, 'loadTime', default=0)
     error_count = safe_get(test_results, 'errorCount', default=0)
     warning_count = safe_get(test_results, 'warningCount', default=0)
 
-    if reverb_loaded:
-        print(f"{GREEN}\u2705 Reverb Runtime{NC}")
-        print(f"   \u2022 Loaded successfully")
+    mode_label = 'vanilla (no-bypass file://)' if vanilla_mode else 'default (bypass)'
+
+    if preload_cleared:
+        print(f"{GREEN}\u2705 Reverb Runtime{NC} (primary signal: preload cleared on body#connect_body)")
+        print(f"   \u2022 Fully loaded \u2014 first content page rendered")
+        print(f"   \u2022 Launch mode: {mode_label}")
         print(f"   \u2022 Load time: {load_time}ms")
     else:
-        print(f"{RED}\u274c Reverb Runtime{NC}")
-        print(f"   \u2022 Failed to load")
+        print(f"{RED}\u274c Reverb Runtime{NC} (primary signal: preload NOT cleared on body#connect_body)")
+        print(f"   \u2022 Stuck on spinner \u2014 first content page never rendered")
+        print(f"   \u2022 Launch mode: {mode_label}")
+
+    # Secondary diagnostic \u2014 explicitly flagged as unreliable so it is never
+    # mistaken for the pass condition.
+    if parcels_loaded_all is not None:
+        parcels_label = 'true' if parcels_loaded_all else 'false'
+        print(f"   \u2022 Parcels.loaded_all: {parcels_label} (secondary diagnostic \u2014 unreliable)")
 
     print()
 
@@ -234,13 +249,24 @@ def print_summary(test_results: dict) -> None:
     error_count = safe_get(test_results, 'errorCount', default=0)
     warning_count = safe_get(test_results, 'warningCount', default=0)
 
-    if error_count == 0:
-        print(f"{GREEN}\u2705 Status: PASS{NC}")
-    else:
-        print(f"{RED}\u274c Status: FAIL{NC}")
+    # PASS/FAIL follows the primary preload signal, not the console-error count
+    # (connect.js catches exceptions, so errors are an unreliable gate). Prefer
+    # `success`, fall back to preloadCleared/reverbLoaded, then to the old rule.
+    status_pass = safe_get(
+        test_results, 'success',
+        default=safe_get(
+            test_results, 'preloadCleared',
+            default=safe_get(test_results, 'reverbLoaded', default=(error_count == 0)),
+        ),
+    )
 
-    print(f"   \u2022 Errors: {error_count}")
-    print(f"   \u2022 Warnings: {warning_count}")
+    if status_pass:
+        print(f"{GREEN}\u2705 Status: PASS{NC} (preload cleared)")
+    else:
+        print(f"{RED}\u274c Status: FAIL{NC} (preload not cleared)")
+
+    print(f"   \u2022 Errors: {error_count} (secondary)")
+    print(f"   \u2022 Warnings: {warning_count} (secondary)")
 
     # Count active components
     components = safe_get(test_results, 'components', default={})

--- a/plugins/webworks-agent-skills/skills/reverb2/templates/test-results.json
+++ b/plugins/webworks-agent-skills/skills/reverb2/templates/test-results.json
@@ -1,7 +1,17 @@
 {
   "success": true,
+  "preloadCleared": true,
   "reverbLoaded": true,
+  "vanillaMode": false,
   "loadTime": 0,
+  "parcelsLoadedAll": true,
+  "diagnostics": {
+    "bodyId": "connect_body",
+    "hasPreloadClass": false,
+    "parcelsLoadedAll": true,
+    "firstPageLoaded": true,
+    "readyState": "complete"
+  },
   "errors": [],
   "warnings": [],
   "components": {

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/browser-test/README.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/browser-test/README.md
@@ -1,0 +1,32 @@
+# browser-test.js fixtures
+
+Two static fixtures that reproduce the Reverb load mechanism `browser-test.js`
+keys off — the `preload` class on `<body id="connect_body">` (issue #109).
+
+| Fixture | Models | Expected result |
+|---------|--------|-----------------|
+| `reverb-good.html` | First content page renders; `connect.js` removes `preload`. | `success: true`, `preloadCleared: true`, exit `0` |
+| `reverb-stuck.html` | Spinner hangs (first page never renders) **but** `Parcels.loaded_all` is set to `true`. The false-"passed" trap. | `success: false`, `preloadCleared: false`, `parcelsLoadedAll: true`, exit `1` |
+
+`reverb-stuck.html` is the regression guard: the old heuristic
+(`Parcels.loaded_all === true || readyState === 'complete'`) reports this build
+as passed; the `preload` signal correctly reports failure.
+
+## Run
+
+```bash
+CHROME=$(bash ../../../scripts/detect-chrome.sh | tail -1)
+DIR="file://$(pwd)"
+
+# Should PASS (exit 0)
+TIMEOUT=6000 node ../../../scripts/browser-test.js "$CHROME" "$DIR/reverb-good.html"
+
+# Should FAIL (exit 1) despite parcelsLoadedAll: true
+TIMEOUT=4000 node ../../../scripts/browser-test.js "$CHROME" "$DIR/reverb-stuck.html"
+
+# No-bypass mode (real file:// double-click) — good fixture still passes
+TIMEOUT=6000 node ../../../scripts/browser-test.js "$CHROME" "$DIR/reverb-good.html" --vanilla
+```
+
+A short `TIMEOUT` keeps the stuck case from waiting the full default 30s before
+it fails.

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/browser-test/reverb-good.html
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/browser-test/reverb-good.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<!--
+  Fixture: a HEALTHY Reverb load.
+
+  Models the real connect.js mechanism: the shell starts with the `preload`
+  class on body#connect_body, and the page_load_complete handler removes it once
+  the first content page renders. Here a timer simulates that render: it removes
+  `preload` AND sets the secondary signals. browser-test.js must report
+  success === true / preloadCleared === true (exit 0).
+-->
+<html>
+<head><meta charset="utf-8"><title>Reverb good fixture</title></head>
+<body id="connect_body" class="preload">
+  <div id="toolbar_div"><div class="ww_skin_search_form"></div></div>
+  <div id="toc"><div class="ww_skin_toc_entry"></div></div>
+  <div id="page_div"><iframe id="page_iframe"></iframe></div>
+
+  <script>
+    // Stand-ins for the runtime globals browser-test.js reads as diagnostics.
+    var Parcels = { loaded_all: false };
+    var Connect = { first_page_loaded: false };
+
+    // Simulate page_load_complete firing after the first content page renders.
+    setTimeout(function () {
+      Parcels.loaded_all = true;
+      Connect.first_page_loaded = true;
+      document.body.classList.remove('preload'); // <-- the real "fully loaded" signal
+    }, 300);
+  </script>
+</body>
+</html>

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/browser-test/reverb-stuck.html
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/browser-test/reverb-stuck.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!--
+  Fixture: a BROKEN Reverb load that fools the old heuristics.
+
+  The first content page never renders, so connect.js never removes `preload`
+  from body#connect_body — the spinner is stuck forever. But this fixture STILL
+  sets Parcels.loaded_all = true (and the document reaches readyState
+  'complete' with no console errors), which is exactly the false-"passed" trap
+  from issue #109. The old wait (Parcels.loaded_all === true || readyState
+  complete) reports success here; the preload signal correctly reports FAILURE.
+
+  browser-test.js must report success === false / preloadCleared === false
+  (exit 1), with parcelsLoadedAll === true recorded only as a diagnostic.
+-->
+<html>
+<head><meta charset="utf-8"><title>Reverb stuck fixture</title></head>
+<body id="connect_body" class="preload">
+  <div id="toolbar_div"><div class="ww_skin_search_form"></div></div>
+  <div id="toc"><div class="ww_skin_toc_entry"></div></div>
+  <div id="page_div"><iframe id="page_iframe"></iframe></div>
+
+  <script>
+    var Parcels = { loaded_all: false };
+    var Connect = { first_page_loaded: false };
+
+    // The runtime "completes" by its own internal accounting...
+    setTimeout(function () {
+      Parcels.loaded_all = true;
+      // ...but the first page never renders, so `preload` is NEVER removed.
+      // (Connect.first_page_loaded stays false; spinner hangs.)
+    }, 300);
+  </script>
+</body>
+</html>

--- a/plugins/webworks-agent-skills/skills/reverb2/workflows/browser-testing.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/workflows/browser-testing.md
@@ -45,51 +45,57 @@ If no project file provided, ask user for the path to the Reverb output's `index
 Execute the headless browser test:
 
 ```bash
-node scripts/browser-test.js "<chrome-path>" "<entry-url>" [format-settings-json]
+node scripts/browser-test.js "<chrome-path>" "<entry-url>" [format-settings-json] [--vanilla]
 ```
 
 Arguments:
 - `chrome-path` - From detect-chrome.sh output
 - `entry-url` - From detect-entry-point.sh or user-provided
 - `format-settings-json` - Optional, for validating feature toggles
+- `--vanilla` - Optional **no-bypass mode** (or `VANILLA=1`). The default launch uses `--disable-web-security --allow-file-access-from-files`, which can **mask `file://`-only breakage**. Run once in default mode and, when validating a build users open from disk, again with `--vanilla` to reproduce a real double-click. A pass in default mode but a fail in `--vanilla` means the output is broken on bare `file://`.
 
 ## Step 4: Analyze Results
 
-Parse the JSON output and check:
+The **pass/fail decision is the `preload` signal** — `success` is true only when `preload` was removed from `body#connect_body` (the first content page rendered). Everything else is a secondary diagnostic.
 
-| Check | Pass Condition |
-|-------|---------------|
-| Reverb Loaded | `reverbLoaded === true` |
-| No Errors | `errors.length === 0` |
-| Toolbar | `components.toolbar.present === true` |
-| TOC | `components.toc.present === true` |
-| Content | `components.content.present === true` |
+| Check | Pass Condition | Role |
+|-------|---------------|------|
+| **Reverb fully loaded** | **`preloadCleared === true`** (== `success`, == `reverbLoaded`) | **Primary** |
+| Parcels accounting | `parcelsLoadedAll === true` | Diagnostic only — **unreliable**, can be true on a stuck build |
+| No console errors | `errors.length === 0` | Diagnostic only — `connect.js` catches exceptions |
+| Toolbar | `components.toolbar.present === true` | Diagnostic |
+| TOC | `components.toc.present === true` | Diagnostic |
+| Content | `components.content.present === true` | Diagnostic |
+
+> **Do not report a pass on `parcelsLoadedAll` or "no errors" alone.** A broken build can show `parcelsLoadedAll: true` with an empty `errors` array while stuck on the spinner. Only `preloadCleared: true` confirms a real load.
 
 ## Step 5: Report Findings
 
 Present results to user:
 
-**If all checks pass:**
+**If `preloadCleared` is true:**
 ```
-Reverb output loaded successfully.
+Reverb output fully loaded (preload cleared on body#connect_body).
+- Mode: {vanillaMode ? "vanilla (no-bypass file://)" : "default (bypass)"}
 - Load time: {loadTime}ms
 - TOC items: {toc.itemCount}
 - All components present
 ```
 
-**If any checks fail:**
+**If `preloadCleared` is false:**
 ```
-Issues found in Reverb output:
-- {list specific failures}
-- {include any console errors}
+Reverb output did NOT fully load — preload still present on body#connect_body (stuck spinner).
+- Diagnostics: parcelsLoadedAll={parcelsLoadedAll}, firstPageLoaded={diagnostics.firstPageLoaded}
+- {include any console errors as supporting detail}
 - {suggest remediation}
 ```
 
 Common issues and remediation:
-- `reverbLoaded: false` - JavaScript error preventing initialization
+- `preloadCleared: false` with `parcelsLoadedAll: true` - runtime reports complete but the first page never rendered; inspect `connect.js`, the parcel manifest, and the screenshot
+- Passes in default mode, fails with `--vanilla` - `file://`-only breakage (cross-origin iframe access); the build needs a web server or a fix
+- `bodyId` warning - entry URL is not the Reverb shell `index.html`
 - Missing toolbar - Check FormatSettings.xml toolbar options
 - Missing TOC - Build may have failed or no topics published
-- Console errors - Check for missing resources or script errors
 </process>
 
 <success_criteria>
@@ -99,7 +105,7 @@ This workflow is complete when:
 - [ ] Entry point located
 - [ ] Browser test executed
 - [ ] Results analyzed and reported to user
-- [ ] Reverb runtime confirmed loaded (`Parcels.loaded_all === true`)
-- [ ] No console errors present (or errors reported)
-- [ ] All expected components present in DOM (or issues reported)
+- [ ] Reverb load confirmed via the **primary** signal: `preloadCleared === true` (`preload` removed from `body#connect_body`)
+- [ ] Secondary diagnostics noted (`parcelsLoadedAll`, console errors, component presence) — not used as the pass condition
+- [ ] If validating a `file://`/disk build, `--vanilla` run performed to rule out no-bypass breakage
 </success_criteria>


### PR DESCRIPTION
## Problem

The reverb2 skill's `browser-test.js` gated success on `Parcels.loaded_all === true || readyState === 'complete'`. `connect.js` catches exceptions internally, so a broken build can report `loaded_all === true` (or fail silently) while stuck on the spinner with no content rendered — a confident **false "passed"** (seen during the Reverb-on-S3 deploy-set debugging session).

## The reliable signal

Reverb's true "fully loaded" signal is the **`preload` class being REMOVED from `<body id="connect_body">`**. `connect.js` removes it in its `page_load_complete` handler, which fires when the **first content page** actually renders inside `page_iframe`.

- Verified against `WebWorks Reverb 2.0/Transforms/connect.xsl` (sets `class="preload …"` on `body#connect_body`) and `Pages/scripts/connect.js` (`page_load_complete` removes it on first render).

## Changes

**Ask 1 — primary pass/fail = preload signal** (`scripts/browser-test.js`)
- Wait for `preload` to clear on `body#connect_body` instead of the old heuristic. `success` / `preloadCleared` / `reverbLoaded` / exit code all key off this.
- `Parcels.loaded_all`, console errors, and component checks demoted to **secondary diagnostics** (`parcelsLoadedAll`, `diagnostics`, `errors`, `components`).
- New `capturePrimarySignal()` records the final state (preload class, `parcelsLoadedAll`, `first_page_loaded`, `readyState`) on **both** pass and fail paths, and fail-safes (with a warning) when the entry page isn't a Reverb shell.

**Ask 2 — vanilla (no-bypass) mode**
- `--vanilla` (or `VANILLA=1`) launches Chrome **without** `--disable-web-security --allow-file-access-from-files`, reproducing a real `file://` double-click so `file://`-only breakage the bypass flags mask is caught. The preload read works in both modes (top-level `body#connect_body` is always same-origin).

**Docs / report** — `SKILL.md`, `workflows/browser-testing.md`, `templates/test-results.json`, and `generate-report.py` updated so the primary signal and report PASS/FAIL reflect preload (not the error count).

Ask 3 (static lint) is out of scope here — tracked in #110.

## Verification

Added `tests/fixtures/browser-test/` (good + stuck fixtures, README) and ran them against real Chrome:

| Case | `parcelsLoadedAll` | `preloadCleared` | `success` | exit |
|------|------|------|------|------|
| Good (default) | true | true | true | 0 |
| **Stuck (false-positive trap)** | **true** | false | **false** | 1 |
| Good `--vanilla` / `VANILLA=1` | true | true | true | 0 |
| Non-Reverb page | — | false | false | 1 |

The `stuck` fixture reproduces the exact `Parcels.loaded_all === true` false-pass from the issue — the old heuristic reported it as passed; the preload signal correctly fails it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)