### PR TITLE
Closes #110: add a static Reverb 2.0 output linter (lint-output.py)

### DIFF
--- a/plugins/webworks-agent-skills/skills/reverb2/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/SKILL.md
@@ -2,8 +2,10 @@
 name: reverb2
 description: >
   AUTHORITATIVE REFERENCE for WebWorks Reverb 2.0 output. Use when testing
-  Reverb output in browser, analyzing CSH links, customizing SCSS themes,
-  inspecting url_maps.xml, or generating test reports.
+  Reverb output in browser, statically linting output for structural breakage
+  (self-closed elements, manifest/parcel GroupID consistency), analyzing CSH
+  links, customizing SCSS themes, inspecting url_maps.xml, or generating test
+  reports.
 ---
 
 <objective>
@@ -71,6 +73,7 @@ When investigating a runtime issue — a theme override that didn't apply, a bro
 3. Customize SCSS theme
 4. Generate test report
 5. Resolve a stable Reverb landmark URL (or hash) to a direct file path
+6. Lint output for structural breakage (static, no browser)
 
 **Wait for response before proceeding.**
 </intake>
@@ -86,6 +89,7 @@ When investigating a runtime issue — a theme override that didn't apply, a bro
 | 3, "scss", "theme", "colors" | workflows/scss-theming.md |
 | 4, "report" | workflows/generate-report.md |
 | 5, "resolve", "landmark", "hash" | workflows/landmark-resolution.md |
+| 6, "lint", "validate", "static", "pre-flight" | workflows/output-linting.md |
 </routing>
 
 <capabilities>
@@ -94,6 +98,7 @@ When investigating a runtime issue — a theme override that didn't apply, a bro
 
 | Feature | Script | Description |
 |---------|--------|-------------|
