### PR TITLE
EPUB2868: Rename Deploy Target references to Destination

### DIFF
--- a/plugins/webworks-agent-skills/skills/automap/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/automap/SKILL.md
@@ -38,7 +38,7 @@ Job files inherit format configuration from a **job origin** referenced by `<Pro
 
 **For job origin modes and job file details, see:** references/job-file-guide.md
 
-**Composition Jobs (new in 2026.1):** a `.wacj` (run by the same `WebWorks.Automap.exe`) assembles independently built and deployed Reverb 2.0 parcels into one site under a shared shell — recompose takes seconds, no content rebuild. Related 2026.1 machinery: per-target **deploy scope** (`--deployscope`), **inline deploy-target definitions** plus the `--deploysettings` overlay, **Amazon S3 + CloudFront** destinations, and the global `--dryrun` switch. **Grammar, precedence, S3 behavior, and failure modes:** references/composition-jobs.md
+**Composition Jobs (new in 2026.1):** a `.wacj` (run by the same `WebWorks.Automap.exe`) assembles independently built and deployed Reverb 2.0 parcels into one site under a shared shell — recompose takes seconds, no content rebuild. Related 2026.1 machinery: per-target **deploy scope** (`--deployscope`), **inline destination definitions** plus the `--deploysettings` overlay, **Amazon S3 + CloudFront** destinations, and the global `--dryrun` switch. **Grammar, precedence, S3 behavior, and failure modes:** references/composition-jobs.md
 </overview>
 
 <usage>

--- a/plugins/webworks-agent-skills/skills/automap/references/cli-reference.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/cli-reference.md
@@ -127,7 +127,7 @@ All options below belong after the `--` separator and are forwarded to `WebWorks
 - **Use When**: Layer-scoped deployments (e.g., publishing only group parcels, or only the shell)
 
 **`--deploysettings <file>`** *(2026.1+)*
-- **Purpose**: XML file of inline deploy-target definitions (deploy.prefs entry schema, file/s3 actions only) overlaying deploy.prefs by name
+- **Purpose**: XML file of inline destination definitions (deploy.prefs entry schema, file/s3 actions only) overlaying deploy.prefs by name
 - **Use When**: CI environments where deploy.prefs is not configured on the machine
 
 ### Staging Folder (Job Files)

--- a/plugins/webworks-agent-skills/skills/automap/references/composition-jobs.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/composition-jobs.md
@@ -47,7 +47,7 @@ element):
     <Group name="Administration Guide"/>
   </MergeSettings>
 
-  <DeployTarget name="ProductionMirror"/>
+  <Destination name="ProductionMirror"/>
 </CompositionJob>
 ```
 
@@ -63,7 +63,9 @@ element):
   (DISCOVERY mode); declared groups plus `discover` is the hybrid. The root
   `title` attribute is accepted for `.waj` grammar parity but unused (warned):
   the composed site's title is shell chrome.
-- **`<DeployTarget name>`** — the shared destination. Resolution order:
+- **`<Destination name>`** — the shared destination. (2026.1 pre-release
+  builds spelled this `<DeployTarget>`; that spelling is still read for one
+  release and rewritten as `<Destination>` on save.) Resolution order:
   the composition job's own inline `<DeploySettings>` → a `--deploysettings`
   overlay file → the machine's deploy preferences (`deploy.prefs`), with a
   drift warning when an inline definition shadows a differing preference.
@@ -85,7 +87,7 @@ rebuild and redeploy the shell.
 & $automapExe composition.wacj --deployscope=shell   # NOT valid — scope belongs to member builds
 ```
 
