### PR TITLE
feat: federated parcel composition knowledge (2026.1) for automap, reverb2, epublisher

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "webworks-agent-skills",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "owner": {
     "name": "Quadralay Corporation",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,35 @@ plugins/
             └── UPSTREAM.md        # Source URL, last sync SHA, port process
 ```
 
+## Pre-Release Feature Annotations
+
+Skills track ePublisher **trunk**, not the shipped release: content for features
+that have landed in source but not yet shipped is written immediately, annotated
+with the target release, and the annotations are stripped at GA. This keeps the
+skills authoritative for early-access/dev builds while protecting users of the
+shipped release from being told about functionality they don't have.
+
+**Annotating (pre-GA):**
+
+- A wholly new reference for an unshipped feature opens with a blockquote banner:
+  `> **Applies to ePublisher <version> and later** (new in <version>).`
+- A new section or sentence inside an existing file carries the inline marker
+  `(new in <version>)` or `(<version>+)` — e.g. `(new in 2026.1)`, `(2026.1+)`.
+- List the feature under a `### ePublisher <version>` heading in the epublisher
+  skill's `references/version-compatibility.md` so agents can gate on the
+  user's installed version.
+
+**Stripping (at GA):**
+
+1. `grep -rn "new in <version>\|<version>+\|Applies to ePublisher <version>" plugins/`
+2. Remove banners and inline markers; keep the content. Version-compatibility
+   entries stay (they become the historical record).
+3. Bump the plugin version; note the stripped release in the PR.
+
+The cycle then resets for the next release's features. Precedents:
+`useAsStationery` (annotated pre-2026.1-GA) and the 2026.1 federated parcel
+composition set.
+
 ## SKILL.md Authoring
 
 ### Size Limit

--- a/plugins/webworks-agent-skills/.claude-plugin/plugin.json
+++ b/plugins/webworks-agent-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webworks-agent-skills",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "author": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/skills/automap/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/automap/SKILL.md
@@ -3,7 +3,9 @@ name: automap
 description: >
   AUTHORITATIVE REFERENCE for WebWorks AutoMap CLI. Use when working with
   .waj/.wep/.wrp/.wxsp files, executing builds, detecting installation,
-  creating job files, or automating CI/CD publishing workflows.
+  creating job files, automating CI/CD publishing workflows, or (2026.1+)
+  running .wacj composition jobs, federated parcel deploys (deploy scope,
+  inline deploy settings), and Amazon S3 / CloudFront destinations.
 ---
 
 <objective>
@@ -35,6 +37,8 @@ Job files inherit format configuration from a **job origin** referenced by `<Pro
 - Origin is usually a Stationery (`.wxsp`), but a `.wep`/`.wrp` project can be used directly as a stationery via `useAsStationery="True"` (2026.1+), removing the manual "Save As Stationery" step from CI
 
 **For job origin modes and job file details, see:** references/job-file-guide.md
+
+**Composition Jobs (new in 2026.1):** a `.wacj` (run by the same `WebWorks.Automap.exe`) assembles independently built and deployed Reverb 2.0 parcels into one site under a shared shell — recompose takes seconds, no content rebuild. Related 2026.1 machinery: per-target **deploy scope** (`--deployscope`), **inline deploy-target definitions** plus the `--deploysettings` overlay, **Amazon S3 + CloudFront** destinations, and the global `--dryrun` switch. **Grammar, precedence, S3 behavior, and failure modes:** references/composition-jobs.md
 </overview>
 
 <usage>

--- a/plugins/webworks-agent-skills/skills/automap/references/composition-jobs.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/composition-jobs.md
@@ -1,0 +1,211 @@
+# Composition Jobs (.wacj) — Federated Parcel Composition
+
+> **Applies to ePublisher 2026.1 and later** (new in 2026.1). Earlier versions
+> do not recognize `.wacj` files, the `deployScope` attribute, inline
+> `<DeploySettings>`, or the `--deployscope` / `--deploysettings` / `--dryrun`
+> options. Check the installed version before recommending any of this —
+> see the epublisher skill's `references/version-compatibility.md`.
+
+Federated parcel composition assembles independently built and deployed
+WebWorks Reverb 2.0 outputs (parcels) into one site under a shared shell.
+The lifecycle has three independent steps:
+
+1. **Build** — each parcel project builds a complete standalone Reverb site.
+2. **Deploy** — each project deploys only its role-appropriate slice into one
+   shared destination (the mirror): parcels deploy their content groups,
+   the shell deploys the site files. Every parcel deployment includes a
+   composition descriptor (`wwcomposition.xml` + a byte-faithful manifest
+   fragment) recording its identity.
+3. **Compose** — an AutoMap Composition Job (`.wacj`) reads the deployed
+   descriptors, splices the combined site TOC into the deployed shell,
+   refreshes `sitemap.xml` / `url_maps.xml`, and advances the browser cache
+   key — in seconds, without rebuilding any content. On S3 it uploads the
+   recomposed files and issues a CloudFront invalidation.
+
+Reverb 2.0 only: the format declares the composition capabilities in
+`format.wwfmt`; other formats always deploy everything.
+
+## Grammar
+
+A `.wacj` is a distinct artifact that *references* jobs — like `.sln` vs
+`.csproj`. The same `WebWorks.Automap.exe` runs both (dispatch on the root
+element):
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<CompositionJob name="product-docs" version="1.0">
+  <Jobs>
+    <Job path="shell\shell.waj"       role="shell"/>
+    <Job path="install\install.waj"   role="parcel" build="true"/>
+    <Job path="admin\admin.wep"       role="parcel"/>
+  </Jobs>
+
+  <MergeSettings>
+    <TOC name="Guides">
+      <Group name="Installation Guide"/>
+    </TOC>
+    <Group name="Administration Guide"/>
+  </MergeSettings>
+
+  <DeployTarget name="ProductionMirror"/>
+</CompositionJob>
+```
+
+- **`<Job path role build>`** — members are `.waj` jobs or `.wep`/`.wrp`
+  projects. `role` is `shell` or `parcel`. `build` defaults to **false**
+  (compose-only; member output is already deployed). A `build="true"` member
+  is built first, in its own process, with `--deployscope` derived from its
+  role (`shell` → shell, `parcel` → groups) so a composition-driven federation
+  cannot be mis-scoped.
+- **`<MergeSettings>`** — the composed site TOC. `<Group name>` references a
+  deployed parcel **by group name**; `<TOC name>` nests groups under folders.
+  `discover="true"` composes every parcel found in the mirror instead
+  (DISCOVERY mode); declared groups plus `discover` is the hybrid. The root
+  `title` attribute is accepted for `.waj` grammar parity but unused (warned):
+  the composed site's title is shell chrome.
+- **`<DeployTarget name>`** — the shared destination. Resolution order:
+  the composition job's own inline `<DeploySettings>` → a `--deploysettings`
+  overlay file → the machine's deploy preferences (`deploy.prefs`), with a
+  drift warning when an inline definition shadows a differing preference.
+
+**Group names are the durable identity.** Parcel GroupIDs regenerate across
+rebuilds and re-stagings; composition harvests whatever GID each deployed
+descriptor currently carries. Always reference parcels by name, never by a
+captured GroupID.
+
+**Tolerance:** a declared group with no deployed descriptor is warned and
+omitted; the composed site loads cleanly with the parcels present. A missing
+shell composition descriptor (`wwcomposition-shell.xml`) is a hard error —
+rebuild and redeploy the shell.
+
+## Running
+
+```powershell
+& $automapExe composition.wacj                       # compose only
+& $automapExe composition.wacj --deployscope=shell   # NOT valid — scope belongs to member builds
+```
+
+- Exit code 0 on success; non-zero on error (undefined deploy target, missing
+  shell descriptor, member build failure).
+- A job-style log is written beside the file: `<name>-log.txt`.
+- Expected success lines: `Harvested N parcel descriptor(s) from the mirror`,
+  `Composed #parcels (N parcel(s)) into index.html`, `Composed cache key: ...`,
+  `Composition complete: N parcel(s), M warning(s).`
+
+Options forwarded to `build="true"` member builds: `--deployscope` (from
+role), `--deploysettings` (merged inline + overlay definitions), `--dryrun`,
+and `-t`/`--target` semantics apply per member job.
+
+## Deploy scope
+
+Every target declares which slice a deployment publishes. In the project it
+is the Target Settings **Deploy** field; in a `.waj` it is the optional
+`deployScope` attribute on `<Target>`; on the CLI it is `--deployscope`.
+CLI overrides job attribute overrides project declaration.
+
+| Value | Publishes | Use for |
+|-------|-----------|---------|
+| `everything` | complete generated output (default, legacy behavior) | standalone sites |
+| `groups` | content groups + their composition descriptors, no site files | every parcel |
+| `shell` | site files + shell composition descriptor, no groups | the shell |
+
+Scoped deployments (and scoped AutoMap Clean) are additive within their
+slice: they never delete another project's files in the mirror. Clean is an
+AutoMap capability — the Designer/Express Deploy command copies only.
+
+Slice attribution is by group-name prefix and mirrors the format's directory
+naming exactly, including space-replacement settings and path-invalid
+character folding, so groups with names like `C# API [Draft]` slice
+correctly. Per-parcel knowledge-base archives
+(`knowledge-parcel-<slug>-<hash>.zip`) belong to the group slice; a folder
+Groups-scope Clean also sweeps the build's own prior-generation archives
+(never a sibling's).
+
+## Inline deploy-target definitions
+
+Deploy preferences are per-user, per-machine state; a version-controlled job
+that references a destination by name alone needs every machine seeded. Both
+job kinds can carry the **definition** inline, using the exact deploy.prefs
+entry schema — references stay by name:
+
+```xml
+<!-- .waj: a direct child of <Job> -->
+<DeploySettings>
+  <DeploySetting Name="ProductionMirror" Action="s3">
+    <Configuration Value="s3://docs-bucket/product" Region="us-east-1"
+                   Distribution="E2EXAMPLE" />
+  </DeploySetting>
+</DeploySettings>
+
+<!-- .wacj: inside <DeployTarget> -->
+<DeployTarget name="ProductionMirror">
+  <DeploySettings>
+    <DeploySetting Name="ProductionMirror" Action="s3">...</DeploySetting>
+  </DeploySettings>
+</DeployTarget>
+```
+
+- Precedence per name: **job file's own inline > `--deploysettings` overlay
+  file > deploy.prefs.** The log records which source resolved each name and
+  warns when an inline definition shadows a differing preference (the drift
+  detector).
+- `--deploysettings=<file>` takes the same `<DeploySetting>` entries from an
+  XML file — the CI seeding mechanism. A composition forwards its merged
+  inline definitions to member builds automatically (they are separate
+  processes), so name-only member jobs run on unseeded machines.
+- **Security guardrail:** only secret-free transports may be inline — Folder
+  (`Action="file"`) and Amazon S3 (`Action="s3"`). WebDAV (`Action="http"`)
+  embeds credentials and is rejected at parse time with a clear error, as are
+  custom actions. Those stay in deploy.prefs.
+
+## Amazon S3 + CloudFront destinations
+
+An S3 destination stores bucket URI (`s3://bucket` or `s3://bucket/prefix`),
+region, optional named AWS credential profile, and optional CloudFront
+distribution ID. **No access keys are ever stored** — credentials resolve
+through the standard AWS chain (profile, environment, instance role) on the
+deploying machine.
+
+- Uploads apply web-appropriate caching: versioned assets immutable,
+  pages/maps (html/xml) always revalidated (no-cache).
+- A deploy invalidates its own no-cache uploads through CloudFront when a
+  distribution is configured (root files exactly; directory contents collapse
+  to one `<dir>/*` wildcard per top-level directory). Compose issues one
+  invalidation for the recomposed chrome.
+- Composition against S3 is two-phase: descriptors + chrome sync down to a
+  local `.compose-staging\<name>\` mirror, compose runs locally, changed
+  files upload, one invalidation is issued.
+- Per-parcel knowledge-base archives are excluded from S3 deploys by design
+  (the Platform ingests them by upload from build output, never from S3).
+- Nonexistent-on-disk slice entries (external-link baggage stubs) are skipped,
+  not fatal.
+
+**Dry run** — two layers:
+- The destination's own **Dry run** setting (persisted): every run prints the
+  DELETE / PUT / INVALIDATE sets and makes no AWS call.
+- The global **`--dryrun`** switch (new in 2026.1): forces a resolved S3
+  setting dry for that one run, skips transports without dry-run support with
+  an explicit log line, and is forwarded to member builds. There is
+  deliberately no opposite switch — a setting declared dry cannot be forced
+  live from the CLI.
+
+## Failure behavior
+
+- A failed deploy is an **error**: it reaches the per-target error count and
+  the process exit status (2026.1; earlier versions logged a warning and
+  exited 0).
+- `Deploy target '<name>' is not defined in deploy.prefs or inline in the
+  composition job.` — seed the name via inline definitions, an overlay file,
+  or deploy.prefs.
+- `The mirror has no shell composition descriptor (wwcomposition-shell.xml)`
+  — the shell was never deployed to that mirror (or the path points at an
+  empty directory); rebuild and redeploy the shell.
+- An inline WebDAV definition fails at job load, before any build starts.
+
+## Related
+
+- Job origin modes, `deployScope`, and inline `<DeploySettings>` in `.waj`
+  files: `references/job-file-guide.md`
+- What a composed mirror looks like on disk and how to verify it (descriptors,
+  manifest splice, cache key): the reverb2 skill's
+  `references/federation-architecture.md`

--- a/plugins/webworks-agent-skills/skills/automap/references/job-file-guide.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/job-file-guide.md
@@ -499,6 +499,34 @@ Settings override format-level configuration from Stationery:
 python scripts/parse-stationery.py stationery.wxsp
 ```
 
+### Deployment (new in 2026.1: scope and inline definitions)
+
+A `<Target>` element routes deployment through `deployTarget` (a named
+destination) and, as of ePublisher 2026.1, can scope what the deployment
+publishes with `deployScope`:
+
+```xml
+<Targets>
+  <Target name="WebWorks Reverb 2.0" format="WebWorks Reverb 2.0"
+          formatType="Application" build="True"
+          deployTarget="ProductionMirror" deployScope="groups" />
+</Targets>
+```
+
+- `deployScope` — `everything` (default), `groups` (content only), or
+  `shell` (site files only). Overrides the scope declared in the project;
+  `--deployscope` on the CLI overrides both. Supports federated parcel
+  composition in WebWorks Reverb 2.0.
+- The job can carry the **definition** of its named destinations inline in a
+  `<DeploySettings>` element (a direct child of `<Job>`, exact deploy.prefs
+  entry schema), so a version-controlled job runs on machines with no seeded
+  deploy preferences. Folder and Amazon S3 definitions only; WebDAV is
+  rejected (embeds credentials). Precedence per name: job inline >
+  `--deploysettings` overlay file > deploy.prefs.
+
+**For the full federation workflow (.wacj composition jobs, S3 + CloudFront
+destinations, dry run), see:** references/composition-jobs.md
+
 ---
 
 ## Merge Settings (Multivolume / Merged TOC)

--- a/plugins/webworks-agent-skills/skills/epublisher/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/SKILL.md
@@ -79,6 +79,10 @@ A Designer `.wep` carries **no** `<format>.base` snapshots, so its transforms re
 
 **For job-file usage of `useAsStationery`, see the automap skill's `references/job-file-guide.md`.**
 
+### Deploy Targets and Deploy Scope (new in 2026.1)
+
+Output destinations (Target Settings **Deploy to** / **Add deploy target**) are machine-global named definitions shared across projects. As of ePublisher 2026.1: destinations can be **Folder** or **Amazon S3** (bucket/region/named credential profile/CloudFront distribution — no stored secrets; dry run supported); each target also declares a **Deploy** scope — Everything (complete site), Groups (content only), or Shell (site files only) — which powers federated parcel composition in WebWorks Reverb 2.0 (the field is disabled for formats without the capability). Deployments never delete outside their own scope slice, and Clean remains AutoMap-only. For the federation workflow, `.wacj` composition jobs, and inline deploy-target definitions, see the automap skill's `references/composition-jobs.md`; for version gating, `references/version-compatibility.md`.
+
 ### Project File Format
 
 The `.wep` file is XML containing target definitions:

--- a/plugins/webworks-agent-skills/skills/epublisher/references/version-compatibility.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/references/version-compatibility.md
@@ -13,6 +13,14 @@
 
 ## Breaking Changes by Version
 
+### ePublisher 2026.1 (new in 2026.1 — features below do NOT exist in earlier versions)
+- `useAsStationery="True"` on a job's `<Project>` element (a live `.wep`/`.wrp` as stationery)
+- Federated parcel composition (Reverb 2.0): `.wacj` composition jobs, per-target deploy scope (Everything / Groups / Shell; `deployScope` attribute, `--deployscope`), `wwcomposition*` output descriptors
+- Amazon S3 + CloudFront deploy destinations (named profile/role credentials, deploy-time invalidation, dry run; global `--dryrun`)
+- Inline deploy-target definitions in `.waj`/`.wacj` (`<DeploySettings>`) and the `--deploysettings` overlay file
+- A failed deploy is an error (reaches the exit status); earlier versions warned and exited 0
+- See the automap skill's `references/composition-jobs.md` before recommending any of these — never suggest them to users on 2025.1 or earlier
+
 ### ePublisher 2024.1
 - New AutoMap CLI executable name
 - Updated registry paths

--- a/plugins/webworks-agent-skills/skills/reverb2/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/SKILL.md
@@ -4,8 +4,9 @@ description: >
   AUTHORITATIVE REFERENCE for WebWorks Reverb 2.0 output. Use when testing
   Reverb output in browser, statically linting output for structural breakage
   (self-closed elements, manifest/parcel GroupID consistency), analyzing CSH
-  links, customizing SCSS themes, inspecting url_maps.xml, or generating test
-  reports.
+  links, customizing SCSS themes, inspecting url_maps.xml, generating test
+  reports, or (2026.1+) inspecting federated/composed sites and their
+  wwcomposition descriptors.
 ---
 
 <objective>
@@ -44,6 +45,8 @@ Reverb 2.0 runtime output is built from three source types in `<format name>/Pag
 When investigating a runtime issue — a theme override that didn't apply, a broken search, a navigation glitch, a missing chrome element — look in `Pages/` first. The published output is transformed; the source of truth lives in these three directories.
 
 **Detailed SCSS guidance:** `## SCSS Customization` (below) and `references/scss-architecture.md`.
+
+**Federated parcel composition (new in 2026.1):** a Reverb site can be assembled from independently built parcels under a shared shell. Builds emit `wwcomposition*` descriptor files (inert in standalone sites), shells legitimately have an empty `#parcels` tree, and a composed mirror mixes GroupIDs and generation hashes from different builds — all of which changes what linting and browser testing should expect. See `references/federation-architecture.md` before flagging any of those as breakage.
 </runtime_architecture>
 
 <related_skills>

--- a/plugins/webworks-agent-skills/skills/reverb2/references/federation-architecture.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/references/federation-architecture.md
@@ -1,0 +1,94 @@
+# Federated Parcel Composition — Output Architecture
+
+> **Applies to ePublisher 2026.1 and later** (new in 2026.1). Earlier Reverb
+> 2.0 builds emit none of the `wwcomposition*` artifacts described here.
+
+A federated Reverb 2.0 site is assembled from independently built outputs:
+parcel builds contribute content groups, a shell build contributes the site
+files, and an AutoMap composition (`.wacj`) splices them together in the
+deployed mirror. This reference covers what federation looks like **in the
+output** — what to expect when inspecting, linting, or browser-testing a
+composed mirror. For the build/deploy/compose workflow, grammar, and CLI, see
+the automap skill's `references/composition-jobs.md`.
+
+## Composition artifacts in build output
+
+Every Reverb 2.0 build (2026.1+) emits composition descriptors alongside its
+normal output:
+
+- **`<Group Dir>/wwcomposition.xml`** — per-parcel descriptor: decoded group
+  name, GroupID, title, entry/index-chunk hrefs (URL-encoded,
+  mirror-relative), generation hash, and a url_maps slice.
+- **`<Group Dir>/wwcomposition-manifest.html`** — the parcel's `#parcels`
+  TOC `<li>` fragment, **byte-identical** to the leaf in that build's own
+  `index.html`. Composition splices these raw bytes, never re-serializes.
+- **`wwcomposition-shell.xml`** (output root) — shell descriptor: entry file,
+  cache-key surface, splice anchor, and compose parameters. Emitted by every
+  build; consumed from whichever project deployed the shell slice.
+
+These files are inert in a standalone site — their presence is normal and not
+a defect.
+
+## Shell outputs
+
+Two ways a build produces a content-free shell (full chrome, empty `#parcels`
+tree, no group-derived files):
+
+- a project with **no source document groups** (the `generate-empty-project`
+  capability lets the zero-document build proceed), or
+- any project with the **Generate Groups** target setting disabled
+  (`connect-groups-generate`) — chrome only: no parcel units, pages, group
+  CSS, search index chunks, landmark chunks, per-group sitemaps, companion
+  PDFs, or stub-group entries in `sitemap.xml` / `url_maps.xml`.
+
+A shell loads error-free with zero parcels. Do not flag an empty `#parcels`
+`<ul role="tree">` as breakage when the target is a shell.
+
+## The composed mirror
+
+After composition, the mirror is a normal Reverb 2.0 site plus:
+
+- `index.html` `#parcels` contains leaves harvested from **different
+  builds** — GroupIDs (`group:<id>` element ids, `data-group-title`
+  attributes) come from each parcel's own build and share no sequence.
+  Container `<li>` folders (from `.wacj` `<TOC>` nesting) carry a colon-join
+  of their descendant GroupIDs.
+- The site cache key (`GLOBAL_GENERATION_HASH` query strings) is a **composed**
+  value that advances on every composition — chrome resources carry the
+  composed hash while each parcel's own pages keep their build's hash. A
+  mixed hash population across parcels is correct, not stale output.
+- Root `sitemap.xml` and `url_maps.xml` are recomposed aggregates over the
+  deployed parcels.
+
+**Linting a composed mirror:** GroupID-consistency checks must scope to a
+single parcel's slice; cross-parcel ID uniformity does not hold and is not a
+defect. The `#parcels` manifest leaves are byte-copies of each parcel's own
+manifest fragment, so leaf-vs-parcel-unit consistency still holds per group.
+
+## Runtime tolerance
+
+The 2026.1 loader tolerates missing parcels: parcel iframes are armed for
+failure before their `src` is assigned (onerror, a post-load grace check, and
+a watchdog), so a declared-but-absent parcel degrades to an omitted entry
+instead of a spinner hang. Consequences for testing:
+
+- A composed site with a missing parcel should still load with **zero console
+  errors** and no `#connect_body` stuck in `preload`.
+- Search results from an absent parcel are silently absent — there is no
+  runtime error to detect; verify expected-parcel coverage explicitly.
+- Cross-parcel navigation and search work only after composition — parcels
+  deployed but not yet composed are invisible to the shell.
+
+## Deploy slices (what belongs to whom)
+
+- **Groups slice:** `<Group Dir>/`, `<Group>.html`, `<Group>_ix.html`,
+  `<Group>_lx.js`, `<Group>_sx.js`, the group's composition descriptors, and
+  per-parcel knowledge-base archives (`knowledge-parcel-<slug>-<hash>.zip`).
+- **Shell slice:** entry page, `css/`, `scripts/`, `splash/`, search page,
+  `not-found.html`, root `sitemap.xml` / `url_maps.xml`, `robots.txt`,
+  `wwcomposition-shell.xml`.
+
+Slice directory names mirror the format's naming exactly (space replacement
+settings, path-invalid character folding), so unusual group names still
+attribute correctly. Deployments never delete outside their own slice; stale
+files from a pre-federation full deploy must be cleaned deliberately.


### PR DESCRIPTION
Teaches the skills the ePublisher **2026.1 federation feature set** — Parcels, deploy scope, Amazon S3 + CloudFront destinations, inline deploy settings, and `.wacj` composition — written against trunk r35949–r35959 (EPUB2830–2835, 2838–2845) and validated behavior from the epublisher-tests federation harness.

## Pre-release annotation convention (new, in CONTRIBUTING.md)

Skills track trunk; unshipped-feature content is annotated with grep-able markers — `(new in 2026.1)`, `(2026.1+)`, and per-file `Applies to ePublisher 2026.1 and later` banners — and the markers are **stripped at GA** (content stays; the version-compatibility entry becomes the permanent record). This PR follows the `useAsStationery` precedent and codifies the cycle so it resets cleanly for the next release.

## Changes

**automap**
- New `references/composition-jobs.md`: `.wacj` grammar (members/roles/`build`, SPEC vs discovery, group-name identity, tolerance), deploy scope + `--deployscope`, inline `<DeploySettings>` (precedence job-inline > `--deploysettings` overlay > deploy.prefs; Folder/S3-only guardrail, WebDAV rejected), S3 + CloudFront (no stored secrets, deploy-time invalidation, two-phase `.compose-staging` compose, KB-zip exclusion, phantom-baggage skip), dry run (persisted setting + global `--dryrun`, deliberately no opposite switch), failure modes (failed deploy = error exit as of 2026.1)
- `job-file-guide.md`: Deployment subsection (`deployScope`, inline definitions) under Target Configuration
- SKILL.md: description triggers + overview pointer (kept under the 500-line limit)

**reverb2**
- New `references/federation-architecture.md`: the output-side view — `wwcomposition*` artifacts (inert in standalone sites), shell outputs, composed-mirror expectations (mixed GroupIDs/generation hashes are *correct*), runtime tolerance, deploy-slice contents — so linting and browser testing don't flag federation as breakage
- SKILL.md: description trigger + Runtime Architecture pointer

**epublisher**
- `version-compatibility.md`: 2026.1 feature gate (the never-suggest-to-2025.1-users list)
- SKILL.md: Deploy Targets and Deploy Scope section

**Housekeeping**: CONTRIBUTING.md annotation convention; version 3.6.0.

## At GA

`grep -rn "new in 2026.1|2026.1+|Applies to ePublisher 2026.1" plugins/` → strip markers, keep content, bump version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)