+| Output Linting | `lint-output.py` | Static pre-flight (no browser): self-closed non-void elements, manifest↔parcel GroupID consistency, parcel deploy-unit completeness, asset reference integrity. CI-friendly exit codes |
 | Browser Testing | `browser-test.js` | Load output in headless Chrome; pass/fail on the `preload` load signal (`--vanilla` for no-bypass file:// mode) |
 | CSH Analysis | `parse-url-maps.py` | Extract topic mappings from url_maps.xml |
 | SCSS Theming | `extract-scss-variables.py` | Read current theme values |
@@ -101,6 +106,57 @@ When investigating a runtime issue — a theme override that didn't apply, a bro
 | Report Generation | `generate-report.py` | Create formatted test reports |
 | Landmark Resolution | `resolve-landmarks.py` | Resolve Reverb stable URLs (#/<id>) to direct file paths using _lx.js chunks |
 </capabilities>
+
+<output_linting>
+
+## Output Linting (static pre-flight)
+
+`lint-output.py` statically scans a built or assembled Reverb 2.0 output
+directory for structural breakages that kill the runtime **silently** — the page
+hangs on the spinner with no console error — and that are detectable without a
+browser. Run it in CI or before a deploy.
+
+### Run
+
+```bash
+python scripts/lint-output.py <output-dir> [--json] [--strict] [--no-color]
+```
+
+`<output-dir>` is the folder containing `index.html` (e.g.
+`"Output/WebWorks Reverb 2.0"`).
+
+### Checks
+
+| Check | Severity | What it catches |
+|-------|----------|-----------------|
+| `self-closed-element` | error | A non-void element in XML self-closing form (`<script/>`, `<iframe/>`, `<div/>`, …). In `text/html` the `/` is ignored, so the element swallows the rest of the document — the first page never renders, with **zero** console errors. (Trac #2792.) Void elements (`<meta/>`, `<link/>`, …) and `<svg>`/`<math>` foreign content are exempt. |
+| `manifest-parcel-groupid` | error | The parcel's own GroupID disagrees with what the `#parcels` manifest binds. `connect.js` reads `id.split(':')[1]` from each anchor `<a id="<ctx>:<GID>" href="<Name>.html">` and looks up `toc:<GID>`/`data:<GID>`/`page:<GID>` inside the fetched parcel; a mismatch means every lookup returns null, the parcel never attaches, and the spinner hangs. Arises when output is assembled from multiple builds (the Reverb-on-S3 deploy-set model). Also flags a `<li id="group:<GID>">`-vs-anchor desync. |
+| `parcel-deploy-unit` | error | A manifest parcel `<Name>` is missing a deploy-unit member: `<Name>.html` and `<Name>/` (always), plus the runtime chunks `<Name>_ix.html`/`<Name>_lx.js`/`<Name>_sx.js`. The required chunk set is version/feature dependent (older builds omit `_lx.js`, search-off builds omit `_sx.js`), so it is read from the build's own `scripts/connect.js`. |
+| `reference-integrity` | warn | A local `scripts/`/`css/` asset referenced by `index.html` (`<script src>`, `<link href>`) is missing on disk. Remote (`http(s)://`, `//`) and `data:` refs are skipped. |
+
+The check set is extensible — add new known-breakage checks to `lint-output.py`
+as they are discovered.
+
+### Exit codes (CI-friendly)
+
+| Code | Meaning |
+|------|---------|
+| `0` | Clean — no errors (and no warnings under `--strict`). |
+| `1` | At least one error-severity finding (or any warning under `--strict`). |
+| `2` | The linter could not run — `<output-dir>` missing or not a directory. |
+
+Files scanned for self-closed elements: `index.html`, the root shell pages
+(`search.html`, `splash.html`, `not-found.html`), and each parcel's `<Name>.html`
+and `<Name>_ix.html`.
+
+### Relationship to browser testing
+
+The linter is the **static** pre-flight (cheap, no browser). `browser-test.js` is
+the **runtime** confirmation (the `preload` load signal; needs Chrome). A good
+flow runs the linter first to catch structural breakage, then the browser test to
+confirm the build actually loads. See `workflows/output-linting.md`.
+
+</output_linting>
 
 <browser_testing>
 
@@ -328,13 +384,16 @@ bash scripts/detect-chrome.sh
 # 1. Detect entry point
 PROJECT_INFO=$(bash scripts/detect-entry-point.sh project.wep)
 
-# 2. Run browser test
+# 2. Static pre-flight — fail fast on structural breakage before launching Chrome
+python scripts/lint-output.py "output/WebWorks Reverb 2.0" || exit 1
+
+# 3. Run browser test (runtime confirmation)
 TEST_RESULTS=$(node scripts/browser-test.js "$CHROME" "$ENTRY_URL")
 
-# 3. Parse CSH
+# 4. Parse CSH
 CSH_DATA=$(python scripts/parse-url-maps.py output/url_maps.xml)
 
-# 4. Generate report
+# 5. Generate report
 python scripts/generate-report.py project.wep "$PROJECT_INFO" "$CSH_DATA" "$TEST_RESULTS"
 ```
 

--- a/plugins/webworks-agent-skills/skills/reverb2/scripts/lint-output.py
+++ b/plugins/webworks-agent-skills/skills/reverb2/scripts/lint-output.py
@@ -1,0 +1,848 @@
+#!/usr/bin/env python3
+"""
+lint-output.py
+
+Static linter for a built or assembled WebWorks Reverb 2.0 output directory.
+Catches structural breakages that kill the runtime *silently* — the page hangs
+on the spinner with no console error — and that are detectable without a
+browser, so they can run in CI or a pre-deploy gate.
+
+Reverb 2.0 is a single-page application whose shell (`index.html`) loads content
+"parcels" at runtime via `scripts/connect.js`. Several breakage classes are
+visible purely in the emitted files:
+
+Checks
+------
+1. self-closed-element  (error)
+   A non-void HTML element written in XML self-closing form — `<script/>`,
+   `<iframe/>`, `<div/>`, `<span/>`, `<a/>`, `<ul/>`, `<li/>`, … In `text/html`
+   the `/` is ignored, so `<script/>` parses as an *open* `<script>` that
+   swallows the rest of the document as script text. The first page never
+   renders and there is **no** console error. (ePublisher Trac #2792.) Void
+   elements (`<meta/>`, `<link/>`, `<br/>`, …) and elements inside foreign
+   content (`<svg>`, `<math>`) are exempt — self-closing is legal there.
+
+2. manifest-parcel-groupid  (error)
+   `connect.js` binds each parcel to the `#parcels` manifest **by GroupID**:
+   it reads each manifest anchor `<a id="<ctx>:<GID>" href="<Name>.html">`,
+   takes `id.split(':')[1]` as the GroupID, fetches `<Name>.html`, and looks up
+   `toc:<GID>`, `data:<GID>`, `breadcrumbs:<GID>`, and `page:<GID>:first/last`
+   inside it. If the parcel's own GroupID (its `<body id="id:<GID>">` and those
+   divs) disagrees with the manifest's — which happens when output is assembled
+   from multiple builds that each minted their own GroupIDs, e.g. the
+   Reverb-on-S3 deploy-set model — every lookup returns null, the parcel never
+   attaches, and the spinner hangs silently.
+
+3. parcel-deploy-unit  (error)
+   Each manifest parcel `<Name>` is published as a deploy unit: `<Name>.html`
+   (the manifest href target), the `<Name>/` content directory, and the runtime
+   chunks `<Name>_ix.html` / `<Name>_lx.js` / `<Name>_sx.js`. Which chunks are
+   required is version/feature dependent — older builds omit the `_lx.js`
+   landmark chunk, search-disabled builds omit `_sx.js` — so the required chunk
+   set is read from the build's own `scripts/connect.js` (it pushes
+   `parcel_directory_url + '<suffix>'` for each chunk it fetches). A missing
+   member means a broken parcel.
+
+4. reference-integrity  (warn)
+   Local `scripts/` and `css/` assets referenced by `index.html`
+   (`<script src>`, `<link href>`) exist on disk. Remote (`http(s)://`,
+   protocol-relative `//`) and `data:` references are skipped.
+
+The check set is extensible — new known-breakage checks get added here as they
+are discovered.
+
+Usage
+-----
+    python lint-output.py <output-dir> [--json] [--strict] [--no-color]
+
+Arguments
+---------
+    output-dir   Root of a built/assembled Reverb 2.0 output (the directory
+                 containing index.html).
+
+Flags
+-----
+    --json       Emit a structured JSON report instead of human-readable text.
+    --strict     Treat warnings as failures (affects the exit code only).
+    --no-color   Disable ANSI color in text output (auto-disabled when stdout
+                 is not a TTY).
+
+Exit codes (CI-friendly)
+------------------------
+    0 - Clean: no error-severity findings (and no warnings under --strict).
+    1 - At least one error-severity finding (or, under --strict, any warning).
+    2 - The linter could not run: <output-dir> missing or not a directory,
+        or an unreadable file. Distinct from "found problems".
+
+Examples
+--------
+    # Lint a debug build
+    python lint-output.py "Output/WebWorks Reverb 2.0"
+
+    # CI gate — fail on warnings too, machine-readable
+    python lint-output.py ./site --strict --json
+
+Relationship to the browser test
+--------------------------------
+This linter is the *static* pre-flight (cheap, no browser). `browser-test.js`
+is the *runtime* confirmation (the `preload` load signal; needs Chrome). A good
+flow runs the linter first, then the browser test.
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.parse
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Optional
+
+# ANSI color codes (matched to the other reverb2 scripts).
+RED = '\033[0;31m'
+GREEN = '\033[0;32m'
+YELLOW = '\033[1;33m'
+NC = '\033[0m'
+
+DEBUG = os.environ.get('DEBUG', '0') == '1'
+
+# Void elements per the HTML spec: legal to write self-closed, the `/` is
+# simply ignored. Self-closing these is harmless, so they are never flagged.
+VOID_ELEMENTS = frozenset({
+    'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+    'link', 'meta', 'param', 'source', 'track', 'wbr',
+})
+
+# Roots of foreign content where XML self-closing syntax is valid HTML5. Any
+# self-closed tag inside an <svg> or <math> subtree (`<path/>`, `<rect/>`,
+# `<circle/>`, …) is legitimate and must not be flagged.
+FOREIGN_ROOTS = frozenset({'svg', 'math'})
+
+# Element-id prefixes whose value is *always* the parcel's GroupID, used to read
+# the parcel's own GroupID and compare it to what the manifest binds:
+#   body  -> id:<GID>          (single, on <body>)
+#   toc   -> toc:<GID>         (single container)
+#   data  -> data:<GID>        (single container)
+#   page  -> page:<GID>:<first|last|N>   (GroupID-keyed; trailing :<suffix>)
+# `breadcrumbs:` is deliberately excluded: it carries one `breadcrumbs:<GID>`
+# container *and* several `breadcrumbs:<pageLandmarkId>` per-result fragments, so
+# its values are not all GroupIDs and must not be compared.
+GID_SIMPLE_PREFIXES = ('id', 'toc', 'data')
+GID_PAGE_PREFIX = 'page'
+
+# Per-parcel runtime chunk suffixes. Which of these a build emits is version- and
+# feature-dependent, so the *required* subset is read from the build's own
+# connect.js rather than assumed (see expected_chunk_suffixes).
+CHUNK_SUFFIXES = ('_ix.html', '_lx.js', '_sx.js')
+
+# Root-level shell HTML pages scanned for self-closed elements in addition to
+# index.html and the per-parcel pages. Only those that exist are scanned.
+SHELL_HTML_FILES = ('index.html', 'search.html', 'splash.html', 'not-found.html')
+
+# Finding severities.
+SEVERITY_ERROR = 'error'
+SEVERITY_WARN = 'warn'
+
+
+def debug_log(message: str) -> None:
+    """Print a debug message to stderr (only when DEBUG=1)."""
+    if DEBUG:
+        print(f"{YELLOW}[DEBUG]{NC} {message}", file=sys.stderr)
+
+
+def error_log(message: str) -> None:
+    """Print an error message to stderr."""
+    print(f"{RED}[ERROR]{NC} {message}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Finding model
+# ---------------------------------------------------------------------------
+
+
+class Finding:
+    """A single lint result.
+
+    `file` is relative to the output directory (for readable, stable output).
+    `line`/`col` are 1-based and optional (None for whole-file findings). For
+    minified output every line is 1, so `snippet` carries the local context.
+    """
+
+    def __init__(
+        self,
+        check: str,
+        severity: str,
+        message: str,
+        file: Optional[str] = None,
+        line: Optional[int] = None,
+        col: Optional[int] = None,
+        snippet: Optional[str] = None,
+    ):
+        self.check = check
+        self.severity = severity
+        self.message = message
+        self.file = file
+        self.line = line
+        self.col = col
+        self.snippet = snippet
+
+    def to_dict(self) -> dict:
+        out: dict = {'check': self.check, 'severity': self.severity}
+        if self.file is not None:
+            out['file'] = self.file
+        if self.line is not None:
+            out['line'] = self.line
+        if self.col is not None:
+            out['col'] = self.col
+        out['message'] = self.message
+        if self.snippet is not None:
+            out['snippet'] = self.snippet
+        return out
+
+
+# ---------------------------------------------------------------------------
+# HTML parsing helpers
+# ---------------------------------------------------------------------------
+
+
+class SelfClosedScanner(HTMLParser):
+    """Collect self-closed non-void elements that are not inside foreign content.
+
+    HTMLParser dispatches XML-style `<tag .../>` to handle_startendtag, and
+    treats <script>/<style> bodies as raw CDATA, so a `<div/>` written *inside*
+    a script string literal is never mistaken for a real tag. Foreign-content
+    depth (<svg>/<math>) is tracked so legal self-closing there is exempt.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.findings: list[tuple[int, int, str, str]] = []
+        self.foreign_depth = 0
+
+    def handle_starttag(self, tag: str, attrs) -> None:
+        if tag in FOREIGN_ROOTS:
+            self.foreign_depth += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in FOREIGN_ROOTS and self.foreign_depth > 0:
+            self.foreign_depth -= 1
+
+    def handle_startendtag(self, tag: str, attrs) -> None:
+        # An empty foreign root (`<svg/>`) or any self-closed tag within foreign
+        # content is valid HTML5 — never flag it.
+        if tag in FOREIGN_ROOTS or self.foreign_depth > 0:
+            return
+        if tag in VOID_ELEMENTS:
+            return
+        line, offset = self.getpos()
+        raw = self.get_starttag_text() or f"<{tag}/>"
+        self.findings.append((line, offset + 1, tag, raw))
+
+
+def find_self_closed(html_text: str) -> list[tuple[int, int, str, str]]:
+    """Return (line, col, tag, raw) for each self-closed non-void element.
+
+    `col` is 1-based. Parsing is lenient: HTMLParser does not raise on the kind
+    of malformed markup that triggers this very check.
+    """
+    scanner = SelfClosedScanner()
+    scanner.feed(html_text)
+    scanner.close()
+    return scanner.findings
+
+
+class ElementIdCollector(HTMLParser):
+    """Collect (tag, id) for every element that carries an `id` attribute."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.ids: list[tuple[str, str]] = []
+
+    def _record(self, tag: str, attrs) -> None:
+        for name, value in attrs:
+            if name == 'id' and value:
+                self.ids.append((tag, value))
+
+    def handle_starttag(self, tag: str, attrs) -> None:
+        self._record(tag, attrs)
+
+    def handle_startendtag(self, tag: str, attrs) -> None:
+        self._record(tag, attrs)
+
+
+def collect_element_ids(html_text: str) -> list[tuple[str, str]]:
+    """Return (tag, id_value) for every element with an id, in document order."""
+    collector = ElementIdCollector()
+    collector.feed(html_text)
+    collector.close()
+    return collector.ids
+
+
+class ParcelEntry:
+    """One `#parcels` manifest entry.
+
+    `gid_anchor` is the GroupID connect.js binds on: `anchor_id.split(':')[1]`.
+    `gid_li` is the GroupID on the wrapping `<li id="group:<GID>">` (used by
+    connect.js for TOC hierarchy). They normally agree; a disagreement is itself
+    a manifest-internal breakage.
+    """
+
+    def __init__(
+        self,
+        gid_li: Optional[str],
+        name: Optional[str],
+        anchor_id: Optional[str],
+        href: Optional[str],
+    ):
+        self.gid_li = gid_li
+        self.name = name
+        self.anchor_id = anchor_id
+        self.href = href
+
+    @property
+    def gid_anchor(self) -> Optional[str]:
+        if not self.anchor_id:
+            return None
+        parts = self.anchor_id.split(':')
+        return parts[1] if len(parts) >= 2 and parts[0] != '' else None
+
+
+class ManifestParser(HTMLParser):
+    """Extract `#parcels` manifest entries from index.html.
+
+    Tracks entry/exit of `<div id="parcels">` by counting nested <div> tags, so
+    only anchors inside the manifest are collected (not TOC or chrome anchors
+    elsewhere in the shell). Within each `<li id="group:<GID>">` it records the
+    GroupID, the `data-group-title`, and the first `<a id=… href=…>` anchor.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.entries: list[ParcelEntry] = []
+        self._in_parcels = False
+        self._div_depth = 0
+        self._current: Optional[ParcelEntry] = None
+
+    def handle_starttag(self, tag: str, attrs) -> None:
+        attr = dict(attrs)
+        if tag == 'div':
+            if not self._in_parcels:
+                if attr.get('id') == 'parcels':
+                    self._in_parcels = True
+                    self._div_depth = 0
+                return
+            # Already inside #parcels — count nested divs to find the close.
+            self._div_depth += 1
+            return
+        if not self._in_parcels:
+            return
+        if tag == 'li':
+            gid_li = None
+            lid = attr.get('id', '')
+            if lid.startswith('group:'):
+                gid_li = lid[len('group:'):]
+            self._current = ParcelEntry(
+                gid_li=gid_li,
+                name=attr.get('data-group-title'),
+                anchor_id=None,
+                href=None,
+            )
+        elif tag == 'a' and self._current is not None and self._current.href is None:
+            if attr.get('id') and attr.get('href'):
+                self._current.anchor_id = attr['id']
+                self._current.href = attr['href']
+
+    def handle_endtag(self, tag: str) -> None:
+        if not self._in_parcels:
+            return
+        if tag == 'div':
+            if self._div_depth == 0:
+                # This </div> closes #parcels itself.
+                self._in_parcels = False
+            else:
+                self._div_depth -= 1
+        elif tag == 'li' and self._current is not None:
+            self.entries.append(self._current)
+            self._current = None
+
+
+def parse_manifest(index_html_text: str) -> list[ParcelEntry]:
+    """Return the `#parcels` manifest entries from index.html, in document order."""
+    parser = ManifestParser()
+    parser.feed(index_html_text)
+    parser.close()
+    return parser.entries
+
+
+def classify_gid_id(id_value: str) -> Optional[str]:
+    """Return the GroupID a parcel element id encodes, or None if it encodes none.
+
+    `page:<GID>:<suffix>` yields GID (middle segment); `id:`/`toc:`/`data:`
+    yield the segment after the colon. GroupIDs never contain a colon (connect.js
+    builds these ids by string concatenation around `:`), so the split is
+    unambiguous. `breadcrumbs:` is intentionally not classified here.
+    """
+    if id_value.startswith(GID_PAGE_PREFIX + ':'):
+        gid = id_value[len(GID_PAGE_PREFIX) + 1:].split(':', 1)[0]
+        return gid or None
+    for prefix in GID_SIMPLE_PREFIXES:
+        if id_value.startswith(prefix + ':'):
+            gid = id_value[len(prefix) + 1:]
+            return gid if gid and ':' not in gid else None
+    return None
+
+
+def extract_parcel_gids(parcel_html_text: str) -> tuple[Optional[str], set]:
+    """Return (body_gid, {gid,...}) for a parcel page.
+
+    `body_gid` is the GroupID on the `<body id="id:<GID>">` element (the parcel's
+    own GroupID marker), or None if absent. The set is every GroupID that appears
+    under the always-GroupID prefixes (`id:`/`toc:`/`data:`/`page:`) — for a
+    well-formed parcel it is exactly the parcel's single GroupID.
+    """
+    body_gid: Optional[str] = None
+    gids: set = set()
+    for tag, id_value in collect_element_ids(parcel_html_text):
+        gid = classify_gid_id(id_value)
+        if gid is None:
+            continue
+        gids.add(gid)
+        if tag == 'body' and id_value.startswith('id:'):
+            body_gid = gid
+    return body_gid, gids
+
+
+class AssetRefCollector(HTMLParser):
+    """Collect local asset references from index.html: <script src>, <link href>."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.refs: list[tuple[str, str]] = []  # (kind, raw_ref)
+
+    def _add(self, kind: str, ref: Optional[str]) -> None:
+        if ref:
+            self.refs.append((kind, ref))
+
+    def handle_starttag(self, tag: str, attrs) -> None:
+        attr = dict(attrs)
+        if tag == 'script':
+            self._add('script src', attr.get('src'))
+        elif tag == 'link':
+            self._add('link href', attr.get('href'))
+
+    def handle_startendtag(self, tag: str, attrs) -> None:
+        self.handle_starttag(tag, attrs)
+
+
+def extract_local_assets(index_html_text: str) -> list[tuple[str, str]]:
+    """Return (kind, ref) for each *local* asset referenced by index.html.
+
+    Remote (`http(s)://`, protocol-relative `//`) and `data:` refs are dropped —
+    only on-disk assets are checkable. The `?v=<hash>` cache-buster query and any
+    fragment are stripped, and the path is percent-decoded for filesystem lookup.
+    """
+    collector = AssetRefCollector()
+    collector.feed(index_html_text)
+    collector.close()
+
+    local: list[tuple[str, str]] = []
+    for kind, ref in collector.refs:
+        stripped = ref.strip()
+        lowered = stripped.lower()
+        if lowered.startswith(('http://', 'https://', '//', 'data:', 'mailto:', '#')):
+            continue
+        path = stripped.split('?', 1)[0].split('#', 1)[0]
+        if not path:
+            continue
+        local.append((kind, urllib.parse.unquote(path)))
+    return local
+
+
+# ---------------------------------------------------------------------------
+# Checks
+# ---------------------------------------------------------------------------
+
+
+def _read_text(path: Path) -> str:
+    """Read a file as UTF-8, tolerating stray bytes (output is generated UTF-8)."""
+    return path.read_text(encoding='utf-8', errors='replace')
+
+
+def expected_chunk_suffixes(output_dir: Path) -> list[str]:
+    """Return the parcel-chunk suffixes this build's connect.js actually fetches.
+
+    The required deploy-unit chunks are version/feature dependent: every build
+    fetches `_ix.html`, newer builds also fetch the `_lx.js` landmark chunk, and
+    `_sx.js` is present when search is enabled. connect.js is the source of truth
+    — it pushes `parcel_directory_url + '<suffix>'` for each chunk it loads — so a
+    suffix is required iff it appears there. If connect.js cannot be read, only
+    the always-present deploy-unit members (`<Name>.html`, `<Name>/`) are
+    required; the missing connect.js itself surfaces via reference-integrity.
+    """
+    connect = output_dir / 'scripts' / 'connect.js'
+    try:
+        text = connect.read_text(encoding='utf-8', errors='replace')
+    except OSError:
+        return []
+    return [suffix for suffix in CHUNK_SUFFIXES if suffix in text]
+
+
+def check_self_closed(
+    output_dir: Path,
+    rel_files: list[str],
+    findings: list[Finding],
+) -> int:
+    """Flag self-closed non-void elements in each scanned HTML file.
+
+    Returns the number of files actually scanned (existing + readable).
+    """
+    scanned = 0
+    for rel in rel_files:
+        path = output_dir / rel
+        if not path.is_file():
+            continue
+        try:
+            text = _read_text(path)
+        except OSError as e:
+            findings.append(Finding(
+                'self-closed-element', SEVERITY_ERROR,
+                f"could not read file: {e}", file=rel,
+            ))
+            continue
+        scanned += 1
+        for line, col, tag, raw in find_self_closed(text):
+            findings.append(Finding(
+                'self-closed-element', SEVERITY_ERROR,
+                f"<{tag}> is self-closed; in text/html the '/' is ignored and the "
+                f"element swallows following markup - kills the Reverb runtime "
+                f"silently (Trac #2792)",
+                file=rel, line=line, col=col, snippet=raw.strip(),
+            ))
+    return scanned
+
+
+def check_manifest_and_parcels(
+    output_dir: Path,
+    entries: list[ParcelEntry],
+    chunk_suffixes: list[str],
+    findings: list[Finding],
+) -> None:
+    """Run the GroupID-consistency and deploy-unit-completeness checks per parcel."""
+    for entry in entries:
+        if not entry.href:
+            findings.append(Finding(
+                'manifest-parcel-groupid', SEVERITY_ERROR,
+                f"manifest parcel '{entry.name or entry.gid_li or '?'}' has no "
+                f"<a href> - cannot bind a parcel page",
+                file='index.html',
+            ))
+            continue
+
+        href_path = urllib.parse.unquote(entry.href.split('?', 1)[0].split('#', 1)[0])
+        stem = href_path[:-5] if href_path.lower().endswith('.html') else href_path
+        gid_manifest = entry.gid_anchor
+
+        # Manifest-internal: the anchor GID and the wrapping <li group:> GID
+        # should match. connect.js binds on the anchor; the <li> drives TOC
+        # hierarchy. A split here breaks one or the other.
+        if gid_manifest is None:
+            findings.append(Finding(
+                'manifest-parcel-groupid', SEVERITY_ERROR,
+                f"manifest anchor id={entry.anchor_id!r} is not of the form "
+                f"'<ctx>:<GroupID>'; connect.js reads the GroupID as "
+                f"id.split(':')[1] and will bind nothing",
+                file='index.html',
+            ))
+        elif entry.gid_li is not None and entry.gid_li != gid_manifest:
+            findings.append(Finding(
+                'manifest-parcel-groupid', SEVERITY_ERROR,
+                f"manifest GroupID mismatch for '{href_path}': anchor binds "
+                f"'{gid_manifest}' but the wrapping <li> is 'group:{entry.gid_li}'",
+                file='index.html',
+            ))
+
+        _check_deploy_unit(output_dir, stem, href_path, chunk_suffixes, findings)
+        _check_parcel_groupid(output_dir, href_path, gid_manifest, findings)
+
+
+def _check_deploy_unit(
+    output_dir: Path,
+    stem: str,
+    href_path: str,
+    chunk_suffixes: list[str],
+    findings: list[Finding],
+) -> None:
+    """Verify the parcel's deploy unit exists on disk.
+
+    `<Name>.html` (the manifest href) and the `<Name>/` content directory are
+    always required; the chunk files (`chunk_suffixes`) are those this build's
+    connect.js actually fetches.
+    """
+    required_files = [f"{stem}.html"] + [f"{stem}{suffix}" for suffix in chunk_suffixes]
+    for rel in required_files:
+        if not (output_dir / rel).is_file():
+            findings.append(Finding(
+                'parcel-deploy-unit', SEVERITY_ERROR,
+                f"missing parcel deploy-unit file for '{href_path}'",
+                file=rel,
+            ))
+    if not (output_dir / stem).is_dir():
+        findings.append(Finding(
+            'parcel-deploy-unit', SEVERITY_ERROR,
+            f"missing parcel content directory for '{href_path}'",
+            file=f"{stem}/",
+        ))
+
+
+def _check_parcel_groupid(
+    output_dir: Path,
+    href_path: str,
+    gid_manifest: Optional[str],
+    findings: list[Finding],
+) -> None:
+    """Verify the parcel page's own GroupID matches what the manifest binds."""
+    if gid_manifest is None:
+        return  # already reported as a manifest-anchor error
+    parcel_file = output_dir / href_path
+    if not parcel_file.is_file():
+        return  # the missing file is reported by the deploy-unit check
+    try:
+        text = _read_text(parcel_file)
+    except OSError as e:
+        findings.append(Finding(
+            'manifest-parcel-groupid', SEVERITY_ERROR,
+            f"could not read parcel page: {e}", file=href_path,
+        ))
+        return
+
+    body_gid, parcel_gids = extract_parcel_gids(text)
+
+    if not parcel_gids and body_gid is None:
+        findings.append(Finding(
+            'manifest-parcel-groupid', SEVERITY_ERROR,
+            f"parcel page carries no GroupID landmarks (id:/toc:/data:/page:) - "
+            f"the manifest binds GroupID '{gid_manifest}' but this is not a "
+            f"recognizable Reverb parcel page",
+            file=href_path,
+        ))
+        return
+
+    if gid_manifest not in parcel_gids:
+        # The manifest GroupID appears on none of the parcel's landmarks — the
+        # whole parcel was built under a different GroupID (the classic deploy-set
+        # mismatch). connect.js binds toc:/data:/page: by the manifest GroupID,
+        # so every getElementById returns null and the parcel never attaches.
+        observed = sorted(parcel_gids)
+        observed_str = observed[0] if len(observed) == 1 else str(observed)
+        findings.append(Finding(
+            'manifest-parcel-groupid', SEVERITY_ERROR,
+            f"GroupID mismatch: the manifest binds parcel '{href_path}' to "
+            f"GroupID '{gid_manifest}', but the parcel's landmarks use "
+            f"'{observed_str}'. connect.js binds toc:/data:/page: by the manifest "
+            f"GroupID, so this parcel never attaches and the spinner hangs with "
+            f"no console error",
+            file=href_path,
+        ))
+    else:
+        # Manifest GroupID is present, but the parcel also carries landmarks under
+        # a different GroupID — a partial / mixed-GroupID page.
+        extra = sorted(g for g in parcel_gids if g != gid_manifest)
+        if extra:
+            findings.append(Finding(
+                'manifest-parcel-groupid', SEVERITY_ERROR,
+                f"parcel '{href_path}' mixes GroupIDs: the manifest binds "
+                f"'{gid_manifest}' but some landmarks use {extra}; those elements "
+                f"will not bind",
+                file=href_path,
+            ))
+
+
+def check_reference_integrity(
+    output_dir: Path,
+    index_html_text: str,
+    findings: list[Finding],
+) -> None:
+    """Warn on local scripts/css referenced by index.html that are missing on disk."""
+    for kind, ref in extract_local_assets(index_html_text):
+        if not (output_dir / ref).is_file():
+            findings.append(Finding(
+                'reference-integrity', SEVERITY_WARN,
+                f"index.html references a local asset that is missing on disk "
+                f"({kind})",
+                file=ref,
+            ))
+
+
+def lint(output_dir: Path) -> list[Finding]:
+    """Run every check against `output_dir` and return all findings.
+
+    The output directory is assumed to exist (the caller validates it). A
+    missing index.html is itself reported as an error finding; the manifest- and
+    reference-dependent checks are then skipped.
+    """
+    findings: list[Finding] = []
+
+    index_path = output_dir / 'index.html'
+    if not index_path.is_file():
+        findings.append(Finding(
+            'self-closed-element', SEVERITY_ERROR,
+            "index.html not found - not a Reverb 2.0 output directory, or the "
+            "shell entry point is missing",
+            file='index.html',
+        ))
+        # Still scan any parcel-less shell pages that happen to exist.
+        check_self_closed(output_dir, list(SHELL_HTML_FILES), findings)
+        return findings
+
+    index_text = _read_text(index_path)
+    entries = parse_manifest(index_text)
+    debug_log(f"parsed {len(entries)} manifest parcel(s)")
+
+    # Files scanned for self-closed elements: the shell pages plus, per parcel,
+    # the entry page and its index chunk.
+    html_files = [f for f in SHELL_HTML_FILES]
+    for entry in entries:
+        if not entry.href:
+            continue
+        href_path = urllib.parse.unquote(entry.href.split('?', 1)[0].split('#', 1)[0])
+        stem = href_path[:-5] if href_path.lower().endswith('.html') else href_path
+        for rel in (href_path, f"{stem}_ix.html"):
+            if rel not in html_files:
+                html_files.append(rel)
+
+    chunk_suffixes = expected_chunk_suffixes(output_dir)
+    debug_log(f"connect.js fetches chunk suffixes: {chunk_suffixes}")
+
+    check_self_closed(output_dir, html_files, findings)
+    check_manifest_and_parcels(output_dir, entries, chunk_suffixes, findings)
+    check_reference_integrity(output_dir, index_text, findings)
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def _counts(findings: list[Finding]) -> tuple[int, int]:
+    errors = sum(1 for f in findings if f.severity == SEVERITY_ERROR)
+    warnings = sum(1 for f in findings if f.severity == SEVERITY_WARN)
+    return errors, warnings
+
+
+def render_text(
+    output_dir: Path,
+    findings: list[Finding],
+    use_color: bool,
+) -> str:
+    """Render findings as grouped, human-readable text."""
+    def c(code: str, text: str) -> str:
+        return f"{code}{text}{NC}" if use_color else text
+
+    errors, warnings = _counts(findings)
+    lines: list[str] = [f"Reverb 2.0 output lint: {output_dir}"]
+
+    if not findings:
+        lines.append(c(GREEN, "  OK - no issues found"))
+        return '\n'.join(lines)
+
+    # Stable grouping by check name, errors before warnings within each.
+    order = {SEVERITY_ERROR: 0, SEVERITY_WARN: 1}
+    for finding in sorted(
+        findings, key=lambda f: (f.check, order.get(f.severity, 9), f.file or '', f.line or 0)
+    ):
+        if finding.severity == SEVERITY_ERROR:
+            tag = c(RED, 'ERROR')
+        else:
+            tag = c(YELLOW, ' WARN')
+        loc = finding.file or '(output)'
+        if finding.line is not None:
+            loc += f":{finding.line}"
+            if finding.col is not None:
+                loc += f":{finding.col}"
+        lines.append(f"{tag}  [{finding.check}]  {loc}")
+        lines.append(f"       {finding.message}")
+        if finding.snippet:
+            lines.append(f"       > {finding.snippet}")
+
+    summary = f"{errors} error(s), {warnings} warning(s)"
+    lines.append('')
+    lines.append(c(RED if errors else YELLOW, summary))
+    return '\n'.join(lines)
+
+
+def render_json(output_dir: Path, findings: list[Finding], success: bool) -> str:
+    """Render findings as a structured JSON report."""
+    errors, warnings = _counts(findings)
+    report = {
+        'tool': 'lint-output',
+        'output_dir': str(output_dir),
+        'success': success,
+        'summary': {'errors': errors, 'warnings': warnings, 'total': len(findings)},
+        'findings': [f.to_dict() for f in findings],
+    }
+    return json.dumps(report, ensure_ascii=False, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Static linter for WebWorks Reverb 2.0 output directories.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Exit codes:
+    0  Clean (no errors; no warnings under --strict)
+    1  Error-severity findings (or any warning under --strict)
+    2  Could not run (output dir missing / unreadable)
+
+Examples:
+    %(prog)s "Output/WebWorks Reverb 2.0"
+    %(prog)s ./site --strict --json
+""",
+    )
+    parser.add_argument('output_dir', help='Reverb 2.0 output directory (contains index.html)')
+    parser.add_argument('--json', action='store_true', help='Emit a structured JSON report')
+    parser.add_argument(
+        '--strict', action='store_true',
+        help='Treat warnings as failures (exit code only)',
+    )
+    parser.add_argument('--no-color', action='store_true', help='Disable ANSI color in text output')
+    args = parser.parse_args()
+
+    # Findings may contain non-ASCII GroupIDs, paths, or snippets; keep stdout
+    # from choking on a non-UTF-8 console (common on Windows).
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+    output_dir = Path(args.output_dir)
+    if not output_dir.is_dir():
+        error_log(f"not a directory: {output_dir}")
+        return 2
+
+    try:
+        findings = lint(output_dir)
+    except OSError as e:
+        error_log(f"could not lint {output_dir}: {e}")
+        return 2
+
+    errors, warnings = _counts(findings)
+    success = errors == 0 and (warnings == 0 if args.strict else True)
+
+    if args.json:
+        print(render_json(output_dir, findings, success))
+    else:
+        use_color = not args.no_color and sys.stdout.isatty()
+        print(render_text(output_dir, findings, use_color))
+
+    return 0 if success else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/README.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/README.md
@@ -1,0 +1,33 @@
+# lint-output.py fixtures
+
+A single committed fixture tree, `good/`, that is a structurally valid minimal
+Reverb 2.0 output — `lint-output.py` must report it clean (exit 0).
+
+`good/` is the baseline for the whole suite. `tests/verify-lint-output.py` copies
+it to a tempdir and mutates **one** file per scenario to inject a single defect,
+then asserts the linter's exit code and findings. Keeping one good tree (rather
+than a broken tree per check) means each failure mode is expressed as a minimal
+diff from a known-good build — exactly how the real breakages arise.
+
+## What `good/` exercises
+
+| Aspect | Why it is in the fixture |
+|--------|--------------------------|
+| Two parcels (`Alpha`, `Bravo`) with full deploy units | `parcel-deploy-unit` happy path: `<Name>.html`, `<Name>_ix.html`, `<Name>_lx.js`, `<Name>_sx.js`, `<Name>/` |
+| `#parcels` manifest with `<li id="group:<GID>">` + `<a id="<ctx>:<GID>" href>` | `manifest-parcel-groupid` anchor/`<li>` parsing |
+| Parcel body `id:<GID>` + `toc:`/`data:`/`page:` divs | parcel-side GroupID extraction |
+| Overloaded `breadcrumbs:<GID>` **and** `breadcrumbs:<pageId>` ids | regression guard: page-keyed `breadcrumbs:` ids must **not** be read as GroupIDs (the false positive that the `id`/`toc`/`data`/`page`-only rule fixes) |
+| Self-closed **void** elements (`<meta/>`, `<link/>`) | `self-closed-element` must not flag void elements |
+| A remote `https://cdn.jsdelivr.net/...` `<script src>` | `reference-integrity` must skip remote refs |
+| Local `scripts/*.js` + `css/base.css` with `?v=` cache-busters | `reference-integrity` happy path (query stripped before the on-disk check) |
+
+## Run
+
+```bash
+python ../../verify-lint-output.py
+```
+
+The verifier injects each defect (self-closed `<script/>`, whole-parcel GroupID
+mismatch, `<li>`/anchor GroupID desync, missing deploy-unit file, missing content
+directory, missing local asset, missing `index.html`) into a throwaway copy — the
+committed `good/` tree is never modified.

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Alpha.html
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Alpha.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"/></head>
+<body id="id:gid-alpha" data-is-parcel="true">
+  <div id="toc:gid-alpha"><ul><li><a href="Alpha/alpha.1.1.html">Alpha topic</a></li></ul></div>
+  <div id="data:gid-alpha"></div>
+  <!-- breadcrumbs is overloaded: one GroupID container plus page-keyed
+       fragments. The page-keyed ids must NOT be read as GroupIDs. -->
+  <div id="breadcrumbs:gid-alpha"></div>
+  <div id="breadcrumbs:p9aXbYcZ01"></div>
+  <div id="breadcrumbs:pQ7rS8tU02"></div>
+  <div id="page:gid-alpha:first"><a href="Alpha/alpha.1.1.html"></a></div>
+  <div id="page:gid-alpha:last"></div>
+</body>
+</html>

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Alpha/alpha.1.1.html
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Alpha/alpha.1.1.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"/></head>
+<body><h1>Alpha</h1><p>Topic body.</p></body></html>

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Alpha_ix.html
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Alpha_ix.html
@@ -1,0 +1,1 @@
+<ul><li><a href="Alpha/alpha.1.1.html">Alpha topic</a></li></ul>

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Alpha_lx.js
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Alpha_lx.js
@@ -1,0 +1,1 @@
+var landmarks = {"f":["Alpha/alpha.1.1.html"],"a":[""],"e":[[0,0,"gid-alpha01"]]};Landmarks.Advance(landmarks);

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Alpha_sx.js
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Alpha_sx.js
@@ -1,0 +1,1 @@
+var search = {"docs":[]};Search.Advance(search);

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Bravo.html
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Bravo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"/></head>
+<body id="id:gid-bravo" data-is-parcel="true">
+  <div id="toc:gid-bravo"><ul><li><a href="Bravo/bravo.1.1.html">Bravo topic</a></li></ul></div>
+  <div id="data:gid-bravo"></div>
+  <div id="breadcrumbs:gid-bravo"></div>
+  <div id="breadcrumbs:pK3lM4nO05"></div>
+  <div id="page:gid-bravo:first"><a href="Bravo/bravo.1.1.html"></a></div>
+  <div id="page:gid-bravo:last"></div>
+</body>
+</html>

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Bravo/bravo.1.1.html
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Bravo/bravo.1.1.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"/></head>
+<body><h1>Bravo</h1><p>Topic body.</p></body></html>

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Bravo_ix.html
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Bravo_ix.html
@@ -1,0 +1,1 @@
+<ul><li><a href="Bravo/bravo.1.1.html">Bravo topic</a></li></ul>

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Bravo_lx.js
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Bravo_lx.js
@@ -1,0 +1,1 @@
+var landmarks = {"f":["Bravo/bravo.1.1.html"],"a":[""],"e":[[0,0,"gid-bravo01"]]};Landmarks.Advance(landmarks);

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Bravo_sx.js
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/Bravo_sx.js
@@ -1,0 +1,1 @@
+var search = {"docs":[]};Search.Advance(search);

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/css/base.css
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/css/base.css
@@ -1,0 +1,2 @@
+/* base.css stub */
+body { margin: 0; }

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/index.html
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<!--
+  Fixture: a STRUCTURALLY VALID minimal Reverb 2.0 shell. lint-output.py must
+  report it clean (exit 0). The verifier copies this tree to a tempdir and
+  mutates one file per scenario to exercise each check.
+
+  Models the real shell: the #parcels manifest carries one <li id="group:<GID>">
+  per parcel, each wrapping an <a id="<ctx>:<GID>" href="<Name>.html">. Void
+  elements are written self-closed (<meta/>, <link/>) exactly as Reverb emits
+  them — these must NOT be flagged.
+-->
+<html>
+<head>
+<meta charset="utf-8"/>
+<link rel="stylesheet" type="text/css" href="css/base.css?v=abc123"/>
+<title>Reverb lint fixture</title>
+</head>
+<body id="connect_body" class="preload">
+  <div id="toolbar_div"></div>
+  <div id="page_div"><iframe id="page_iframe"></iframe></div>
+  <!-- Parcels -->
+  <div id="parcels"><ul role="tree">
+    <li id="group:gid-alpha" data-group-title="Alpha" role="treeitem" aria-expanded="false">
+      <div class="ww_skin_toc_entry ww_skin_toc_folder">
+        <a class="ww_skin_toc_entry_title" id="Alpha:gid-alpha" href="Alpha.html" target="_self" title="Alpha">Alpha</a>
+      </div>
+    </li>
+    <li id="group:gid-bravo" data-group-title="Bravo" role="treeitem" aria-expanded="false">
+      <div class="ww_skin_toc_entry ww_skin_toc_folder">
+        <a class="ww_skin_toc_entry_title" id="Bravo:gid-bravo" href="Bravo.html" target="_self" title="Bravo">Bravo</a>
+      </div>
+    </li>
+  </ul></div>
+  <!-- A remote asset reference must be skipped by reference-integrity. -->
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
+  <script type="text/javascript" src="scripts/common.js?v=abc123"></script>
+  <script type="text/javascript" src="scripts/connect.js?v=abc123"></script>
+</body>
+</html>

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/scripts/common.js
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/scripts/common.js
@@ -1,0 +1,1 @@
+// common.js stub

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/scripts/connect.js
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/scripts/connect.js
@@ -1,0 +1,7 @@
+// connect.js stub for the lint-output fixture. The deploy-unit check reads which
+// per-parcel chunks a build fetches from these push calls (mirrors the real
+// Parcels.Add in connect.js), so this stub fetches all three: _ix.html, _lx.js,
+// _sx.js. An older build that omits the _lx.js line makes that chunk optional.
+Parcels.index.push({ id: param_parcel_id, url: parcel_directory_url + '_ix.html' });
+Parcels.landmarks.push(parcel_directory_url + '_lx.js?v=' + GLOBAL_GENERATION_HASH);
+Parcels.search.push(parcel_directory_url + '_sx.js?v=' + GLOBAL_GENERATION_HASH);

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/verify-lint-output.py
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/verify-lint-output.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""
+verify-lint-output.py
+
+Standalone verifier for lint-output.py. Runs every test scenario and prints
+PASS/FAIL lines. Exits 0 only when every scenario passes.
+
+Usage:
+    python verify-lint-output.py
+
+Two layers:
+  - Internal-function tests import lint-output.py as a module and exercise the
+    pure parsing/classification helpers directly.
+  - CLI contract tests copy the committed `tests/fixtures/lint-output/good`
+    tree to a tempdir, mutate one file to inject a single defect, and assert the
+    linter's exit code and findings. No network access is required.
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+SKILL_DIR = THIS_DIR.parent
+SCRIPT_PATH = SKILL_DIR / 'scripts' / 'lint-output.py'
+GOOD_FIXTURE = THIS_DIR / 'fixtures' / 'lint-output' / 'good'
+
+
+def _load_linter_module():
+    """Import lint-output.py despite the dash in its filename."""
+    spec = importlib.util.spec_from_file_location('lint_output', SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+linter = _load_linter_module()
+
+# Reuse the script's palette so PASS/FAIL output stays in sync.
+RED = linter.RED
+GREEN = linter.GREEN
+YELLOW = linter.YELLOW
+NC = linter.NC
+
+_results: list[tuple[str, bool, str]] = []
+
+
+def check(name: str, condition: bool, detail: str = '') -> None:
+    _results.append((name, bool(condition), detail))
+    if condition:
+        print(f"{GREEN}PASS:{NC} {name}")
+    else:
+        print(f"{RED}FAIL:{NC} {name}" + (f" — {detail}" if detail else ''))
+
+
+def run_cli(*cli_args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *cli_args],
+        capture_output=True,
+        text=True,
+    )
+
+
+class CopyOfGood:
+    """Context manager: a throwaway copy of the good fixture in a tempdir."""
+
+    def __enter__(self) -> Path:
+        self._tmp = Path(tempfile.mkdtemp(prefix='lint-output-'))
+        self.root = self._tmp / 'out'
+        shutil.copytree(GOOD_FIXTURE, self.root)
+        return self.root
+
+    def __exit__(self, *exc) -> None:
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding='utf-8')
+
+
+def _write(path: Path, text: str) -> None:
+    path.write_text(text, encoding='utf-8', newline='\n')
+
+
+def _findings(proc: subprocess.CompletedProcess) -> list[dict]:
+    """Parse the --json report's findings list from a CLI run."""
+    return json.loads(proc.stdout)['findings']
+
+
+def _checks_present(findings: list[dict], check_name: str) -> list[dict]:
+    return [f for f in findings if f['check'] == check_name]
+
+
+# ---------------------------------------------------------------------------
+# Internal-function tests
+# ---------------------------------------------------------------------------
+
+def test_self_closed_flags_non_void() -> None:
+    findings = linter.find_self_closed('<div/><span/><a/>')
+    tags = sorted(t for _, _, t, _ in findings)
+    check("find_self_closed flags non-void <div>/<span>/<a>", tags == ['a', 'div', 'span'], str(tags))
+
+
+def test_self_closed_ignores_void() -> None:
+    findings = linter.find_self_closed('<meta charset="utf-8"/><br/><link href="x"/><img src="y"/>')
+    check("find_self_closed ignores void elements", findings == [], str(findings))
+
+
+def test_self_closed_flags_script() -> None:
+    findings = linter.find_self_closed('<head><script src="a.js"/></head>')
+    tags = [t for _, _, t, _ in findings]
+    check("find_self_closed flags self-closed <script> (Trac #2792)", tags == ['script'], str(tags))
+
+
+def test_self_closed_skips_cdata_script_body() -> None:
+    # A literal "<div/>" inside a real <script> body is CDATA text, not a tag.
+    findings = linter.find_self_closed('<script>var s = "<div/>";</script><p>ok</p>')
+    check("find_self_closed ignores <div/> inside script CDATA", findings == [], str(findings))
+
+
+def test_self_closed_exempts_foreign_content() -> None:
+    findings = linter.find_self_closed('<svg viewBox="0 0 1 1"><path d="M0 0"/><rect/></svg>')
+    check("find_self_closed exempts <svg> foreign content", findings == [], str(findings))
+
+
+def test_self_closed_after_foreign_closes() -> None:
+    # Once </svg> closes, a self-closed <div/> in HTML context is flagged again.
+    findings = linter.find_self_closed('<svg><path d="x"/></svg><div/>')
+    tags = [t for _, _, t, _ in findings]
+    check("find_self_closed resumes flagging after </svg>", tags == ['div'], str(tags))
+
+
+def test_parse_manifest_good() -> None:
+    entries = linter.parse_manifest(_read(GOOD_FIXTURE / 'index.html'))
+    ok = (
+        len(entries) == 2
+        and entries[0].gid_anchor == 'gid-alpha' and entries[0].href == 'Alpha.html'
+        and entries[0].gid_li == 'gid-alpha' and entries[0].name == 'Alpha'
+        and entries[1].gid_anchor == 'gid-bravo' and entries[1].href == 'Bravo.html'
+    )
+    check("parse_manifest extracts both parcels with gid/href/name", ok,
+          f"got {[(e.name, e.gid_anchor, e.href) for e in entries]}")
+
+
+def test_gid_anchor_split() -> None:
+    mk = linter.ParcelEntry
+    ok = (
+        mk(None, None, 'Alpha:gid-alpha', 'Alpha.html').gid_anchor == 'gid-alpha'
+        and mk(None, None, ':gid-x', 'x.html').gid_anchor is None
+        and mk(None, None, 'nocolon', 'x.html').gid_anchor is None
+        and mk(None, None, None, None).gid_anchor is None
+    )
+    check("ParcelEntry.gid_anchor mirrors id.split(':')[1]", ok)
+
+
+def test_classify_gid_id() -> None:
+    c = linter.classify_gid_id
+    ok = (
+        c('id:gid-a') == 'gid-a'
+        and c('toc:gid-a') == 'gid-a'
+        and c('data:gid-a') == 'gid-a'
+        and c('page:gid-a:first') == 'gid-a'
+        and c('page:gid-a:last') == 'gid-a'
+        and c('breadcrumbs:gid-a') is None       # excluded prefix
+        and c('breadcrumbs:p9aXbYcZ') is None     # page-keyed, not a GroupID
+        and c('connect_body') is None
+    )
+    check("classify_gid_id maps id/toc/data/page, excludes breadcrumbs", ok)
+
+
+def test_extract_parcel_gids() -> None:
+    body_gid, gids = linter.extract_parcel_gids(_read(GOOD_FIXTURE / 'Alpha.html'))
+    ok = body_gid == 'gid-alpha' and gids == {'gid-alpha'}
+    check("extract_parcel_gids returns body GID, ignores page-keyed breadcrumbs", ok,
+          f"body={body_gid} gids={sorted(gids)}")
+
+
+def test_extract_local_assets() -> None:
+    refs = linter.extract_local_assets(_read(GOOD_FIXTURE / 'index.html'))
+    paths = sorted(p for _, p in refs)
+    ok = paths == ['css/base.css', 'scripts/common.js', 'scripts/connect.js']
+    check("extract_local_assets strips ?v=, drops remote cdn refs", ok, str(paths))
+
+
+def test_expected_chunk_suffixes() -> None:
+    suffixes = linter.expected_chunk_suffixes(GOOD_FIXTURE)
+    ok = sorted(suffixes) == ['_ix.html', '_lx.js', '_sx.js']
+    check("expected_chunk_suffixes reads all three from the fixture connect.js", ok, str(suffixes))
+
+
+# ---------------------------------------------------------------------------
+# CLI contract tests
+# ---------------------------------------------------------------------------
+
+def test_cli_good_clean() -> None:
+    proc = run_cli(str(GOOD_FIXTURE), '--no-color')
+    check("CLI: good fixture exits 0", proc.returncode == 0, proc.stdout + proc.stderr)
+    check("CLI: good fixture reports OK", 'OK' in proc.stdout, proc.stdout)
+
+
+def test_cli_good_json() -> None:
+    proc = run_cli(str(GOOD_FIXTURE), '--json')
+    data = json.loads(proc.stdout)
+    ok = data['success'] is True and data['findings'] == [] and data['summary']['errors'] == 0
+    check("CLI: good fixture --json has success=true, no findings", ok, proc.stdout)
+
+
+def test_cli_self_closed() -> None:
+    with CopyOfGood() as root:
+        idx = root / 'index.html'
+        text = _read(idx).replace(
+            'src="scripts/connect.js?v=abc123"></script>',
+            'src="scripts/connect.js?v=abc123"/>',
+        )
+        _write(idx, text)
+        proc = run_cli(str(root), '--json')
+        sc = _checks_present(_findings(proc), 'self-closed-element')
+        ok = proc.returncode == 1 and any(f['file'] == 'index.html' and 'script' in f['snippet'] for f in sc)
+        check("CLI: self-closed <script/> flagged on index.html, exit 1", ok,
+              f"rc={proc.returncode} findings={sc}")
+
+
+def test_cli_groupid_total_mismatch() -> None:
+    with CopyOfGood() as root:
+        alpha = root / 'Alpha.html'
+        _write(alpha, _read(alpha).replace('gid-alpha', 'gid-wrong'))
+        proc = run_cli(str(root), '--json')
+        gm = _checks_present(_findings(proc), 'manifest-parcel-groupid')
+        ok = (
+            proc.returncode == 1
+            and any(f['file'] == 'Alpha.html' and 'gid-wrong' in f['message']
+                    and 'gid-alpha' in f['message'] for f in gm)
+        )
+        check("CLI: whole-parcel GroupID mismatch flagged, exit 1", ok,
+              f"rc={proc.returncode} findings={gm}")
+
+
+def test_cli_li_anchor_mismatch() -> None:
+    with CopyOfGood() as root:
+        idx = root / 'index.html'
+        # Desync the wrapping <li group:GID> from its anchor's GID.
+        _write(idx, _read(idx).replace('id="group:gid-alpha"', 'id="group:gid-zzz"'))
+        proc = run_cli(str(root), '--json')
+        gm = _checks_present(_findings(proc), 'manifest-parcel-groupid')
+        ok = (
+            proc.returncode == 1
+            and any(f['file'] == 'index.html' and 'gid-zzz' in f['message'] for f in gm)
+        )
+        check("CLI: manifest <li> vs anchor GroupID desync flagged, exit 1", ok,
+              f"rc={proc.returncode} findings={gm}")
+
+
+def test_cli_missing_deploy_file() -> None:
+    with CopyOfGood() as root:
+        os.remove(root / 'Alpha_lx.js')
+        proc = run_cli(str(root), '--json')
+        du = _checks_present(_findings(proc), 'parcel-deploy-unit')
+        ok = proc.returncode == 1 and any(f['file'] == 'Alpha_lx.js' for f in du)
+        check("CLI: missing _lx.js deploy-unit file flagged, exit 1", ok,
+              f"rc={proc.returncode} findings={du}")
+
+
+def test_cli_older_build_omits_lx_chunk() -> None:
+    # An older build whose connect.js does not fetch _lx.js legitimately ships no
+    # <Name>_lx.js. Removing the chunk AND its connect.js reference must NOT be
+    # flagged (regression guard: real pre-landmark builds were false-positived).
+    with CopyOfGood() as root:
+        os.remove(root / 'Alpha_lx.js')
+        os.remove(root / 'Bravo_lx.js')
+        connect = root / 'scripts' / 'connect.js'
+        text = _read(connect)
+        text = '\n'.join(line for line in text.splitlines() if '_lx.js' not in line) + '\n'
+        _write(connect, text)
+        proc = run_cli(str(root), '--json')
+        du = _checks_present(_findings(proc), 'parcel-deploy-unit')
+        ok = proc.returncode == 0 and du == []
+        check("CLI: older build (connect.js omits _lx.js) is not flagged for missing _lx.js",
+              ok, f"rc={proc.returncode} findings={du}")
+
+
+def test_cli_missing_content_dir() -> None:
+    with CopyOfGood() as root:
+        shutil.rmtree(root / 'Alpha')
+        proc = run_cli(str(root), '--json')
+        du = _checks_present(_findings(proc), 'parcel-deploy-unit')
+        ok = proc.returncode == 1 and any(f['file'] == 'Alpha/' for f in du)
+        check("CLI: missing parcel content directory flagged, exit 1", ok,
+              f"rc={proc.returncode} findings={du}")
+
+
+def test_cli_missing_asset_warns() -> None:
+    with CopyOfGood() as root:
+        os.remove(root / 'scripts' / 'common.js')
+        proc = run_cli(str(root), '--json')
+        data = json.loads(proc.stdout)
+        ri = _checks_present(data['findings'], 'reference-integrity')
+        ok = (
+            proc.returncode == 0  # warnings alone do not fail
+            and data['success'] is True
+            and any(f['file'] == 'scripts/common.js' and f['severity'] == 'warn' for f in ri)
+        )
+        check("CLI: missing local asset warns, exit 0 (non-strict)", ok,
+              f"rc={proc.returncode} findings={ri}")
+
+        proc_strict = run_cli(str(root), '--json', '--strict')
+        ok_strict = proc_strict.returncode == 1 and json.loads(proc_strict.stdout)['success'] is False
+        check("CLI: --strict turns the warning into exit 1", ok_strict,
+              f"rc={proc_strict.returncode}")
+
+
+def test_cli_missing_index() -> None:
+    tmp = Path(tempfile.mkdtemp(prefix='lint-output-empty-'))
+    try:
+        proc = run_cli(str(tmp), '--json')
+        findings = _findings(proc)
+        ok = proc.returncode == 1 and any('index.html' in (f.get('file') or '') for f in findings)
+        check("CLI: missing index.html flagged, exit 1", ok, f"rc={proc.returncode} findings={findings}")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def test_cli_not_a_directory() -> None:
+    proc = run_cli(str(THIS_DIR / 'does-not-exist-xyz'), '--no-color')
+    check("CLI: non-existent output dir exits 2", proc.returncode == 2, f"rc={proc.returncode}")
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    tests = [
+        test_self_closed_flags_non_void,
+        test_self_closed_ignores_void,
+        test_self_closed_flags_script,
+        test_self_closed_skips_cdata_script_body,
+        test_self_closed_exempts_foreign_content,
+        test_self_closed_after_foreign_closes,
+        test_parse_manifest_good,
+        test_gid_anchor_split,
+        test_classify_gid_id,
+        test_extract_parcel_gids,
+        test_extract_local_assets,
+        test_expected_chunk_suffixes,
+        test_cli_good_clean,
+        test_cli_good_json,
+        test_cli_self_closed,
+        test_cli_groupid_total_mismatch,
+        test_cli_li_anchor_mismatch,
+        test_cli_missing_deploy_file,
+        test_cli_older_build_omits_lx_chunk,
+        test_cli_missing_content_dir,
+        test_cli_missing_asset_warns,
+        test_cli_missing_index,
+        test_cli_not_a_directory,
+    ]
+    print(f"Running {len(tests)} lint-output test scenarios\n")
+    for test in tests:
+        try:
+            test()
+        except Exception as e:  # noqa: BLE001 — a crashing test is a failed test
+            check(test.__name__, False, f"raised {type(e).__name__}: {e}")
+
+    passed = sum(1 for _, ok, _ in _results if ok)
+    total = len(_results)
+    print()
+    if passed == total:
+        print(f"{GREEN}All {total} checks passed{NC}")
+        return 0
+    print(f"{RED}{total - passed} of {total} checks failed{NC}")
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/plugins/webworks-agent-skills/skills/reverb2/workflows/output-linting.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/workflows/output-linting.md
@@ -1,0 +1,139 @@
+# Workflow: Output Linting (static pre-flight)
+
+*From SKILL.md intake item 6.*
+
+<required_reading>
+**No additional references needed** — all information is in this file. The
+checks mirror how `scripts/connect.js` loads parcels in any Reverb 2.0 output;
+consult that runtime file only when investigating a behavior mismatch.
+</required_reading>
+
+<process>
+## When to Use
+
+Run the linter on a built or **assembled** Reverb 2.0 output directory to catch
+structural breakages that kill the runtime **silently** — the page hangs on the
+spinner with no console error — before anyone opens it in a browser. It needs no
+Chrome and no runtime, so it belongs in CI and in pre-deploy gates. It is the
+cheap *static* counterpart to the browser test (intake item 1), which is the
+*runtime* confirmation.
+
+Reach for it especially when output is **assembled from more than one build** —
+the Reverb-on-S3 "deploy set" model, a manifest splice, a hand-edit, or any
+pretty-printer/formatter run over the HTML. Those are exactly the situations
+that produce the breakages below.
+
+## Step 1: Point It at the Output Directory
+
+The argument is the directory that contains `index.html` (the shell entry
+point), e.g. `Output/WebWorks Reverb 2.0`.
+
+```bash
+python scripts/lint-output.py "<output-dir>"
+```
+
+Flags:
+
+| Flag | Effect |
+|------|--------|
+| `--json` | Emit a structured JSON report instead of human-readable text. |
+| `--strict` | Treat warnings as failures (affects the exit code only). |
+| `--no-color` | Disable ANSI color (auto-disabled when stdout is not a TTY). |
+
+## Step 2: Read the Checks
+
+| Check | Severity | Breakage | Fix |
+|-------|----------|----------|-----|
+| `self-closed-element` | error | A non-void element written in XML self-closing form (`<script/>`, `<iframe/>`, `<div/>`, `<span/>`, `<ul/>`, …). In `text/html` the `/` is ignored, so the element parses as *open* and swallows the rest of the document. The first page never renders and there is **no** console error. (Trac #2792.) | Re-emit the element with a real close tag (`<div></div>`). Usually caused by an XML/XHTML formatter run over the output — stop pretty-printing the HTML, or use an HTML-aware formatter. Void elements (`<meta/>`, `<link/>`, `<br/>`, …) and `<svg>`/`<math>` foreign content are exempt. |
+| `manifest-parcel-groupid` | error | A parcel's own GroupID disagrees with what the `#parcels` manifest binds. `connect.js` reads `id.split(':')[1]` from each anchor `<a id="<ctx>:<GID>" href="<Name>.html">`, fetches `<Name>.html`, and looks up `toc:<GID>`/`data:<GID>`/`page:<GID>:first` inside it. On a mismatch every lookup returns null, the parcel never attaches, and the spinner hangs. | Rebuild the parcel and the manifest entry from the **same** GroupID, or rewrite the manifest anchor's GroupID to match the parcel (this is what a correct deploy-set assembler does — splice by GroupID). The linter also flags a `<li id="group:<GID>">`-vs-anchor desync within the manifest itself. |
+| `parcel-deploy-unit` | error | A manifest parcel `<Name>` is missing a deploy-unit member. | Deploy the whole unit together: `<Name>.html` (the manifest href) and the `<Name>/` content directory are always required; the runtime chunks `<Name>_ix.html`/`<Name>_lx.js`/`<Name>_sx.js` are required when the build's `scripts/connect.js` fetches them (older builds omit `_lx.js`, search-off builds omit `_sx.js`). A parcel is **not** a single self-contained folder. |
+| `reference-integrity` | warn | A local `scripts/`/`css/` asset referenced by `index.html` is missing on disk. | Deploy the referenced asset, or fix the reference. Remote (`http(s)://`, `//`) and `data:` references are not checked. |
+
+The self-closed scan covers `index.html`, the root shell pages (`search.html`,
+`splash.html`, `not-found.html`), and each parcel's `<Name>.html` and
+`<Name>_ix.html`.
+
+## Step 3: Interpret the Exit Code
+
+| Exit code | Meaning | CI action |
+|-----------|---------|-----------|
+| `0` | Clean — no errors (and no warnings under `--strict`). | Proceed. |
+| `1` | At least one error-severity finding (or any warning under `--strict`). | Fail the build; read the findings. |
+| `2` | The linter could not run — `<output-dir>` is missing or not a directory. | Check the path; this is a harness error, not a lint result. |
+
+Warnings alone do **not** fail the default run. Add `--strict` in a gate that
+should also block on missing-asset warnings.
+
+## Step 4: Output Shapes
+
+**Text** (default) groups findings by check and shows `file:line:col`, the
+message, and a source snippet for self-closed hits:
+
+```
+ERROR  [self-closed-element]  index.html:7:1900
+       <div> is self-closed; in text/html the '/' is ignored and the element
+       swallows following markup - kills the Reverb runtime silently (Trac #2792)
+       > <div id="injected_break"/>
+
+1 error(s), 0 warning(s)
+```
+
+(For minified output every line is `1`; the `col` and snippet locate the hit.)
+
+**JSON** (`--json`) is machine-readable for CI:
+
+```json
+{
+  "tool": "lint-output",
+  "output_dir": "Output/WebWorks Reverb 2.0",
+  "success": false,
+  "summary": { "errors": 1, "warnings": 0, "total": 1 },
+  "findings": [
+    {
+      "check": "manifest-parcel-groupid",
+      "severity": "error",
+      "file": "Charlie.html",
+      "message": "GroupID mismatch: the manifest binds parcel 'Charlie.html' to GroupID 'parcel-lab-grp-charlie', but the parcel's landmarks use 'other-build-gid-99'. ..."
+    }
+  ]
+}
+```
+
+`success` already folds in `--strict`; gate on it (or on the exit code) rather
+than re-deriving from the counts.
+
+## Step 5: Chain Into the Browser Test
+
+The linter and the browser test are complementary, not redundant:
+
+- **Linter** = fast *static* pre-flight (CI / pre-deploy; no browser). Catches
+  structural breakage — the kinds above — instantly.
+- **Browser test** (`browser-test.js`, intake item 1) = *runtime* confirmation
+  (post-flight; needs Chrome). Confirms the build actually loads via the
+  `preload` signal.
+
+Run the linter first; only spend a browser launch on output that is structurally
+sound:
+
+```bash
+python scripts/lint-output.py "output/WebWorks Reverb 2.0" || exit 1
+node scripts/browser-test.js "$CHROME" "$ENTRY_URL"
+```
+
+## Step 6: Extending the Linter
+
+New known-breakage checks are added to `scripts/lint-output.py` as they are
+discovered — write a `check_*` function that appends `Finding` objects, call it
+from `lint()`, and add a fixture-mutation scenario to
+`tests/verify-lint-output.py`. The GroupID-consistency check, for example, came
+straight out of a real Reverb-on-S3 deploy-set assembly bug.
+</process>
+
+<success_criteria>
+This workflow is complete when:
+- [ ] The linter was pointed at the directory containing `index.html`
+- [ ] Every error-severity finding was understood and fixed (or consciously accepted)
+- [ ] The chosen gate strictness (`--strict` or not) matches whether missing-asset warnings should block
+- [ ] The exit code was interpreted correctly — `2` traced to a bad path, not mistaken for "found problems"
+- [ ] For a real load confirmation, the browser test was run after a clean lint
+</success_criteria>


### PR DESCRIPTION
## What

Adds `scripts/lint-output.py` to the **reverb2** skill — a browser-free static linter for a built or **assembled** Reverb 2.0 output directory, exit-coded for CI / pre-deploy. It catches structural breakages that kill the runtime *silently* (the page hangs on the spinner with **zero** console errors) and are visible purely in the emitted files.

Static pre-flight counterpart to the runtime [`browser-test.js`](https://github.com/quadralay/webworks-agent-skills/pull/114) (#109): run the linter first to catch structural breakage cheaply, then the browser test to confirm the build actually loads.

## Checks

| Check | Severity | Catches |
|-------|----------|---------|
| `self-closed-element` | error | Non-void elements in XML self-closing form (`<script/>`, `<iframe/>`, `<div/>`, …). In `text/html` the `/` is ignored, so the element swallows the rest of the document (Trac #2792). Void elements and `<svg>`/`<math>` foreign content are exempt. |
| `manifest-parcel-groupid` | error | The parcel's own GroupID vs the GroupID the `#parcels` manifest binds. `connect.js` binds by `anchor id.split(':')[1]`, so a mismatch means every `toc:`/`data:`/`page:` lookup returns null and the parcel never attaches. This is the **Reverb-on-S3 deploy-set assembly bug**. |
| `parcel-deploy-unit` | error | Per-parcel deploy-unit completeness. `<Name>.html` and `<Name>/` are always required; the chunk set (`_ix.html`/`_lx.js`/`_sx.js`) is read from the build's own `connect.js`, so older / landmark-disabled builds are **not** false-positived. |
| `reference-integrity` | warn | Local `scripts/`/`css/` assets referenced by `index.html` exist on disk (remote and `data:` refs skipped). |

Exit codes: `0` clean · `1` errors (or warnings under `--strict`) · `2` could not run. Text and `--json` output.

## Implementation notes

- Engine uses `html.parser` (correct CDATA/comment handling, foreign-content depth tracking for `<svg>`/`<math>`) rather than regex.
- The GroupID logic mirrors `connect.js`'s exact binding semantics, derived from reading the runtime source. `breadcrumbs:` is deliberately excluded from the GroupID comparison because it is overloaded (one GroupID container + several page-keyed fragments) — a regression guard is in the fixture.
- The required deploy-unit chunk set is read from each build's `connect.js` (the runtime's own declaration of which chunks it fetches), which is what makes the check robust across Reverb versions and feature gates.

## Validation

- **59 real Reverb outputs** on disk linted → **0 false positives** (across single/multi-parcel, merge-settings, per-locale deploy sets, url-encoded-slash group names, and older pre-landmark builds).
- Injected real bugs (self-closed element, whole-parcel GroupID mismatch, dropped `_lx.js` on a build that expects it) → correctly flagged.
- `tests/verify-lint-output.py` — mutate-the-good-fixture suite, **25 checks**, all passing. Run: `python tests/verify-lint-output.py`.

## Docs

Wired into `SKILL.md` (capabilities table, intake item 6, routing, a new **Output Linting** section, and the Full Output Validation flow) and a new `workflows/output-linting.md`.

Closes #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)