-- Exit code 0 on success; non-zero on error (undefined deploy target, missing
+- Exit code 0 on success; non-zero on error (undefined destination, missing
   shell descriptor, member build failure).
 - A job-style log is written beside the file: `<name>-log.txt`.
 - Expected success lines: `Harvested N parcel descriptor(s) from the mirror`,
@@ -121,7 +123,7 @@ correctly. Per-parcel knowledge-base archives
 Groups-scope Clean also sweeps the build's own prior-generation archives
 (never a sibling's).
 
-## Inline deploy-target definitions
+## Inline destination definitions
 
 Deploy preferences are per-user, per-machine state; a version-controlled job
 that references a destination by name alone needs every machine seeded. Both
@@ -137,12 +139,12 @@ entry schema — references stay by name:
   </DeploySetting>
 </DeploySettings>
 
-<!-- .wacj: inside <DeployTarget> -->
-<DeployTarget name="ProductionMirror">
+<!-- .wacj: inside <Destination> -->
+<Destination name="ProductionMirror">
   <DeploySettings>
     <DeploySetting Name="ProductionMirror" Action="s3">...</DeploySetting>
   </DeploySettings>
-</DeployTarget>
+</Destination>
 ```
 
 - Precedence per name: **job file's own inline > `--deploysettings` overlay
@@ -194,8 +196,8 @@ deploying machine.
 - A failed deploy is an **error**: it reaches the per-target error count and
   the process exit status (2026.1; earlier versions logged a warning and
   exited 0).
-- `Deploy target '<name>' is not defined in deploy.prefs or inline in the
-  composition job.` — seed the name via inline definitions, an overlay file,
+- `Destination '<name>' is not defined in deploy.prefs, the --deploysettings
+  overlay, or inline in the composition job.` — seed the name via inline definitions, an overlay file,
   or deploy.prefs.
 - `The mirror has no shell composition descriptor (wwcomposition-shell.xml)`
   — the shell was never deployed to that mirror (or the path points at an

--- a/plugins/webworks-agent-skills/skills/automap/references/job-file-guide.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/job-file-guide.md
@@ -79,7 +79,7 @@ Stationery (.wxsp)              Job File (.waj)
 - Source documents and organization
 - Which targets to build
 - Target-specific overrides (conditions, variables, settings)
-- Deploy target names
+- Destination names
 - Build flags (clean, build enabled)
 
 ---
@@ -124,7 +124,7 @@ A job that uses a live Designer project as its stationery looks exactly like a S
             format="WebWorks Reverb 2.0"
             formatType="Application"
             build="True"
-            deployTarget=""
+            destination=""
             cleanOutput="False" />
   </Targets>
 </Job>
@@ -154,7 +154,7 @@ On each build AutoMap re-reads `design.wep`, stages a stationery from its curren
             format="WebWorks Reverb 2.0"
             formatType="Application"
             build="True"
-            deployTarget=""
+            destination=""
             cleanOutput="False" />
   </Targets>
 </Job>
@@ -184,7 +184,7 @@ On each build AutoMap re-reads `design.wep`, stages a stationery from its curren
             format="WebWorks Reverb 2.0"
             formatType="Application"
             build="True"
-            deployTarget="Production Help"
+            destination="Production Help"
             cleanOutput="False">
 
       <Conditions Expression="" UseClassicConditions="False" UseDocumentExpression="True">
@@ -207,7 +207,7 @@ On each build AutoMap re-reads `design.wep`, stages a stationery from its curren
             format="PDF - XSL-FO"
             formatType="Document"
             build="False"
-            deployTarget=""
+            destination=""
             cleanOutput="False" />
   </Targets>
 </Job>
@@ -271,7 +271,7 @@ Container for build targets. Contains one or more `<Target>` elements.
 | `format` | Yes | Format name from Stationery | Must match exactly (case-sensitive) |
 | `formatType` | Yes | Format type | `"Application"`, `"Document"` |
 | `build` | Yes | Build this target by default | `"True"`, `"False"` |
-| `deployTarget` | No | Deployment target name | Empty string or name |
+| `destination` | No | Named destination (pre-release spelling `deployTarget` still read for one release) | Empty string or name |
 | `cleanOutput` | Yes | Clean output before build | `"True"`, `"False"` |
 
 ### `<Conditions>` Element
@@ -383,7 +383,7 @@ powershell -ExecutionPolicy Bypass -File "<skill-dir>/scripts/Invoke-Automap.ps1
 
 **Notes**:
 
-- The staged project (and its `Output/`) persists after the build by default (the AutoMap "Remove temporary files" preference is off), which is why output can be retrieved from the Staging Folder. Deployment (`-d`/`--deployfolder`, or a `deployTarget`) copies output elsewhere; without it, the Staging Folder is the only place output lands.
+- The staged project (and its `Output/`) persists after the build by default (the AutoMap "Remove temporary files" preference is off), which is why output can be retrieved from the Staging Folder. Deployment (`-d`/`--deployfolder`, or a `destination`) copies output elsewhere; without it, the Staging Folder is the only place output lands.
 - This staging behavior applies to Stationery-based jobs (mode 1) **and** to `.wep`/`.wrp` jobs that opt in with `useAsStationery="True"` (mode 3) — both stage a temporary `.wrp` under the Staging Folder. A `.waj` that references a `.wep`/`.wrp` master project **without** `useAsStationery` (mode 2) instead builds in place, into that project's own `Output/` folder, ignoring the job's `<Files>`. See [Job Origin Modes (Stationery vs Project)](#job-origin-modes-stationery-vs-project).
 
 ---
@@ -433,7 +433,7 @@ When using `create-job.py` with `--config`, use this JSON format:
       "formatType": "Application",
       "build": true,
       "cleanOutput": false,
-      "deployTarget": "Production",
+      "destination": "Production",
       "conditions": [
         {"name": "OnlineOnly", "value": "True"}
       ],
@@ -501,15 +501,16 @@ python scripts/parse-stationery.py stationery.wxsp
 
 ### Deployment (new in 2026.1: scope and inline definitions)
 
-A `<Target>` element routes deployment through `deployTarget` (a named
-destination) and, as of ePublisher 2026.1, can scope what the deployment
+A `<Target>` element routes deployment through `destination` (a named
+destination; the 2026.1 pre-release spelling `deployTarget` is still read for
+one release) and, as of ePublisher 2026.1, can scope what the deployment
 publishes with `deployScope`:
 
 ```xml
 <Targets>
   <Target name="WebWorks Reverb 2.0" format="WebWorks Reverb 2.0"
           formatType="Application" build="True"
-          deployTarget="ProductionMirror" deployScope="groups" />
+          destination="ProductionMirror" deployScope="groups" />
 </Targets>
 ```
 
@@ -565,7 +566,7 @@ Groups are referenced **by name** (matching a top-level `<Files>` group). AutoMa
             format="WebWorks Reverb 2.0"
             formatType="Application"
             build="True"
-            deployTarget=""
+            destination=""
             cleanOutput="False">
 
       <!-- Define the merged TOC: title, containers, and parcel placement -->

--- a/plugins/webworks-agent-skills/skills/automap/scripts/create-job.py
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/create-job.py
@@ -268,7 +268,9 @@ def generate_job_xml(config: dict) -> str:
         target.set('format', target_config.get('format', ''))
         target.set('formatType', target_config.get('formatType', 'Application'))
         target.set('build', 'True' if target_config.get('build', True) else 'False')
-        target.set('deployTarget', target_config.get('deployTarget', ''))
+        # destination= is the current spelling; the pre-release deployTarget
+        # config key is accepted for one release.
+        target.set('destination', target_config.get('destination', target_config.get('deployTarget', '')))
         target.set('cleanOutput', 'True' if target_config.get('cleanOutput', False) else 'False')
 
         # Add Conditions if present
@@ -403,7 +405,7 @@ def interactive_collect_targets(stationery_data: dict) -> list[dict]:
             'formatType': selected_format['type'],
             'build': confirm("  Build this target by default?"),
             'cleanOutput': confirm("  Clean output before build?", default=False),
-            'deployTarget': prompt("  Deploy target name (blank for none)", ""),
+            'destination': prompt("  Destination name (blank for none)", ""),
             'conditions': [],
             'variables': [],
             'settings': []
@@ -530,8 +532,9 @@ def print_summary(config: dict) -> None:
     for target in targets:
         status = "[BUILD]" if target.get('build', True) else "[SKIP]"
         print(f"\n  {status} {target['name']}")
-        if target.get('deployTarget'):
-            print(f"         Deploy: {target['deployTarget']}")
+        destination = target.get('destination') or target.get('deployTarget')
+        if destination:
+            print(f"         Deploy: {destination}")
         if target.get('conditions'):
             conds = ', '.join(f"{c['name']}={c['value']}" for c in target['conditions'])
             print(f"         Conditions: {conds}")
@@ -574,7 +577,7 @@ def generate_template(stationery_data: dict, stationery_path: str) -> dict:
             'formatType': fmt['type'],
             'build': True,
             'cleanOutput': False,
-            'deployTarget': '',
+            'destination': '',
             'conditions': [],
             'variables': [],
             'settings': []

--- a/plugins/webworks-agent-skills/skills/automap/scripts/list-job-targets.py
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/list-job-targets.py
@@ -92,7 +92,7 @@ def extract_targets(root: Element) -> list[dict]:
             'formatType': target_elem.get('formatType', 'Application'),
             'build': target_elem.get('build', 'True') == 'True',
             'cleanOutput': target_elem.get('cleanOutput', 'False') == 'True',
-            'deployTarget': target_elem.get('deployTarget', ''),
+            'destination': target_elem.get('destination') or target_elem.get('deployTarget', ''),
             'conditionsCount': 0,
             'variablesCount': 0,
             'settingsCount': 0,
@@ -169,8 +169,8 @@ def output_table(job_name: str, stationery: str, targets: list[dict],
         print(f"  {status} {target['name']}")
         print(f"          Format: {target['format']}")
 
-        if target['deployTarget']:
-            print(f"          Deploy: {target['deployTarget']}")
+        if target['destination']:
+            print(f"          Deploy: {target['destination']}")
 
         if target['cleanOutput']:
             print(f"          Clean: Yes")
@@ -208,8 +208,8 @@ def output_detailed(job_name: str, stationery: str, targets: list[dict],
         print(f"          Format: {target['format']}")
         print(f"          Type: {target['formatType']}")
 
-        if target['deployTarget']:
-            print(f"          Deploy: {target['deployTarget']}")
+        if target['destination']:
+            print(f"          Deploy: {target['destination']}")
 
         print(f"          Clean: {'Yes' if target['cleanOutput'] else 'No'}")
 

--- a/plugins/webworks-agent-skills/skills/automap/scripts/parse-job.py
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/parse-job.py
@@ -138,7 +138,7 @@ def extract_job_info(root: Element, job_path: str) -> dict:
                 'formatType': target_elem.get('formatType', 'Application'),
                 'build': target_elem.get('build', 'True') == 'True',
                 'cleanOutput': target_elem.get('cleanOutput', 'False') == 'True',
-                'deployTarget': target_elem.get('deployTarget', ''),
+                'destination': target_elem.get('destination') or target_elem.get('deployTarget', ''),
                 'conditions': [],
                 'variables': [],
                 'settings': []
@@ -206,8 +206,8 @@ def output_human_readable(job_info: dict) -> None:
         print(f"         Format: {target['format']}")
         print(f"         Type: {target['formatType']}")
 
-        if target['deployTarget']:
-            print(f"         Deploy: {target['deployTarget']}")
+        if target['destination']:
+            print(f"         Deploy: {target['destination']}")
 
         if target['cleanOutput']:
             print(f"         Clean: Yes")

--- a/plugins/webworks-agent-skills/skills/automap/tests/sample-designer-stationery.waj
+++ b/plugins/webworks-agent-skills/skills/automap/tests/sample-designer-stationery.waj
@@ -12,7 +12,7 @@
             format="WebWorks Reverb 2.0"
             formatType="Application"
             build="True"
-            deployTarget=""
+            destination=""
             cleanOutput="False" />
   </Targets>
 </Job>

--- a/plugins/webworks-agent-skills/skills/automap/tests/sample.waj
+++ b/plugins/webworks-agent-skills/skills/automap/tests/sample.waj
@@ -15,7 +15,7 @@
             format="WebWorks Reverb 2.0"
             formatType="Application"
             build="True"
-            deployTarget=""
+            destination=""
             cleanOutput="False">
       <Conditions Expression="" UseClassicConditions="False" UseDocumentExpression="True">
         <Condition name="OnlineOnly" value="True" Passthrough="False" UseDocumentValue="False" />
@@ -31,7 +31,7 @@
             format="PDF - XSL-FO"
             formatType="Document"
             build="False"
-            deployTarget=""
+            destination=""
             cleanOutput="False" />
   </Targets>
 </Job>

--- a/plugins/webworks-agent-skills/skills/epublisher/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/SKILL.md
@@ -79,9 +79,9 @@ A Designer `.wep` carries **no** `<format>.base` snapshots, so its transforms re
 
 **For job-file usage of `useAsStationery`, see the automap skill's `references/job-file-guide.md`.**
 
-### Deploy Targets and Deploy Scope (new in 2026.1)
+### Deploy Destinations and Deploy Scope (new in 2026.1)
 
-Output destinations (Target Settings **Deploy to** / **Add deploy target**) are machine-global named definitions shared across projects. As of ePublisher 2026.1: destinations can be **Folder** or **Amazon S3** (bucket/region/named credential profile/CloudFront distribution — no stored secrets; dry run supported); each target also declares a **Deploy** scope — Everything (complete site), Groups (content only), or Shell (site files only) — which powers federated parcel composition in WebWorks Reverb 2.0 (the field is disabled for formats without the capability). Deployments never delete outside their own scope slice, and Clean remains AutoMap-only. For the federation workflow, `.wacj` composition jobs, and inline deploy-target definitions, see the automap skill's `references/composition-jobs.md`; for version gating, `references/version-compatibility.md`.
+Output destinations (Target Settings **Deploy to** / Edit > **Deploy Destinations**) are machine-global named definitions shared across projects. As of ePublisher 2026.1: destinations can be **Folder** or **Amazon S3** (bucket/region/named credential profile/CloudFront distribution — no stored secrets; dry run supported); each target also declares a **Deploy** scope — Everything (complete site), Groups (content only), or Shell (site files only) — which powers federated parcel composition in WebWorks Reverb 2.0 (the field is disabled for formats without the capability). Deployments never delete outside their own scope slice, and Clean remains AutoMap-only. For the federation workflow, `.wacj` composition jobs, and inline destination definitions, see the automap skill's `references/composition-jobs.md`; for version gating, `references/version-compatibility.md`.
 
 ### Project File Format
 

--- a/plugins/webworks-agent-skills/skills/epublisher/references/version-compatibility.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/references/version-compatibility.md
@@ -17,7 +17,7 @@
 - `useAsStationery="True"` on a job's `<Project>` element (a live `.wep`/`.wrp` as stationery)
 - Federated parcel composition (Reverb 2.0): `.wacj` composition jobs, per-target deploy scope (Everything / Groups / Shell; `deployScope` attribute, `--deployscope`), `wwcomposition*` output descriptors
 - Amazon S3 + CloudFront deploy destinations (named profile/role credentials, deploy-time invalidation, dry run; global `--dryrun`)
-- Inline deploy-target definitions in `.waj`/`.wacj` (`<DeploySettings>`) and the `--deploysettings` overlay file
+- Inline destination definitions in `.waj`/`.wacj` (`<DeploySettings>`) and the `--deploysettings` overlay file
 - A failed deploy is an error (reaches the exit status); earlier versions warned and exited 0
 - See the automap skill's `references/composition-jobs.md` before recommending any of these — never suggest them to users on 2025.1 or earlier
 


### PR DESCRIPTION
The 2026.1 pre-release rename (Trac #2868) reserves "Target" for output targets; the named deployment destination is now **Destination**:

- `.wacj` `<DeployTarget name="…">` → `<Destination name="…">`
- `.waj` `<Target deployTarget="…">` → `<Target destination="…">`
- UI: "Local Deploy Targets" → "Deploy Destinations"; "Folder / Amazon S3 Deploy Target" dialogs → "Folder / Amazon S3 Destination"

## Changes

- **References**: `composition-jobs.md`, `job-file-guide.md`, `cli-reference.md`, automap `SKILL.md`, epublisher `SKILL.md`, `version-compatibility.md` — grammar samples, attribute tables, UI names, and the expected error wording (`Destination '<name>' is not defined in deploy.prefs, the --deploysettings overlay, or inline in the composition job.`). Compat notes state the old spellings are read for one release and rewritten on save.
- **Scripts** follow the product's compat rule: `create-job.py` writes `destination=` (still accepting a legacy `deployTarget` config key), `parse-job.py` / `list-job-targets.py` read `destination=` with a `deployTarget=` fallback.
- **Test fixtures** (`tests/*.waj`) swept to the new spelling.

## Verification

`parse-job.py` and `list-job-targets.py` run against samples in both spellings (legacy `deployTarget="LegacyName"` and new `destination="NewName"`) resolve the destination correctly.

Known gap (separate change): `Invoke-Automap.ps1` does not yet recognize `.wacj` as a job file argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)