### PR TITLE
Closes #120: Strengthen relative-path guidance for .wep/.wrp/.waj document, stationery, and output paths

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "webworks-agent-skills",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "owner": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/.claude-plugin/plugin.json
+++ b/plugins/webworks-agent-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webworks-agent-skills",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "author": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/skills/automap/references/job-file-guide.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/job-file-guide.md
@@ -177,7 +177,11 @@ Stationery (.wxsp)              Job File (.waj)
 |-----------|----------|-------------|---------|
 | `path` | Yes | Relative or absolute path to Stationery | `"stationery\main.wxsp"` |
 
-**Path Resolution**: Paths are relative to the job file's directory.
+**Path Resolution**: Paths are relative to the job file's directory. **Prefer a relative path** to the Stationery — including parent-relative (`..\`) traversal when the Stationery lives outside the job file's folder (e.g. `..\stationery\main.wxsp`). Relative paths keep the job portable across machines. Reach for an **absolute path only when** a relative one is impossible or impractical:
+
+1. The Stationery is on a **different drive** than the job file (no shared path root exists)
+2. The Stationery is on a **different network share**
+3. The job file and the Stationery share **only the drive letter or share root** as a common ancestor — a relative path technically works but is long and unmaintainable (e.g. `..\..\..\..\Other\Tree\main.wxsp`), so absolute is preferable
 
 ### `<Files>` Element
 
@@ -197,7 +201,7 @@ Contains one or more `<Document>` elements.
 |-----------|----------|-------------|---------|
 | `path` | Yes | Path to source document | `"Source\en\intro.md"` |
 
-**Path Resolution**: Paths are relative to the job file's directory.
+**Path Resolution**: Paths are relative to the job file's directory. **Prefer a relative path** to each source document — including parent-relative (`..\`) traversal when a document lives outside the job file's folder (e.g. `..\Source\Word\Overview.docx`). Relative paths keep the job portable. Use an absolute path only in the narrow cases listed under the [`<Project>` element](#project-element) (different drive, different network share, or only the drive/share root as a common ancestor).
 
 ### `<Targets>` Element
 

--- a/plugins/webworks-agent-skills/skills/epublisher/references/project-parsing-guide.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/references/project-parsing-guide.md
@@ -82,7 +82,7 @@ For per-style trait configuration inside `<GlobalConfiguration>` or `<FormatConf
 </Format>
 ```
 - Output generated to specified directory
-- Can be absolute or relative to project file
+- Can be absolute or relative to project file — prefer relative, including parent-relative `..\`, per [Relative vs Absolute Paths](#relative-vs-absolute-paths)
 
 **When absent:**
 ```xml
@@ -282,7 +282,7 @@ done
 
 **`Path`** (MOST IMPORTANT)
 - Path to source file
-- Can be relative (to project file) or absolute
+- Can be relative (to project file) or absolute — prefer relative, including parent-relative `..\`, per [Relative vs Absolute Paths](#relative-vs-absolute-paths)
 - Use backslashes for Windows: `"Source\file.md"`
 - Example: `"Source\getting-started.md"`, `"C:\Docs\manual.md"`
 
@@ -562,21 +562,31 @@ new_doc_id=$(generate_id_with_prefix "doc")     # docK4Rt8Wq
 
 ### Relative vs Absolute Paths
 
-**Relative (preferred):**
+**Prefer relative paths in all cases** — including parent-relative (`..\`) traversal for sources that live outside the project folder. Relative paths stay portable across machines and play well with version control.
+
+**Child-relative** (source inside the project tree):
 ```xml
 <Document Path="Source\getting-started.md" ... />
 ```
-- Relative to project file directory
-- Portable across machines
-- Recommended for version control
+- Relative to the project file's directory
 
-**Absolute (less common):**
+**Parent-relative** (source outside the project folder — verified to resolve and build correctly):
+```xml
+<Document Path="..\Source\Word\Overview.docx" ... />
+```
+- `..\` walks up to a shared ancestor, then back down to the source
+- Still portable, as long as the project and source move together
+
+**Reach for an absolute path only when** a relative one is impossible or impractical:
+
+1. The source is on a **different drive** than the project file (no shared path root exists)
+2. The source is on a **different network share**
+3. The project file and the source share **only the drive letter or share root** as a common ancestor — a relative path technically works but is long and unmaintainable (e.g. `..\..\..\..\Other\Tree\file.docx`), so absolute is preferable
+
 ```xml
 <Document Path="C:\projects\my-proj\Source\content.md" ... />
 ```
-- Full path from drive root
-- Not portable
-- Use only for external references
+- Full path from drive root; not portable across machines
 
 ### Path Validation
 
@@ -668,5 +678,5 @@ $ bash scripts/manage-sources.sh --validate project.wep
 ---
 
 **Version**: 1.0.0
-**Last Updated**: 2025-11-04
+**Last Updated**: 2026-06-12
 **Target**: ePublisher 2024.1+ project files


### PR DESCRIPTION
Brings the #120 documentation work onto `main`. The change originally landed on the `dev-worker` integration branch (via #121); this PR cherry-picks the doc commit cleanly onto current `main` (which has since advanced to 3.3.x), avoiding the stale version bump and chore commits that lived on `dev-worker`.

## What changed
- **`project-parsing-guide.md`** — replace the "Relative (preferred) / Absolute (less common, for external references)" framing with an exception-based rule. Adds a verified parent-relative example (`..\Source\Word\Overview.docx`) and the three cases where absolute is warranted (different drive, different network share, or only the drive/share root as common ancestor). Cross-links the Document Path and OutputDirectory bullets.
- **`job-file-guide.md`** — carries the same recommendation and exceptions on the `<Project>` Stationery `path` note and the `<Document>` path note.
- Version bump 3.3.2 → 3.3.3 (patch, per CLAUDE.md for doc updates).

## Notes
- Cherry-pick auto-merged against `main`'s newer `job-file-guide.md` (no conflict); main's content is preserved with the #120 edits layered on.
- Issue #120 is already closed by #121; this PR completes the path to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)