### PR TITLE
chore: bump plugin version to 3.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "webworks-agent-skills",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "owner": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/.claude-plugin/plugin.json
+++ b/plugins/webworks-agent-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webworks-agent-skills",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "author": {
     "name": "Quadralay Corporation",


### PR DESCRIPTION
## Why

[PR #115](https://github.com/quadralay/webworks-agent-skills/pull/115) (the reverb2 static output linter, #110) added a new skill capability but did not bump the plugin version. Without a bump, plugin managers won't know an update is available.

## Change

Bump in sync, **3.2.0 → 3.3.0**:
- `plugins/webworks-agent-skills/.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`

Minor bump, matching the convention for prior capability additions (`ce54d06` add customization-audit → 3.1.0; `a2673b9` add reconcile command → 3.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)