### PR TITLE
Closes #111: discover _lx.js chunks via the #parcels manifest on multi-parcel mirrors

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "webworks-agent-skills",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "owner": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/.claude-plugin/plugin.json
+++ b/plugins/webworks-agent-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webworks-agent-skills",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "author": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/skills/reverb2/scripts/resolve-landmarks.py
+++ b/plugins/webworks-agent-skills/skills/reverb2/scripts/resolve-landmarks.py
@@ -52,6 +52,15 @@ the _lx.js data. URL-fragment IDs are urllib.parse.unquote'd before lookup, so
 percent-encoded Unicode IDs (e.g., %E6%A6%82%E8%A6%81 -> 概要) round-trip the
 same way the browser runtime resolves them.
 
+Remote chunk discovery (first non-empty source wins):
+    1. The landing page's `#parcels` manifest — multi-parcel / merge-settings
+       (multivolume) mirrors reference their per-parcel chunks only through
+       this runtime-parsed tree. Each parcel anchor href "<Name>.html" maps
+       to a sibling chunk "<Name>_lx.js", exactly as the runtime derives it.
+    2. An `_lx-manifest.json` probe at the base URL.
+    3. `<script src="..._lx.js">` tags scraped from the landing page
+       (single-build / flat mirrors).
+
 Manifest file shape (forward-compatible; Reverb does not currently emit one):
     {"chunks": ["Foo_lx.js", "Bar_lx.js"]}
 The names resolve relative to the remote base URL.
@@ -108,6 +117,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
+from html.parser import HTMLParser
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -707,6 +717,88 @@ def extract_chunk_srcs_from_html(html: str, base_url: str) -> list[str]:
     return result
 
 
+class _ParcelAnchorExtractor(HTMLParser):
+    """Collect parcel-anchor href values inside `<div id="parcels">`.
+
+    Mirrors the runtime's parcel filter in connect.js (Parcels.PrepareForLoad):
+    an anchor counts as a parcel anchor when its id has the form
+    "<context>:<id>" with a non-empty context. Entry/exit of the `#parcels`
+    subtree is tracked by counting nested <div> tags (same approach as
+    lint-output.py's ManifestParser) — the generated markup nests divs inside
+    each parcel <li>, but never an unbalanced one.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.hrefs: list[str] = []
+        self._in_parcels = False
+        self._div_depth = 0
+        self._done = False
+
+    def handle_starttag(self, tag: str, attrs) -> None:
+        attr = dict(attrs)
+        if tag == 'div':
+            if not self._in_parcels:
+                if not self._done and attr.get('id') == 'parcels':
+                    self._in_parcels = True
+                    self._div_depth = 0
+                return
+            self._div_depth += 1
+            return
+        if not self._in_parcels or tag != 'a':
+            return
+        anchor_id = attr.get('id') or ''
+        href = attr.get('href') or ''
+        if href and ':' in anchor_id and anchor_id.split(':', 1)[0]:
+            self.hrefs.append(href)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag != 'div' or not self._in_parcels:
+            return
+        if self._div_depth == 0:
+            # This </div> closes #parcels itself. Like getElementById, only
+            # the first #parcels container counts.
+            self._in_parcels = False
+            self._done = True
+        else:
+            self._div_depth -= 1
+
+
+def extract_parcel_chunk_urls(html: str, base_url: str) -> list[str]:
+    """
+    Derive absolute `_lx.js` chunk URLs from the landing page's `#parcels`
+    manifest, in document order with duplicates removed.
+
+    Multi-parcel (merge-settings / multivolume) mirrors reference their
+    per-parcel landmark chunks only through this runtime-parsed tree — there
+    are no static `<script src="..._lx.js">` tags. The derivation mirrors
+    Parcels.Add in the runtime's connect.js: resolve each parcel anchor's
+    href against the base URL, strip the extension when the last '.' follows
+    the last '/', and append '_lx.js'. Hrefs stay URL-encoded — the chunk is
+    fetched at the encoded URL, exactly as the browser does.
+
+    Returns [] when the page has no usable `#parcels` tree, so discovery
+    falls back to the `_lx-manifest.json` probe and the `<script src>` scrape.
+    """
+    extractor = _ParcelAnchorExtractor()
+    extractor.feed(html)
+    extractor.close()
+
+    base = _ensure_slash(base_url)
+    seen: set[str] = set()
+    result: list[str] = []
+    for href in extractor.hrefs:
+        absolute = urllib.parse.urljoin(base, href)
+        last_dot = absolute.rfind('.')
+        last_slash = absolute.rfind('/')
+        prefix = absolute[:last_dot] if last_dot > last_slash else absolute
+        chunk_url = prefix + '_lx.js'
+        if chunk_url not in seen:
+            seen.add(chunk_url)
+            result.append(chunk_url)
+    return result
+
+
 def extract_generation_hash(html: str) -> Optional[str]:
     """
     Return the `GLOBAL_GENERATION_HASH` constant emitted into the landing page,
