### PR TITLE
Closes #118: Python tool template, UTF-8 retrofit of existing tools, and static checker

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "webworks-agent-skills",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "owner": {
     "name": "Quadralay Corporation",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,10 @@ The script updates both `plugin.json` and `marketplace.json` to keep versions sy
 3. Include the version bump in your PR
 4. Merge PR - version is already updated
 
+## New Python Tools
+
+Create new skill Python tools by copying `templates/skill-python-tool.py` — it bakes in the UTF-8 conventions (stdio reconfigure, `PYTHONUTF8` for children, explicit encodings on file and subprocess I/O) that Windows locale codepages otherwise break. Rules in CONTRIBUTING.md "New Python Tools".
+
 ## Documented Solutions
 
 `docs/solutions/` — documented solutions to past problems (bugs, best practices, workflow patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in documented areas.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,14 @@ Start new Python tools from [`templates/skill-python-tool.py`](templates/skill-p
 
 Rules 2 and 3 are per-call-site because UTF-8 mode cannot be enabled retroactively for a running interpreter — `ensure_utf8()` covers children and stdio only.
 
+Verify before submitting a PR:
+
+```bash
+python scripts/check-python-utf8.py
+```
+
+The checker statically enforces all three rules (plus the entry-point preamble) across `plugins/`, `templates/`, and `scripts/`, and exits 1 with `file:line` findings on any violation.
+
 ## Versioning
 
 Bump the plugin version **before creating a PR** using the bump script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,16 @@ See [docs/solutions/bash-syntax-errors-in-skill-tables.md](docs/solutions/bash-s
 - **Documentation:** Clear language with examples
 - **Testing:** Validate with real ePublisher projects
 
+### New Python Tools
+
+Start new Python tools from [`templates/skill-python-tool.py`](templates/skill-python-tool.py). ePublisher content is Unicode-first (Japanese outputs, CJK landmark IDs, non-ASCII group names), and Python on Windows defaults console I/O, subprocess pipes, and text-mode file I/O to the locale codepage (cp1252/cp932) — so a tool written without explicit encodings breaks on real projects the first time it meets non-ASCII content (#118). The template bakes in the three rules:
+
+1. Call `ensure_utf8()` first thing in `main()` — Python children spawned later start in full UTF-8 mode, and the tool's own stdout/stderr print Unicode safely on any console.
+2. Always pass `encoding='utf-8'` to text-mode `open()` / `read_text()` / `write_text()`.
+3. Never use bare `text=True` with `subprocess.run` — use the template's `run_utf8()` or pass `encoding='utf-8'` explicitly (pipe decoding ignores `PYTHONIOENCODING`).
+
+Rules 2 and 3 are per-call-site because UTF-8 mode cannot be enabled retroactively for a running interpreter — `ensure_utf8()` covers children and stdio only.
+
 ## Versioning
 
 Bump the plugin version **before creating a PR** using the bump script:

--- a/plugins/webworks-agent-skills/.claude-plugin/plugin.json
+++ b/plugins/webworks-agent-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webworks-agent-skills",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "author": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/skills/automap/scripts/create-job.py
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/create-job.py
@@ -31,6 +31,7 @@ Exit Codes:
 
 import argparse
 import json
+import os
 import sys
 # Use defusedxml to prevent XXE attacks (CWE-611)
 import defusedxml.ElementTree as ET
@@ -565,7 +566,24 @@ def generate_template(stationery_data: dict, stationery_path: str) -> dict:
     return config
 
 
+def ensure_utf8() -> None:
+    """Make this tool Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault only
+    affects Python children spawned later; the reconfigure handles this
+    process's own stdio on locale-codepage consoles (Windows cp1252).
+    See CONTRIBUTING.md "New Python Tools".
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
 def main() -> int:
+    ensure_utf8()
     parser = argparse.ArgumentParser(
         description='Create AutoMap job files (.waj) interactively or from configuration.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -626,7 +644,7 @@ Examples:
             return EXIT_FILE_ERROR
 
         try:
-            with open(config_path) as f:
+            with open(config_path, encoding='utf-8') as f:
                 config = json.load(f)
         except json.JSONDecodeError as e:
             log_error(f"Invalid JSON in config file: {e}")

--- a/plugins/webworks-agent-skills/skills/automap/scripts/list-job-targets.py
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/list-job-targets.py
@@ -22,6 +22,7 @@ Exit Codes:
 
 import argparse
 import json
+import os
 import sys
 # Use defusedxml to prevent XXE attacks (CWE-611)
 import defusedxml.ElementTree as ET
@@ -228,7 +229,24 @@ def output_json(targets: list[dict]) -> None:
     print(json.dumps(targets, indent=2))
 
 
+def ensure_utf8() -> None:
+    """Make this tool Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault only
+    affects Python children spawned later; the reconfigure handles this
+    process's own stdio on locale-codepage consoles (Windows cp1252).
+    See CONTRIBUTING.md "New Python Tools".
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
 def main() -> int:
+    ensure_utf8()
     parser = argparse.ArgumentParser(
         description='List targets from AutoMap job files (.waj).',
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/plugins/webworks-agent-skills/skills/automap/scripts/parse-job.py
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/parse-job.py
@@ -24,6 +24,7 @@ Exit Codes:
 
 import argparse
 import json
+import os
 import sys
 # Use defusedxml to prevent XXE attacks (CWE-611)
 import defusedxml.ElementTree as ET
@@ -235,7 +236,24 @@ def output_config(job_info: dict) -> None:
     print(json.dumps(config, indent=2))
 
 
+def ensure_utf8() -> None:
+    """Make this tool Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault only
+    affects Python children spawned later; the reconfigure handles this
+    process's own stdio on locale-codepage consoles (Windows cp1252).
+    See CONTRIBUTING.md "New Python Tools".
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
 def main() -> int:
+    ensure_utf8()
     parser = argparse.ArgumentParser(
         description='Parse AutoMap job files (.waj) to extract configuration.',
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/plugins/webworks-agent-skills/skills/automap/scripts/parse-stationery.py
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/parse-stationery.py
@@ -24,6 +24,7 @@ Exit Codes:
 
 import argparse
 import json
+import os
 import sys
 # Use defusedxml to prevent XXE attacks (CWE-611)
 import defusedxml.ElementTree as ET
@@ -231,7 +232,24 @@ def output_json(stationery_path: str, runtime_version: str,
     print(json.dumps(data, indent=2))
 
 
+def ensure_utf8() -> None:
+    """Make this tool Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault only
+    affects Python children spawned later; the reconfigure handles this
+    process's own stdio on locale-codepage consoles (Windows cp1252).
+    See CONTRIBUTING.md "New Python Tools".
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
 def main() -> int:
+    ensure_utf8()
     parser = argparse.ArgumentParser(
         description='Parse ePublisher Stationery files (.wxsp) to extract formats, settings, and file mappings.',
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/plugins/webworks-agent-skills/skills/automap/scripts/validate-job.py
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/validate-job.py
@@ -23,6 +23,7 @@ Exit Codes:
 """
 
 import argparse
+import os
 import sys
 # Use defusedxml to prevent XXE attacks (CWE-611)
 import defusedxml.ElementTree as ET
@@ -296,7 +297,24 @@ def validate_target_formats(root: Element, stationery_path: Path) -> ValidationR
         return result.fail_check("No valid formats")
 
 
+def ensure_utf8() -> None:
+    """Make this tool Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault only
+    affects Python children spawned later; the reconfigure handles this
+    process's own stdio on locale-codepage consoles (Windows cp1252).
+    See CONTRIBUTING.md "New Python Tools".
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
 def main() -> int:
+    ensure_utf8()
     parser = argparse.ArgumentParser(
         description='Validate AutoMap job files (.waj) for correctness.',
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/plugins/webworks-agent-skills/skills/customization-audit/scripts/audit-overrides.py
+++ b/plugins/webworks-agent-skills/skills/customization-audit/scripts/audit-overrides.py
@@ -46,6 +46,7 @@ import json
 import re
 import shutil
 import subprocess
+import os
 import sys
 import tempfile
 from dataclasses import dataclass, field, asdict
@@ -1627,7 +1628,24 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def ensure_utf8() -> None:
+    """Make this tool Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault only
+    affects Python children spawned later; the reconfigure handles this
+    process's own stdio on locale-codepage consoles (Windows cp1252).
+    See CONTRIBUTING.md "New Python Tools".
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
 def main() -> int:
+    ensure_utf8()
     args = build_parser().parse_args()
     try:
         return args.func(args)

--- a/plugins/webworks-agent-skills/skills/epublisher/scripts/copy-customization.py
+++ b/plugins/webworks-agent-skills/skills/epublisher/scripts/copy-customization.py
@@ -369,8 +369,25 @@ def perform_copy_customization(
 
     return EXIT_SUCCESS
 
+def ensure_utf8() -> None:
+    """Make this tool Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault only
+    affects Python children spawned later; the reconfigure handles this
+    process's own stdio on locale-codepage consoles (Windows cp1252).
+    See CONTRIBUTING.md "New Python Tools".
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
 def main() -> None:
     """Main entry point"""
+    ensure_utf8()
     parser = argparse.ArgumentParser(
         description="Copy ePublisher installation files while maintaining parallel structure",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/plugins/webworks-agent-skills/skills/epublisher/scripts/parse-targets.py
+++ b/plugins/webworks-agent-skills/skills/epublisher/scripts/parse-targets.py
@@ -181,7 +181,24 @@ def validate_target(targets: list[dict], target_name: str) -> bool:
         return False
 
 
+def ensure_utf8() -> None:
+    """Make this tool Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault only
+    affects Python children spawned later; the reconfigure handles this
+    process's own stdio on locale-codepage consoles (Windows cp1252).
+    See CONTRIBUTING.md "New Python Tools".
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
 def main() -> int:
+    ensure_utf8()
     parser = argparse.ArgumentParser(
         description='Parse ePublisher project files (.wep, .wrp) to extract target and format information.',
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/plugins/webworks-agent-skills/skills/epublisher/scripts/resolve-version-root.py
+++ b/plugins/webworks-agent-skills/skills/epublisher/scripts/resolve-version-root.py
@@ -242,7 +242,24 @@ def build_result(version_root: Path, version: str, source: str) -> dict[str, obj
     }
 
 
+def ensure_utf8() -> None:
+    """Make this tool Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault only
+    affects Python children spawned later; the reconfigure handles this
+    process's own stdio on locale-codepage consoles (Windows cp1252).
+    See CONTRIBUTING.md "New Python Tools".
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
 def main() -> int:
+    ensure_utf8()
     parser = argparse.ArgumentParser(
         description="Resolve ePublisher VersionRoot (deterministic precedence: AUTOMAP_EXE_PATH, Designer registry, AutoMap registry).",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/plugins/webworks-agent-skills/skills/reverb2/scripts/extract-scss-variables.py
+++ b/plugins/webworks-agent-skills/skills/reverb2/scripts/extract-scss-variables.py
@@ -163,7 +163,24 @@ def extract_all_variables(content: str) -> dict:
     return parse_scss_variables(content, r'^\$[a-z_]')
 
 
+def ensure_utf8() -> None:
+    """Make this tool Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault only
+    affects Python children spawned later; the reconfigure handles this
+    process's own stdio on locale-codepage consoles (Windows cp1252).
+    See CONTRIBUTING.md "New Python Tools".
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
 def main() -> int:
+    ensure_utf8()
     parser = argparse.ArgumentParser(
         description='Extract SCSS variable values from Reverb project files.',
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/plugins/webworks-agent-skills/skills/reverb2/scripts/generate-report.py
+++ b/plugins/webworks-agent-skills/skills/reverb2/scripts/generate-report.py
@@ -292,7 +292,7 @@ def parse_json_arg(arg: str) -> Any:
     # Try to read as file
     if Path(arg).exists():
         try:
-            with open(arg) as f:
+            with open(arg, encoding='utf-8') as f:
                 return json.load(f)
         except (json.JSONDecodeError, IOError) as e:
             print(f"{RED}[ERROR]{NC} Failed to read JSON file: {e}", file=sys.stderr)
@@ -303,7 +303,24 @@ def parse_json_arg(arg: str) -> Any:
     return None
 
 
+def ensure_utf8() -> None:
+    """Make this tool Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault only
+    affects Python children spawned later; the reconfigure handles this
+    process's own stdio on locale-codepage consoles (Windows cp1252).
+    See CONTRIBUTING.md "New Python Tools".
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
 def main() -> int:
+    ensure_utf8()
     parser = argparse.ArgumentParser(
         description='Generate human-readable report from Reverb analysis results.',
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/plugins/webworks-agent-skills/skills/reverb2/scripts/lint-output.py
+++ b/plugins/webworks-agent-skills/skills/reverb2/scripts/lint-output.py
@@ -789,7 +789,24 @@ def render_json(output_dir: Path, findings: list[Finding], success: bool) -> str
 # ---------------------------------------------------------------------------
 
 
+def ensure_utf8() -> None:
+    """Make this tool Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault only
+    affects Python children spawned later; the reconfigure handles this
+    process's own stdio on locale-codepage consoles (Windows cp1252).
+    See CONTRIBUTING.md "New Python Tools".
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
 def main() -> int:
+    ensure_utf8()
     parser = argparse.ArgumentParser(
         description='Static linter for WebWorks Reverb 2.0 output directories.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -812,14 +829,6 @@ Examples:
     )
     parser.add_argument('--no-color', action='store_true', help='Disable ANSI color in text output')
     args = parser.parse_args()
-
-    # Findings may contain non-ASCII GroupIDs, paths, or snippets; keep stdout
-    # from choking on a non-UTF-8 console (common on Windows).
-    for stream in (sys.stdout, sys.stderr):
-        try:
-            stream.reconfigure(encoding='utf-8')
-        except (AttributeError, ValueError):
-            pass
 
     output_dir = Path(args.output_dir)
     if not output_dir.is_dir():

--- a/plugins/webworks-agent-skills/skills/reverb2/scripts/parse-url-maps.py
+++ b/plugins/webworks-agent-skills/skills/reverb2/scripts/parse-url-maps.py
@@ -140,7 +140,24 @@ def format_as_table(topics: list[dict]) -> str:
     return '\n'.join(lines)
 
 
+def ensure_utf8() -> None:
+    """Make this tool Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault only
+    affects Python children spawned later; the reconfigure handles this
+    process's own stdio on locale-codepage consoles (Windows cp1252).
+    See CONTRIBUTING.md "New Python Tools".
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
 def main() -> int:
+    ensure_utf8()
     parser = argparse.ArgumentParser(
         description='Parse url_maps.xml from Reverb output to extract CSH link mappings.',
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/plugins/webworks-agent-skills/skills/reverb2/scripts/resolve-landmarks.py
+++ b/plugins/webworks-agent-skills/skills/reverb2/scripts/resolve-landmarks.py
@@ -172,6 +172,22 @@ def _now_iso_utc() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
 
 
+def ensure_utf8() -> None:
+    """Make this tool Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault only
+    affects Python children spawned later; the reconfigure handles this
+    process's own stdio on locale-codepage consoles (Windows cp1252).
+    See CONTRIBUTING.md "New Python Tools".
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
 def debug_log(message: str) -> None:
     """Print debug message to stderr."""
     if DEBUG:
@@ -1386,6 +1402,8 @@ def _add_source_flags(subparser: argparse.ArgumentParser, required: bool) -> Non
 
 
 def main() -> int:
+    ensure_utf8()
+
     parser = argparse.ArgumentParser(
         description='Resolve Reverb 2.0 stable landmark URLs to direct file paths.',
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/verify-landmark-resolver.py
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/verify-landmark-resolver.py
@@ -59,6 +59,22 @@ NC = resolver.NC
 _results: list[tuple[str, bool, str]] = []
 
 
+def ensure_utf8() -> None:
+    """Make this harness Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault only
+    affects Python children spawned later (every run_cli/wrapper subprocess);
+    the reconfigure handles this process's own stdio on locale-codepage
+    consoles (Windows cp1252). See CONTRIBUTING.md "New Python Tools".
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
 def check(name: str, condition: bool, detail: str = '') -> None:
     _results.append((name, condition, detail))
     if condition:
@@ -74,7 +90,8 @@ def run_cli(*cli_args: str, env: Optional[dict] = None) -> subprocess.CompletedP
     return subprocess.run(
         [sys.executable, str(SCRIPT_PATH), *cli_args],
         capture_output=True,
-        text=True,
+        encoding='utf-8',
+        errors='replace',
         env=proc_env,
     )
 
@@ -1380,7 +1397,7 @@ def test_cli_resolve_remote_mode_via_proxy_script(tmp_path: Path) -> None:
          '--cache-dir', str(cache_dir),
          '--cache-ttl', '3600',
          '--http-timeout', '5'],
-        capture_output=True, text=True, env={**os.environ, 'PYTHONIOENCODING': 'utf-8'},
+        capture_output=True, encoding='utf-8', errors='replace',
     )
     expected = 'https://stub.example/help/Advanced%20Customizations/_xslt-extensions.04.1.html#wwp_overview'
     check(
@@ -1405,7 +1422,7 @@ def test_cli_resolve_remote_mode_via_proxy_script(tmp_path: Path) -> None:
          '--cache-dir', str(second_cache),
          '--cache-ttl', '3600',
          '--http-timeout', '5'],
-        capture_output=True, text=True, env={**os.environ, 'PYTHONIOENCODING': 'utf-8'},
+        capture_output=True, encoding='utf-8', errors='replace',
     )
     # Reuse the same cache: second invocation should skip every fetch.
     proc3 = subprocess.run(
@@ -1416,7 +1433,7 @@ def test_cli_resolve_remote_mode_via_proxy_script(tmp_path: Path) -> None:
          '--cache-ttl', '3600',
          '--http-timeout', '5',
          '--block-fetcher'],
-        capture_output=True, text=True, env={**os.environ, 'PYTHONIOENCODING': 'utf-8'},
+        capture_output=True, encoding='utf-8', errors='replace',
     )
     check(
         "CLI resolve (remote): second call against same cache requires no network",
@@ -1513,8 +1530,7 @@ def test_cli_rewrite_multi_parcel_mirror(tmp_path: Path) -> None:
          'rewrite', base + '#/abc1234567890def',
          '--cache-dir', str(tmp_path / 'cache'),
          '--cache-ttl', '3600'],
-        capture_output=True, text=True,
-        env={**os.environ, 'PYTHONIOENCODING': 'utf-8'},
+        capture_output=True, encoding='utf-8', errors='replace',
     )
     expected = base + 'Group/page.html#wwp100'
     check(
@@ -1541,8 +1557,7 @@ def test_cli_dump_remote_mode(tmp_path: Path) -> None:
          'dump', '--remote-base-url', base,
          '--cache-dir', str(cache_dir),
          '--cache-ttl', '3600'],
-        capture_output=True, text=True,
-        env={**os.environ, 'PYTHONIOENCODING': 'utf-8'},
+        capture_output=True, encoding='utf-8', errors='replace',
     )
     try:
         artifact = json.loads(proc.stdout)
@@ -1586,8 +1601,7 @@ sys.exit(resolver.main())
          '--remote-base-url', base,
          '--cache-dir', str(cache_dir),
          '--cache-ttl', '3600'],
-        capture_output=True, text=True,
-        env={**os.environ, 'PYTHONIOENCODING': 'utf-8'},
+        capture_output=True, encoding='utf-8', errors='replace',
     )
     check(
         "CLI remote: 404 on landing page exits 2 and names the URL",
@@ -1914,8 +1928,7 @@ def test_cli_dump_remote_source_block(tmp_path: Path) -> None:
          '--cache-dir', str(cache_dir),
          '--cache-ttl', '3600',
          '--out', str(out)],
-        capture_output=True, text=True,
-        env={**os.environ, 'PYTHONIOENCODING': 'utf-8'},
+        capture_output=True, encoding='utf-8', errors='replace',
     )
     if proc.returncode != 0:
         check("remote-mode dump source block", False,
@@ -2296,6 +2309,8 @@ class _StderrCapture:
 
 
 def main() -> int:
+    ensure_utf8()
+
     if not SCRIPT_PATH.exists():
         print(f"{RED}FAIL:{NC} resolver script not found at {SCRIPT_PATH}", file=sys.stderr)
         return 2

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/verify-lint-output.py
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/verify-lint-output.py
@@ -62,7 +62,8 @@ def run_cli(*cli_args: str) -> subprocess.CompletedProcess:
     return subprocess.run(
         [sys.executable, str(SCRIPT_PATH), *cli_args],
         capture_output=True,
-        text=True,
+        encoding='utf-8',
+        errors='replace',
     )
 
 
@@ -333,7 +334,24 @@ def test_cli_not_a_directory() -> None:
 # Runner
 # ---------------------------------------------------------------------------
 
+def ensure_utf8() -> None:
+    """Make this tool Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault only
+    affects Python children spawned later; the reconfigure handles this
+    process's own stdio on locale-codepage consoles (Windows cp1252).
+    See CONTRIBUTING.md "New Python Tools".
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
 def main() -> int:
+    ensure_utf8()
     tests = [
         test_self_closed_flags_non_void,
         test_self_closed_ignores_void,

--- a/scripts/check-python-utf8.py
+++ b/scripts/check-python-utf8.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+check-python-utf8.py
+
+Static check that every Python tool follows the UTF-8 conventions from
+CONTRIBUTING.md "New Python Tools" (issue #118). Run from the repo root;
+exits 1 with file:line findings when a tool would break on a Windows
+locale-codepage (cp1252/cp932) console.
+
+Rules:
+    entry-point-preamble   A file with a __main__ guard must reconfigure
+                           sys.stdout/sys.stderr to UTF-8 (the template's
+                           ensure_utf8()).
+    subprocess-encoding    No text=True / universal_newlines=True without
+                           encoding= — pipe decoding otherwise uses the
+                           locale codepage (PYTHONIOENCODING is ignored).
+    open-encoding          Builtin text-mode open() must pass encoding=.
+    read-write-text        Path.read_text()/write_text() must pass encoding=.
+
+Usage:
+    python scripts/check-python-utf8.py [root ...]
+
+Roots default to plugins/, templates/, and scripts/ (this checker holds
+itself to the same rules).
+
+Exit codes:
+    0 - Clean.
+    1 - Findings reported.
+    2 - IO or parse failure (file unreadable, syntax error).
+"""
+
+import ast
+import os
+import sys
+from pathlib import Path
+
+# ANSI color codes (shared house style across skill tools)
+RED = '\033[0;31m'
+GREEN = '\033[0;32m'
+YELLOW = '\033[1;33m'
+NC = '\033[0m'
+
+SKIP_DIRS = {'__pycache__', 'node_modules', '.git'}
+
+DEFAULT_ROOTS = ['plugins', 'templates', 'scripts']
+
+
+def ensure_utf8() -> None:
+    """Make this tool Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault only
+    affects Python children spawned later; the reconfigure handles this
+    process's own stdio on locale-codepage consoles (Windows cp1252).
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
+def _is_true_constant(node: ast.expr) -> bool:
+    return isinstance(node, ast.Constant) and node.value is True
+
+
+def _open_mode_is_binary(call: ast.Call) -> bool:
+    """True when an open() call's mode argument is a constant containing 'b'."""
+    mode_node = None
+    if len(call.args) >= 2:
+        mode_node = call.args[1]
+    for keyword in call.keywords:
+        if keyword.arg == 'mode':
+            mode_node = keyword.value
+    if mode_node is None:
+        return False
+    if isinstance(mode_node, ast.Constant) and isinstance(mode_node.value, str):
+        return 'b' in mode_node.value
+    # Dynamic mode expression: cannot prove binary, treat as text so the
+    # call still needs an explicit encoding.
+    return False
+
+
+def check_file(path: Path) -> list:
+    """Return (line, rule, message) findings for one Python file."""
+    text = path.read_text(encoding='utf-8')
+    tree = ast.parse(text, filename=str(path))
+    findings: list = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        keyword_names = {k.arg for k in node.keywords if k.arg}
+
+        for keyword in node.keywords:
+            if (
+                keyword.arg in ('text', 'universal_newlines')
+                and _is_true_constant(keyword.value)
+                and 'encoding' not in keyword_names
+            ):
+                findings.append((
+                    node.lineno, 'subprocess-encoding',
+                    f"{keyword.arg}=True without encoding= — pipes decode "
+                    "with the locale codepage on Windows",
+                ))
+
+        if isinstance(node.func, ast.Name) and node.func.id == 'open':
+            if not _open_mode_is_binary(node) and 'encoding' not in keyword_names:
+                findings.append((
+                    node.lineno, 'open-encoding',
+                    "text-mode open() without encoding=",
+                ))
+
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr in ('read_text', 'write_text')
+            and 'encoding' not in keyword_names
+        ):
+            findings.append((
+                node.lineno, 'read-write-text',
+                f"{node.func.attr}() without encoding=",
+            ))
+
+    if "__main__" in text and 'reconfigure(encoding' not in text:
+        findings.append((
+            1, 'entry-point-preamble',
+            "entry point never reconfigures stdout/stderr to UTF-8 — "
+            "add the template's ensure_utf8() (see CONTRIBUTING.md)",
+        ))
+
+    return findings
+
+
+def iter_python_files(roots: list) -> list:
+    result = []
+    for root in roots:
+        root_path = Path(root)
+        if not root_path.exists():
+            continue
+        for path in sorted(root_path.rglob('*.py')):
+            if any(part in SKIP_DIRS for part in path.parts):
+                continue
+            result.append(path)
+    return result
+
+
+def main() -> int:
+    ensure_utf8()
+
+    roots = sys.argv[1:] or DEFAULT_ROOTS
+    files = iter_python_files(roots)
+    if not files:
+        print(f"{RED}[ERROR]{NC} no Python files found under: {', '.join(roots)}",
+              file=sys.stderr)
+        return 2
+
+    total = 0
+    for path in files:
+        try:
+            findings = check_file(path)
+        except (OSError, UnicodeDecodeError, SyntaxError) as e:
+            print(f"{RED}[ERROR]{NC} {path}: {e}", file=sys.stderr)
+            return 2
+        for line, rule, message in findings:
+            total += 1
+            print(f"{YELLOW}{path}:{line}{NC} [{rule}] {message}")
+
+    if total:
+        print(f"\n{RED}FAIL:{NC} {total} finding(s) across {len(files)} file(s)")
+        return 1
+    print(f"{GREEN}OK:{NC} {len(files)} file(s) follow the UTF-8 conventions")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/templates/skill-python-tool.py
+++ b/templates/skill-python-tool.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+<tool-name>.py
+
+One-line description of what this tool does.
+
+Template notes (delete this docstring block when copying):
+    Start new skill Python tools from this file. It bakes in the UTF-8
+    conventions from issue #118 so Unicode content — Japanese output paths,
+    CJK landmark IDs like 概要, non-ASCII group names — survives stock
+    Windows consoles (cp1252/cp932). The three rules, in one place:
+
+    1. ensure_utf8() runs first thing in main(). Python children spawned
+       later start in full UTF-8 mode, and this process's own stdout/stderr
+       print Unicode safely regardless of the console codepage.
+    2. Text-mode file I/O always names its encoding:
+       open(p, encoding='utf-8'), Path.read_text(encoding='utf-8'),
+       Path.write_text(..., encoding='utf-8'). The interpreter default
+       tracks the locale codepage on Windows until Python 3.15.
+    3. subprocess never uses bare text=True — pipe decoding ignores
+       PYTHONIOENCODING and falls back to the locale codepage, which
+       silently turns a child's UTF-8 output into stdout=None when the
+       reader thread dies. Use run_utf8() (or pass encoding='utf-8'
+       explicitly).
+
+Usage:
+    python <tool-name>.py <input> [options]
+
+Exit codes:
+    0 - Success.
+    1 - Usage error or recoverable failure (bad arguments, lookup miss).
+    2 - Parse failure or IO failure (file missing, malformed input).
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# ANSI color codes (shared house style across skill tools)
+RED = '\033[0;31m'
+GREEN = '\033[0;32m'
+YELLOW = '\033[1;33m'
+NC = '\033[0m'
+
+DEBUG = os.environ.get('DEBUG', '0') == '1'
+
+
+def ensure_utf8() -> None:
+    """Make this tool Unicode-safe regardless of the caller's environment.
+
+    UTF-8 mode is read at interpreter startup, so the setdefault cannot fix
+    the *current* process — it guarantees every Python child spawned later
+    starts in full UTF-8 mode. The reconfigure handles this process's own
+    stdio, which Windows otherwise initializes to the console codepage and
+    which raises UnicodeEncodeError on the first non-ASCII path or ID
+    printed. The try/except keeps redirected or captured streams (which may
+    lack reconfigure) from breaking the tool.
+    """
+    os.environ.setdefault('PYTHONUTF8', '1')
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding='utf-8')
+        except (AttributeError, ValueError):
+            pass
+
+
+def debug_log(message: str) -> None:
+    """Print debug message to stderr when DEBUG=1."""
+    if DEBUG:
+        print(f"{YELLOW}[DEBUG]{NC} {message}", file=sys.stderr)
+
+
+def error_log(message: str) -> None:
+    """Print error message to stderr."""
+    print(f"{RED}[ERROR]{NC} {message}", file=sys.stderr)
+
+
+def warn_log(message: str) -> None:
+    """Print warning message to stderr (unconditional, unlike debug_log)."""
+    print(f"{YELLOW}[WARN]{NC} {message}", file=sys.stderr)
+
+
+def run_utf8(cmd: list, **kwargs) -> subprocess.CompletedProcess:
+    """subprocess.run with UTF-8 pipes. Use this instead of text=True.
+
+    Bare text=True decodes child pipes with the locale codepage on Windows
+    (PYTHONIOENCODING does not change this). errors='replace' keeps
+    diagnostics flowing even if a child emits a stray byte; drop it via
+    kwargs when byte-exact output matters.
+    """
+    kwargs.setdefault('encoding', 'utf-8')
+    kwargs.setdefault('errors', 'replace')
+    return subprocess.run(cmd, **kwargs)
+
+
+def read_input(path: Path) -> str:
+    """Example file read — text-mode I/O always names its encoding."""
+    return path.read_text(encoding='utf-8')
+
+
+def main() -> int:
+    ensure_utf8()
+
+    parser = argparse.ArgumentParser(
+        description='One-line description of what this tool does.',
+    )
+    parser.add_argument('input', help='Path to the input file')
+    args = parser.parse_args()
+
+    source = Path(args.input)
+    if not source.is_file():
+        error_log(f"not a file: {source}")
+        return 2
+
+    try:
+        text = read_input(source)
+    except (OSError, UnicodeDecodeError) as e:
+        error_log(f"{source}: {e}")
+        return 2
+
+    debug_log(f"read {len(text)} characters from {source}")
+    print(f"{GREEN}OK{NC} {source}")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Closes #118

> [!NOTE]
> **Stacked on #117** (both touch `resolve-landmarks.py` / `verify-landmark-resolver.py`). Merge #117 first; GitHub will retarget this PR to `main` automatically when the base branch is deleted.

## Why

Every new Python tool re-discovers the same Windows locale-codepage failures: `UnicodeEncodeError` printing non-ASCII IDs/paths, `subprocess.run(text=True)` pipes silently decoding to `stdout=None`, and mojibake from unencoded file reads. ePublisher content is Unicode-first; tools that only survive ASCII are broken for real projects. This PR makes the safe pattern the default for new tools **and** retrofits every existing tool to the same scaffolding.

## What

**Template (new tools start correct):**
- `templates/skill-python-tool.py` — minimal runnable CLI scaffold: `ensure_utf8()` preamble (`PYTHONUTF8` setdefault for spawned children + stdio reconfigure for the process itself — see the [#118 design note](https://github.com/quadralay/webworks-agent-skills/issues/118#issuecomment-4676208685) for why both halves are needed), `run_utf8()` subprocess wrapper, explicit file-I/O encodings, and the shared house conventions (ANSI colors, `DEBUG` gate, stderr log helpers, `0`/`1`/`2` exit codes).
- CONTRIBUTING.md "New Python Tools" section + CLAUDE.md pointer so agent-authored tools start from the template too.

**Retrofit (existing tools made consistent):**
- `ensure_utf8()` preamble added to all 16 CLI entry points (automap ×5, epublisher ×3, customization-audit, reverb2 scripts ×5, both reverb2 test harnesses). `lint-output.py`'s existing inline reconfigure block is replaced by the same standard function.
- Both verifier harnesses now decode subprocess pipes as UTF-8 (`encoding='utf-8', errors='replace'`) instead of the locale codepage; the per-call `PYTHONIOENCODING` child-env workarounds are removed (children inherit `PYTHONUTF8` from the preamble).
- Unencoded text-mode `open()` fixed in `create-job.py` (JSON config) and `generate-report.py` (JSON results).

**Checker (conventions stay enforced):**
- `scripts/check-python-utf8.py` — AST-based static check for all three rules plus the entry-point preamble, across `plugins/`, `templates/`, and `scripts/` (it holds itself and the template to the same rules). Found 26 violations across 15 files at baseline; all fixed; now exits 0 over 23 files. Documented in CONTRIBUTING.md as a pre-PR step.

## Testing (#118 acceptance criteria)

On a stock cp1252 Windows console with `PYTHONUTF8`/`PYTHONIOENCODING` explicitly **unset**:
- `verify-landmark-resolver.py`: **130/130 pass** (previously crashed with `UnicodeEncodeError` printing `概要`, then `stdout=None` → `TypeError` from locale-decoded pipes).
- `verify-lint-output.py`: **25/25 pass**.
- `scripts/check-python-utf8.py`: clean over 23 files.
- All 14 CLI tools pass a `--help` smoke test; `python -m py_compile` clean over every touched file.
- Template smoke test: reads a UTF-8 file named `概要テスト.txt` and prints the Unicode filename correctly (exit 0).

## Version

Bumped 3.3.1 → 3.3.2 (patch) on top of #117's 3.3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)