@@ -775,8 +867,9 @@ def remote_chunk_texts(
     Return a list of (chunk_url, chunk_bytes) ready for build_index_from_texts.
 
     Pure orchestrator: composes cache_decision, the landing-page fetch, the
-    manifest probe, the HTML scrape, and the cache write. Network access is
-    confined to the `fetcher` callable so tests can stub it end-to-end.
+    `#parcels` manifest parse, the manifest probe, the HTML scrape, and the
+    cache write. Network access is confined to the `fetcher` callable so
+    tests can stub it end-to-end.
     """
     base_url = _ensure_slash(base_url)
     timestamp = _now() if now is None else now
@@ -818,8 +911,11 @@ def remote_chunk_texts(
             "falling back to TTL-only caching."
         )
 
-    discovered: Optional[list[str]] = probe_manifest(base_url, fetcher, timeout)
-    discovery_method = 'manifest'
+    discovered: Optional[list[str]] = extract_parcel_chunk_urls(landing_html, base_url)
+    discovery_method = 'parcels'
+    if not discovered:
+        discovered = probe_manifest(base_url, fetcher, timeout)
+        discovery_method = 'manifest'
     if discovered is None or not discovered:
         discovered = extract_chunk_srcs_from_html(landing_html, base_url)
         discovery_method = 'html-scrape'
@@ -827,8 +923,9 @@ def remote_chunk_texts(
     if not discovered:
         raise RemoteFetchError(
             base_url,
-            "no _lx.js chunks discovered (tried _lx-manifest.json probe and "
-            "<script src=…_lx.js> scrape of the landing page)",
+            "no _lx.js chunks discovered (tried the #parcels manifest parse "
+            "of the landing page, the _lx-manifest.json probe, and the "
+            "<script src=…_lx.js> scrape)",
         )
 
     debug_log(f"remote_chunk_texts: discovered {len(discovered)} chunk(s) via {discovery_method}")
@@ -966,15 +1063,20 @@ def _format_remote_rewrite_url(base_url: str, resolved_path: str) -> str:
     Compose `<base_url><quoted-path>[#anchor]` for remote rewrite output.
 
     Splits `resolved_path` on the first `#` (anchor boundary). The path portion
-    is percent-quoted via urllib.parse.quote(safe='/') so spaces become %20 but
-    path separators stay as `/`. The anchor portion is appended verbatim — the
-    runtime's GetPathById emits anchors that are already URL-safe.
+    is percent-quoted via urllib.parse.quote(safe='/%') so spaces become %20,
+    path separators stay as `/`, and existing %xx escapes survive unchanged —
+    multi-parcel (merge-settings) mirrors emit pre-encoded `f` arrays, and
+    re-quoting them would double-encode `%20` into a 404ing `%2520`. Keeping
+    `%` safe matches the browser runtime, which never re-encodes the escape
+    character when it resolves these paths. The anchor portion is appended
+    verbatim — the runtime's GetPathById emits anchors that are already
+    URL-safe.
     """
     base = _ensure_slash(base_url)
     if '#' in resolved_path:
         path_part, anchor = resolved_path.split('#', 1)
-        return base + urllib.parse.quote(path_part, safe='/') + '#' + anchor
-    return base + urllib.parse.quote(resolved_path, safe='/')
+        return base + urllib.parse.quote(path_part, safe='/%') + '#' + anchor
+    return base + urllib.parse.quote(resolved_path, safe='/%')
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/landing-multi-parcel.html
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/landing-multi-parcel.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Reverb 2.0 — Multi-parcel (merge-settings) landing fixture</title>
+    <!-- No GLOBAL_GENERATION_HASH literal and no <script src="..._lx.js"> tags:
+         multivolume mirrors carry the hash only in ?v= query strings and
+         reference per-parcel chunks only through the #parcels tree below. -->
+    <script src="connect.js?v=feedc0de1234"></script>
+    <link rel="stylesheet" href="skin.css?v=feedc0de1234">
+</head>
+<body>
+    <div id="page_div"></div>
+    <div id="parcels" style="display: none;">
+        <ul role="tree">
+            <li id="group:4f2f7c29-1111-2222-3333-444455556666" data-group-title="Getting Started" role="treeitem" aria-expanded="false">
+                <div class="ww_skin_toc_entry ww_skin_toc_folder">
+                    <div class="ww_skin_toc_entry_indent"></div>
+                    <a class="ww_skin_toc_entry_title" id="group:4f2f7c29-1111-2222-3333-444455556666" href="Getting%20Started.html" target="_self" title="Getting Started">Getting Started</a>
+                </div>
+            </li>
+            <li id="group:aaaabbbb-0000-0000-0000-000000000001:aaaabbbb-0000-0000-0000-000000000002" data-group-title="User Guides" role="treeitem" aria-expanded="false">
+                <div class="ww_skin_toc_entry ww_skin_toc_folder">
+                    <div class="ww_skin_toc_entry_indent"></div>
+                    <span class="ww_skin_toc_entry_title" title="User Guides">User Guides</span>
+                </div>
+                <ul role="group">
+                    <li id="group:aaaabbbb-0000-0000-0000-000000000001" data-group-title="Volume A" role="treeitem" aria-expanded="false">
+                        <div class="ww_skin_toc_entry ww_skin_toc_folder">
+                            <a class="ww_skin_toc_entry_title" id="group:aaaabbbb-0000-0000-0000-000000000001" href="Volume%20A.html" target="_self" title="Volume A">Volume A</a>
+                        </div>
+                    </li>
+                    <li id="group:aaaabbbb-0000-0000-0000-000000000002" data-group-title="Reference" role="treeitem" aria-expanded="false">
+                        <div class="ww_skin_toc_entry ww_skin_toc_folder">
+                            <a class="ww_skin_toc_entry_title" id="group:aaaabbbb-0000-0000-0000-000000000002" href="Reference.html" target="_self" title="Reference">Reference</a>
+                        </div>
+                    </li>
+                </ul>
+            </li>
+            <!-- The runtime skips anchors whose id is not "<context>:<id>". -->
+            <li><a href="not-a-parcel.html">plain link without a parcel id</a></li>
+            <!-- Duplicate parcel anchor: collapses to one chunk fetch. -->
+            <li id="group:aaaabbbb-0000-0000-0000-000000000001" data-group-title="Volume A" role="treeitem">
+                <div class="ww_skin_toc_entry">
+                    <a class="ww_skin_toc_entry_title" id="group:aaaabbbb-0000-0000-0000-000000000001" href="Volume%20A.html" target="_self">Volume A</a>
+                </div>
+            </li>
+        </ul>
+    </div>
+    <!-- Outside #parcels: must be ignored even with a parcel-shaped id. -->
+    <a id="group:00000000-dead-beef-0000-000000000000" href="Outside.html">not a parcel</a>
+</body>
+</html>

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/verify-landmark-resolver.py
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/verify-landmark-resolver.py
@@ -35,6 +35,7 @@ MULTI_DIR = FIXTURE_DIR  # contains every *_lx.js fixture
 UNICODE_CHUNK = FIXTURE_DIR / 'unicode-ids_lx.js'
 LANDING_WITH_HASH = FIXTURE_DIR / 'landing-with-hash.html'
 LANDING_NO_HASH = FIXTURE_DIR / 'landing-no-hash.html'
+LANDING_MULTI_PARCEL = FIXTURE_DIR / 'landing-multi-parcel.html'
 LX_MANIFEST = FIXTURE_DIR / 'lx-manifest.json'
 
 
@@ -709,6 +710,54 @@ def test_extract_generation_hash() -> None:
     )
 
 
+def test_extract_parcel_chunk_urls_basic() -> None:
+    html = LANDING_MULTI_PARCEL.read_text(encoding='utf-8')
+    urls = resolver.extract_parcel_chunk_urls(html, 'https://x.example/help/')
+    expected = [
+        'https://x.example/help/Getting%20Started_lx.js',
+        'https://x.example/help/Volume%20A_lx.js',
+        'https://x.example/help/Reference_lx.js',
+    ]
+    check(
+        "extract_parcel_chunk_urls: encoded chunk URLs in order, dedupes, skips non-parcel anchors",
+        urls == expected,
+        f"got {urls}",
+    )
+
+
+def test_extract_parcel_chunk_urls_absent() -> None:
+    html = LANDING_WITH_HASH.read_text(encoding='utf-8')
+    check(
+        "extract_parcel_chunk_urls: returns [] when the page has no #parcels tree",
+        resolver.extract_parcel_chunk_urls(html, 'https://x.example/help/') == [],
+    )
+    check(
+        "extract_parcel_chunk_urls: returns [] for an empty #parcels div",
+        resolver.extract_parcel_chunk_urls(
+            '<div id="parcels"><ul role="tree"></ul></div>',
+            'https://x.example/help/',
+        ) == [],
+    )
+
+
+def test_extract_parcel_chunk_urls_extension_rule() -> None:
+    html = (
+        '<div id="parcels"><ul>'
+        '<li><a id="group:g1" href="sub.dir/Nested%20Volume.html">n</a></li>'
+        '<li><a id="group:g2" href="NoExtension">x</a></li>'
+        '</ul></div>'
+    )
+    urls = resolver.extract_parcel_chunk_urls(html, 'https://x.example/help/')
+    check(
+        "extract_parcel_chunk_urls: strips extension only after the last '/' (mirrors Parcels.Add)",
+        urls == [
+            'https://x.example/help/sub.dir/Nested%20Volume_lx.js',
+            'https://x.example/help/NoExtension_lx.js',
+        ],
+        f"got {urls}",
+    )
+
+
 def _make_remote_chunks_responses(landing_html: str, manifest_status: int = 404) -> dict:
     """Build a stub-fetcher response map for a base URL exposing the unicode fixture chunks."""
     chunk_bytes = SINGLE_CHUNK.read_bytes()
@@ -903,7 +952,8 @@ def test_remote_chunk_texts_empty_discovery_raises(tmp_path: Path) -> None:
     except resolver.RemoteFetchError as e:
         check(
             "remote_chunk_texts: empty discovery raises RemoteFetchError naming base URL and methods",
-            base in str(e) and 'manifest' in str(e).lower() and 'scrape' in str(e).lower(),
+            base in str(e) and 'parcels' in str(e).lower()
+            and 'manifest' in str(e).lower() and 'scrape' in str(e).lower(),
             f"error={e}",
         )
 
@@ -931,6 +981,127 @@ def test_remote_chunk_texts_manifest_preferred(tmp_path: Path) -> None:
         chunk_bytes == [b"chunk A from manifest", b"chunk B from manifest"]
         and (base + 'C_lx.js') not in fetched_urls,
         f"chunk_bytes={chunk_bytes}, fetched={fetched_urls}",
+    )
+
+
+def test_format_remote_rewrite_url_preencoded() -> None:
+    """Multi-parcel mirrors emit pre-encoded `f` arrays; re-quoting them would
+    double-encode %20 into a 404ing %2520. '%' stays in the safe set, matching
+    the browser runtime, which never re-encodes the escape character."""
+    pre = resolver._format_remote_rewrite_url(
+        'https://x.example/help/',
+        'Advanced%20Customizations/_xslt-extensions.04.1.html#wwp100003',
+    )
+    check(
+        "_format_remote_rewrite_url: pre-encoded paths are not double-encoded",
+        pre == 'https://x.example/help/Advanced%20Customizations/_xslt-extensions.04.1.html#wwp100003',
+        f"got {pre}",
+    )
+    raw = resolver._format_remote_rewrite_url(
+        'https://x.example/help/',
+        'Advanced Customizations/page.html',
+    )
+    check(
+        "_format_remote_rewrite_url: raw spaces are still percent-quoted",
+        raw == 'https://x.example/help/Advanced%20Customizations/page.html',
+        f"got {raw}",
+    )
+
+
+def test_remote_chunk_texts_parcels_discovery(tmp_path: Path) -> None:
+    """Issue #111: multi-parcel (merge-settings) mirror — chunks reachable only
+    through the #parcels manifest, no _lx-manifest.json, no <script src> tags,
+    no GLOBAL_GENERATION_HASH literal."""
+    base = 'https://mv.example/help/'
+    chunk_bytes = SINGLE_CHUNK.read_bytes()
+    responses = {
+        base: (200, LANDING_MULTI_PARCEL.read_bytes()),
+        base + 'Getting%20Started_lx.js': (200, chunk_bytes),
+        base + 'Volume%20A_lx.js': (200, chunk_bytes),
+        base + 'Reference_lx.js': (200, chunk_bytes),
+    }
+    fetcher = StubFetcher(responses)
+    cache_dir = tmp_path / 'cache'
+
+    with _StderrCapture() as cap:
+        chunks = resolver.remote_chunk_texts(
+            base_url=base, cache_dir=cache_dir, ttl=3600.0, no_cache=False,
+            fetcher=fetcher, now=1000.0,
+        )
+    chunk_urls = [u for u, _ in chunks]
+    probe_calls = [c for c in fetcher.calls if c[0].endswith('_lx-manifest.json')]
+    check(
+        "remote_chunk_texts: multi-parcel mirror discovers chunks via #parcels (no manifest probe)",
+        chunk_urls == [
+            base + 'Getting%20Started_lx.js',
+            base + 'Volume%20A_lx.js',
+            base + 'Reference_lx.js',
+        ] and not probe_calls,
+        f"chunk_urls={chunk_urls}, probe_calls={probe_calls}",
+    )
+
+    cached_names = set(p.name for p in cache_dir.iterdir())
+    check(
+        "remote_chunk_texts: multi-parcel chunks cached under their encoded names",
+        cached_names == {
+            'Getting%20Started_lx.js', 'Volume%20A_lx.js', 'Reference_lx.js',
+            '_manifest.json',
+        },
+        f"cached={cached_names}",
+    )
+
+    check(
+        "remote_chunk_texts: multi-parcel mirror still warns about the missing generation hash",
+        'GLOBAL_GENERATION_HASH' in cap.read(),
+        f"stderr={cap.read()[:200]!r}",
+    )
+
+
+def test_remote_chunk_texts_parcels_preferred(tmp_path: Path) -> None:
+    """When a landing page has a #parcels tree AND script tags AND a manifest,
+    the #parcels parse wins and nothing else is probed or fetched."""
+    base = 'https://both.example/help/'
+    chunk_bytes = SINGLE_CHUNK.read_bytes()
+    landing_html = (
+        '<html><head>'
+        '<script src="Flat_lx.js"></script>'
+        '<script>var GLOBAL_GENERATION_HASH = "hash42";</script>'
+        '</head><body>'
+        '<div id="parcels"><ul>'
+        '<li><a id="group:g1" href="Parcel%20One.html">Parcel One</a></li>'
+        '</ul></div>'
+        '</body></html>'
+    )
+    responses = {
+        base: (200, landing_html.encode('utf-8')),
+        base + '_lx-manifest.json': (200, LX_MANIFEST.read_bytes()),
+        base + 'Parcel%20One_lx.js': (200, chunk_bytes),
+        base + 'Flat_lx.js': (200, chunk_bytes),
+        base + 'A_lx.js': (200, chunk_bytes),
+        base + 'B_lx.js': (200, chunk_bytes),
+    }
+    fetcher = StubFetcher(responses)
+    cache_dir = tmp_path / 'cache'
+
+    chunks = resolver.remote_chunk_texts(
+        base_url=base, cache_dir=cache_dir, ttl=3600.0, no_cache=False,
+        fetcher=fetcher, now=1000.0,
+    )
+    chunk_urls = [u for u, _ in chunks]
+    fetched = [c[0] for c in fetcher.calls]
+    check(
+        "remote_chunk_texts: #parcels wins over the manifest probe and the script scrape",
+        chunk_urls == [base + 'Parcel%20One_lx.js']
+        and (base + '_lx-manifest.json') not in fetched
+        and (base + 'Flat_lx.js') not in fetched,
+        f"chunk_urls={chunk_urls}, fetched={fetched}",
+    )
+
+    manifest = resolver.read_cache_manifest(cache_dir)
+    check(
+        "remote_chunk_texts: generation hash still recorded with #parcels discovery",
+        manifest is not None and manifest.get('generation_hash') == 'hash42',
+        f"manifest={manifest}",
     )
 
 
@@ -1292,6 +1463,65 @@ resolver.default_fetcher = stub
 
 sys.exit(resolver.main())
 '''
+
+
+def _make_multi_parcel_wrapper_script(base: str, landing_html: bytes, chunk_payload: bytes) -> str:
+    """Wrapper that stubs default_fetcher with multi-parcel mirror responses."""
+    return f'''
+import importlib.util
+import sys
+
+SCRIPT_PATH = {str(SCRIPT_PATH)!r}
+spec = importlib.util.spec_from_file_location("resolve_landmarks", SCRIPT_PATH)
+resolver = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(resolver)
+
+BASE = {base!r}
+LANDING_HTML = {landing_html!r}
+CHUNK_PAYLOAD = {chunk_payload!r}
+
+responses = {{
+    BASE: (200, LANDING_HTML),
+    BASE + 'Getting%20Started_lx.js': (200, CHUNK_PAYLOAD),
+    BASE + 'Volume%20A_lx.js': (200, CHUNK_PAYLOAD),
+    BASE + 'Reference_lx.js': (200, CHUNK_PAYLOAD),
+}}
+
+def stub(url, *, method='GET', timeout=10.0):
+    if url not in responses:
+        raise resolver.RemoteFetchError(url, "stub: no response")
+    return responses[url]
+
+resolver.default_fetcher = stub
+sys.exit(resolver.main())
+'''
+
+
+def test_cli_rewrite_multi_parcel_mirror(tmp_path: Path) -> None:
+    """Issue #111 repro: rewrite a stable URL against a multi-parcel mirror
+    whose chunks are reachable only through the #parcels manifest. Before the
+    fix this exited 2 with 'no _lx.js chunks discovered'."""
+    base = 'https://mv-cli.example/help/'
+    wrapper = tmp_path / 'wrapper.py'
+    wrapper.write_text(_make_multi_parcel_wrapper_script(
+        base=base,
+        landing_html=LANDING_MULTI_PARCEL.read_bytes(),
+        chunk_payload=SINGLE_CHUNK.read_bytes(),
+    ), encoding='utf-8')
+    proc = subprocess.run(
+        [sys.executable, str(wrapper),
+         'rewrite', base + '#/abc1234567890def',
+         '--cache-dir', str(tmp_path / 'cache'),
+         '--cache-ttl', '3600'],
+        capture_output=True, text=True,
+        env={**os.environ, 'PYTHONIOENCODING': 'utf-8'},
+    )
+    expected = base + 'Group/page.html#wwp100'
+    check(
+        "CLI rewrite (remote, multi-parcel): resolves via #parcels discovery (issue #111)",
+        proc.returncode == 0 and proc.stdout.strip() == expected,
+        f"rc={proc.returncode}, stdout={proc.stdout!r}, stderr={proc.stderr!r}",
+    )
 
 
 def test_cli_dump_remote_mode(tmp_path: Path) -> None:
@@ -2120,6 +2350,10 @@ def main() -> int:
     test_extract_chunk_srcs_basic()
     test_extract_chunk_srcs_quote_variants()
     test_extract_generation_hash()
+    test_extract_parcel_chunk_urls_basic()
+    test_extract_parcel_chunk_urls_absent()
+    test_extract_parcel_chunk_urls_extension_rule()
+    test_format_remote_rewrite_url_preencoded()
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         test_remote_chunk_texts_first_call_writes_cache(tmp_path)
@@ -2145,6 +2379,12 @@ def main() -> int:
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         test_remote_chunk_texts_manifest_preferred(tmp_path)
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        test_remote_chunk_texts_parcels_discovery(tmp_path)
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        test_remote_chunk_texts_parcels_preferred(tmp_path)
 
     # CLI: resolve, dump, rewrite (local mode)
     test_cli_resolve_happy_single()
@@ -2173,6 +2413,9 @@ def main() -> int:
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         test_cli_resolve_remote_mode_via_proxy_script(tmp_path)
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        test_cli_rewrite_multi_parcel_mirror(tmp_path)
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         test_cli_dump_remote_mode(tmp_path)

--- a/plugins/webworks-agent-skills/skills/reverb2/workflows/landmark-resolution.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/workflows/landmark-resolution.md
@@ -55,6 +55,14 @@ python scripts/resolve-landmarks.py rewrite \
     "https://static.webworks.com/docs/epublisher/latest/help/#/e5d3d31c42d8d1d4"
 ```
 
+**Chunk discovery.** Remote mode discovers `_lx.js` chunks from the landing page in precedence order — the first non-empty source wins:
+
+1. **`#parcels` manifest parse** — multi-parcel / merge-settings (multivolume) mirrors reference their per-parcel chunks only through the runtime-parsed `#parcels` tree; each parcel anchor `href="<Name>.html"` maps to a sibling chunk `<Name>_lx.js` (names stay URL-encoded), exactly as `connect.js` derives them at load time.
+2. **`_lx-manifest.json` probe** — a forward-compatible manifest file at the base URL (Reverb does not currently emit one).
+3. **`<script src="..._lx.js">` scrape** — single-build / flat mirrors that load chunks via static script tags.
+
+If all three find nothing, the resolver exits `2` with an error naming every discovery path it tried.
+
 ### Step 1c: Lookup table (pre-built artifact)
 
 Point `--lookup-table` at a JSON file produced by `dump`:
@@ -114,7 +122,7 @@ The resolver returns paths exactly as the Reverb runtime's `GetPathById()` does:
 - **Empty anchor** → bare file path (e.g., `Group/page.html`)
 - **Non-empty anchor** → `file#anchor` (e.g., `Group/page.html#wwp100`)
 
-In remote mode, `rewrite` percent-quotes the path portion of the output URL so it is paste-ready for HTTP fetch tools. Spaces become `%20`; path separators (`/`) stay as `/`. The fragment portion (`#anchor`) is left as-is — runtime anchors are already URL-safe.
+In remote mode, `rewrite` percent-quotes the path portion of the output URL so it is paste-ready for HTTP fetch tools. Spaces become `%20`; path separators (`/`) stay as `/`; existing `%xx` escapes survive unchanged (multi-parcel mirrors emit pre-encoded paths in their chunks — re-quoting would double-encode them). The fragment portion (`#anchor`) is left as-is — runtime anchors are already URL-safe.
 
 If an ID appears multiple times in the chunks (typical: one page-level row at anchor index 0, one paragraph-level row at a specific anchor), the resolver applies **last-write-wins** — which usually returns the paragraph-level `file#anchor` form. This matches the runtime contract.
 
@@ -132,7 +140,7 @@ Within that root, each base URL gets its own directory keyed by `<host>/<percent
 
 **Invalidation:** Reverb 2.0 emits a `GLOBAL_GENERATION_HASH` constant into each build's landing page. The resolver caches that hash alongside the chunks; when the mirror rebuilds, the next remote invocation after `--cache-ttl` seconds sees a new hash and re-fetches every chunk atomically. Within the TTL window, the resolver uses cached chunks without any network access.
 
-If a mirror ships without `GLOBAL_GENERATION_HASH`, the resolver falls back to TTL-only invalidation and prints a one-line warning to stderr.
+If a mirror ships without `GLOBAL_GENERATION_HASH`, the resolver falls back to TTL-only invalidation and prints a one-line warning to stderr. Multi-parcel (merge-settings) mirrors never carry the literal in their landing page — it lives only in `?v=` query strings and inside `connect.js` — so the warning is expected there and resolution still succeeds.
 
 **Force a refresh:** pass `--no-cache` to skip every cache check for that invocation.
 
@@ -302,16 +310,17 @@ python scripts/resolve-landmarks.py \
     rewrite "https://static.webworks.com/docs/epublisher/latest/help/#/e5d3d31c42d8d1d4"
 ```
 
-Expected output:
+Expected output (the published help is a multi-parcel mirror; the exact path tracks its current build):
 
 ```
-https://static.webworks.com/docs/epublisher/latest/help/Advanced%20Customizations/_xslt-extensions.04.1.html
+https://static.webworks.com/docs/epublisher/latest/help/Advanced%20Customizations_%20Overrides_%20and%20Extensions/_xslt-extensions.04.1.html#wwp100003
 ```
 
 Notes:
-- First invocation fetches the landing page, reads `GLOBAL_GENERATION_HASH`, fetches every discovered `_lx.js` chunk, and caches them under `%LOCALAPPDATA%\webworks\reverb-landmarks\static.webworks.com\docs%2Fepublisher%2Flatest%2Fhelp%2F\` (Windows) or the equivalent macOS/Linux path.
+- First invocation fetches the landing page, discovers the per-parcel `_lx.js` chunks from its `#parcels` manifest, fetches them, and caches them under `%LOCALAPPDATA%\webworks\reverb-landmarks\static.webworks.com\docs%2Fepublisher%2Flatest%2Fhelp%2F\` (Windows) or the equivalent macOS/Linux path.
+- This mirror carries no `GLOBAL_GENERATION_HASH` literal in its landing page, so the resolver prints a one-line TTL-only-caching warning to stderr — expected, not a failure.
 - Subsequent invocations within 24 hours use the cache directly — no network access.
-- Spaces in the resolved path are percent-quoted in the output URL (`Advanced Customizations` → `Advanced%20Customizations`) so the URL is paste-ready for `curl`, `wget`, or any HTTP fetch tool.
+- The resolved path is percent-quoted in the output URL so it is paste-ready for `curl`, `wget`, or any HTTP fetch tool. Paths that arrive pre-encoded from the chunks (multi-parcel mirrors) are left as-is — never double-encoded.
 
 ## Worked Example: Local Mirror
 


### PR DESCRIPTION
Closes #111

## Problem

`resolve-landmarks.py` remote mode discovered `_lx.js` chunks two ways — the `_lx-manifest.json` probe and the `<script src="..._lx.js">` scrape. Multi-parcel / merge-settings (multivolume) Reverb 2.0 mirrors reference their per-parcel chunks **only** through the runtime-parsed `#parcels` tree, so the resolver found zero chunks and exited 2 on exactly the published multivolume help mirrors people most want to resolve against.

## Fix

**Primary discovery via `#parcels`** — `extract_parcel_chunk_urls()` parses the landing page's `#parcels` subtree with a stdlib `HTMLParser` (same div-counting approach as `lint-output.py`'s `ManifestParser`) and mirrors the runtime exactly:

- Anchor filter matches `Parcels.PrepareForLoad` in `connect.js`: an anchor counts as a parcel anchor when its `id` has the form `<context>:<id>` with a non-empty context.
- Chunk derivation matches `Parcels.Add`: resolve the anchor's href against the base URL, strip the extension only when the last `.` follows the last `/`, append `_lx.js`. Hrefs stay URL-encoded.

The `_lx-manifest.json` probe and the script scrape remain as fallbacks for single-build / flat mirrors, and the exit-2 error now names all three paths.

**Rewrite double-encoding fix** — surfaced immediately by the new discovery: multi-parcel mirrors emit pre-encoded `f` arrays (`Advanced%20Customizations...`), and `quote(safe='/')` re-encoded them into a 404ing `%2520`. `%` joins the safe set, matching the browser runtime, which never re-encodes the escape character. Raw paths with spaces still quote to `%20` (covered by existing tests).

## Testing

- New `landing-multi-parcel.html` fixture modeled on the generated `connect.xsl` markup (nested TOC group, encoded names, duplicate anchor, non-parcel anchors inside and outside `#parcels`, no hash literal, no script tags).
- 12 new verifier checks: extraction order/dedup/filters, the `Parcels.Add` extension rule, precedence over probe and scrape, cache contents under encoded names, expected missing-hash warning, double-encoding regression, and a CLI end-to-end repro of the issue. Suite: **130/130 pass**.
- Verified live against the published help: `rewrite "https://static.webworks.com/docs/epublisher/latest/help/#/e5d3d31c42d8d1d4"` (the issue's repro, previously exit 2) now resolves via `#parcels` discovery and the emitted URL fetches HTTP 200.

## Docs

`workflows/landmark-resolution.md` documents the three-path discovery order, notes the expected TTL-only-caching warning on multivolume mirrors, and refreshes the remote worked example against the current published help. Version bumped to 3.3.1 (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)