### PR TITLE
Closes #140: Invoke-Automap.ps1 accepts .wacj composition jobs

### DIFF
--- a/plugins/webworks-agent-skills/skills/automap/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/automap/SKILL.md
@@ -49,8 +49,8 @@ Job files inherit format configuration from a **job origin** referenced by `<Pro
 
 1. **Executable resolution** — auto-detects the AutoMap installation; `AUTOMAP_EXE_PATH` or `-ExePath` overrides it (e.g., development builds)
 2. **Minimal output** — suppresses AutoMap's streaming stdout (banner, per-file progress); stderr passes through, so genuine errors still surface
-3. **Development-safe defaults** — injects `-n` and `--skip-reports`, and requires an explicit target, unless opted out
-4. **Post-build log scan** — reports per-target warning/error counts from `generate.log`
+3. **Development-safe defaults** — injects `-n` and `--skip-reports`, and requires an explicit target, unless opted out. A composition job (`.wacj`) always runs with native semantics: no flag applies to a compose and targets belong to member builds, so nothing is injected and no target is required (`--dryrun` is the native rehearsal switch)
+4. **Post-build log scan** — reports per-target warning/error counts from `generate.log`, and for a `.wacj` from the composition's `<job name>-log.txt` beside the file
 
 **Every AutoMap flag is pass-through.** The wrapper never translates, renames, or owns AutoMap options. Wrapper-level options are PowerShell-style names (`-NoDefaults`, `-AllTargets`, `-ExePath`, `-Help`) given before the `--` separator; everything after `--` is forwarded to `WebWorks.Automap.exe` verbatim.
 
@@ -111,6 +111,10 @@ powershell -ExecutionPolicy Bypass -File "<skill-dir>/scripts/Invoke-Automap.ps1
 # Job file (.waj): build its build="True" target set (explicitly waive the target requirement)
 powershell -ExecutionPolicy Bypass -File "<skill-dir>/scripts/Invoke-Automap.ps1" -AllTargets -- job.waj
 
+# Composition job (.wacj): rehearse the compose dry, then run it for real
+powershell -ExecutionPolicy Bypass -File "<skill-dir>/scripts/Invoke-Automap.ps1" -- --dryrun composition.wacj
+powershell -ExecutionPolicy Bypass -File "<skill-dir>/scripts/Invoke-Automap.ps1" -- composition.wacj
+
 # Production build: exact native CLI semantics (deploys, generates reports)
 powershell -ExecutionPolicy Bypass -File "<skill-dir>/scripts/Invoke-Automap.ps1" -NoDefaults -- -c -t "WebWorks Reverb 2.0" project.wep
 ```
@@ -127,6 +131,8 @@ Unless `-NoDefaults` is given, the wrapper injects these **native AutoMap flags*
 | `--skip-reports` | already present | Faster builds *(2025.1+ — use `-NoDefaults` with older versions)* |
 
 And one requirement: **an explicit `-t`/`--target` must be present**, so a job file's full `build="True"` set (or a project's every target) never builds by accident. Waive it with `-AllTargets` (defaults still apply) or `-NoDefaults` (verbatim native behavior). On violation the wrapper exits 2 and lists the file's targets.
+
+**Composition jobs are exempt.** A `.wacj` composes already-deployed output: `-n` would fight the run's purpose, `--skip-reports` has nothing to skip, and output targets belong to the member builds. The wrapper therefore runs a `.wacj` with native semantics automatically (reported on an `[INFO]` line) — no injected flags, no target requirement. To rehearse a compose without touching the mirror, pass the native `--dryrun` switch.
 
 Note: a clean build (`-c`) is **not** a default — pass it explicitly when you need one.
 

--- a/plugins/webworks-agent-skills/skills/automap/references/cli-reference.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/cli-reference.md
@@ -27,7 +27,7 @@ powershell -ExecutionPolicy Bypass -File "<skill-dir>/scripts/Invoke-Automap.ps1
 - `[wrapper options]`: PowerShell-style options for the wrapper itself (`-NoDefaults`, `-AllTargets`, `-ExePath <path>`, `-Help`)
 - `--`: separator — everything after it is forwarded to `WebWorks.Automap.exe` verbatim. (Technically optional: the first token that is not a wrapper option also ends wrapper parsing. Always include it anyway; it makes the boundary explicit.)
 - `<automap options>`: native AutoMap CLI flags (see [Native Command Options](#native-command-options))
-- `<project-file>`: path to `.wep`, `.wrp`, `.waj`, or `.wxsp` project/job file
+- `<project-file>`: path to `.wep`, `.wrp`, `.waj`, `.wacj`, or `.wxsp` project/job file. A composition job (`.wacj`) always runs with native semantics — the wrapper injects nothing and requires no target (pass `--dryrun` to rehearse the compose).
 
 ## Wrapper Options
 

--- a/plugins/webworks-agent-skills/skills/automap/scripts/Invoke-Automap.ps1
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/Invoke-Automap.ps1
@@ -8,8 +8,12 @@ The wrapper exists for exactly four jobs:
   2. Suppress AutoMap's streaming stdout (stderr passes through), reporting
      a one-line result instead.
   3. Apply development-safe default flags (-n, --skip-reports) and require
-     an explicit target, unless opted out.
-  4. Scan generate.log files after a successful build and report per-target
+     an explicit target, unless opted out. Composition jobs (.wacj) always
+     run with native semantics: no flag applies to a compose and targets
+     belong to member builds, so nothing is injected and no target is
+     required (use --dryrun to rehearse a compose safely).
+  4. Scan generate.log files (and, for a .wacj, the composition's
+     <job name>-log.txt beside the file) after a successful run and report
      warning/error counts.
 
 Every AutoMap flag is PASS-THROUGH. The wrapper never translates, renames,
@@ -51,7 +55,7 @@ Requires Windows PowerShell 5.1 or later.
 
 Set-StrictMode -Version 2.0
 
-$script:ProjectExtensionPattern = '\.(wep|wrp|waj|wxsp)$'
+$script:ProjectExtensionPattern = '\.(wep|wrp|waj|wacj|wxsp)$'
 $script:DefaultStagingRoot = Join-Path $env:USERPROFILE 'Documents\WebWorks ePublisher AutoMap\Staging'
 
 function Write-StderrLine {
@@ -76,7 +80,9 @@ Everything else is forwarded to WebWorks.Automap.exe verbatim. Run
 
 Defaults injected unless -NoDefaults: -n (unless deploy flags present),
 --skip-reports (2025.1+). An explicit -t/--target is required unless
--NoDefaults or -AllTargets.
+-NoDefaults or -AllTargets. A composition job (.wacj) always runs with
+native semantics -- nothing is injected and no target is required; pass
+--dryrun to rehearse a compose without touching the mirror.
 
 Examples:
   # Dev build, safe defaults applied
@@ -84,6 +90,10 @@ Examples:
 
   # Job file: build its enabled target set, still no deploy/reports
   Invoke-Automap.ps1 -AllTargets -- job.waj
+
+  # Composition job: rehearse the compose dry, then run it for real
+  Invoke-Automap.ps1 -- --dryrun composition.wacj
+  Invoke-Automap.ps1 -- composition.wacj
 
   # Production: exact native semantics (deploys, generates reports)
   Invoke-Automap.ps1 -NoDefaults -- -c -t "WebWorks Reverb 2.0" project.wep
@@ -185,6 +195,47 @@ function Get-GenerateLogSummaries {
         }
     }
     return $summaries
+}
+
+# A composition job writes a job-style log beside the .wacj file, named
+# <job name>-log.txt (job name attribute, falling back to the file's base
+# name). Returns a summary object like Get-GenerateLogSummaries, or $null
+# when the log is absent or clean. Purely observational.
+function Get-CompositionLogSummary {
+    param([string]$Path)
+
+    $fullPath = (Resolve-Path -LiteralPath $Path).Path
+    $dir = Split-Path -Parent $fullPath
+
+    $jobName = $null
+    $content = Get-Content -LiteralPath $fullPath -Raw -ErrorAction SilentlyContinue
+    if ($content) {
+        $nameMatch = [regex]::Match($content, '<CompositionJob\b[^>]*\bname\s*=\s*"([^"]*)"')
+        if ($nameMatch.Success) { $jobName = $nameMatch.Groups[1].Value }
+    }
+    if (-not $jobName) { $jobName = [System.IO.Path]::GetFileNameWithoutExtension($fullPath) }
+
+    $logFile = Join-Path $dir "$jobName-log.txt"
+    if (-not (Test-Path -LiteralPath $logFile -PathType Leaf)) { return $null }
+
+    $warnCount = 0
+    $errorCount = 0
+    try {
+        $warnCount = @(Select-String -LiteralPath $logFile -Pattern '[Warning]' -SimpleMatch).Count
+        $errorCount = @(Select-String -LiteralPath $logFile -Pattern '[Error]' -SimpleMatch).Count
+    }
+    catch {
+        return $null
+    }
+    if (($warnCount -eq 0) -and ($errorCount -eq 0)) { return $null }
+
+    $isError = ($errorCount -gt 0)
+    $label = '[WARNING]'
+    if ($isError) { $label = '[ERROR]' }
+    return [pscustomobject]@{
+        Text    = "$label $warnCount warning(s), $errorCount error(s) in $jobName-log.txt"
+        IsError = $isError
+    }
 }
 
 # Determines the directories whose Logs/ should be scanned after a build.
@@ -300,7 +351,7 @@ function Invoke-Main {
         })
 
     if ($projectFiles.Count -eq 0) {
-        Write-StderrLine '[ERROR] No project or job file (.wep, .wrp, .waj, .wxsp) found in arguments'
+        Write-StderrLine '[ERROR] No project or job file (.wep, .wrp, .waj, .wacj, .wxsp) found in arguments'
         Show-Usage
         exit 2
     }
@@ -310,6 +361,17 @@ function Invoke-Main {
             Write-StderrLine "[ERROR] Project file not found: $file"
             exit 4
         }
+    }
+
+    # --- Composition jobs run verbatim -------------------------------------
+    # A .wacj composes already-deployed output: -n would fight the run's
+    # purpose, --skip-reports has nothing to skip, and output targets belong
+    # to the member builds, not the composition. So a composition implies
+    # -NoDefaults; --dryrun is the native way to rehearse a compose safely.
+    $compositionFiles = @($projectFiles | Where-Object { $_ -match '\.wacj$' })
+    if (($compositionFiles.Count -gt 0) -and (-not $noDefaults)) {
+        $noDefaults = $true
+        Write-Output '[INFO] Composition job (.wacj): native CLI semantics (no injected flags, no target requirement); pass --dryrun to rehearse the compose.'
     }
 
     # --- Explicit-target requirement --------------------------------------
@@ -388,7 +450,15 @@ function Invoke-Main {
 
     # --- Post-build log scan (observational; never alters the exit code) ---
     try {
-        foreach ($base in Get-LogScanBases -ProjectFiles $projectFiles -PassthroughArgs $passthrough) {
+        foreach ($file in $compositionFiles) {
+            $summary = Get-CompositionLogSummary -Path $file
+            if ($summary) {
+                if ($summary.IsError) { Write-StderrLine $summary.Text }
+                else { Write-Output $summary.Text }
+            }
+        }
+        $buildFiles = @($projectFiles | Where-Object { $_ -notmatch '\.wacj$' })
+        foreach ($base in Get-LogScanBases -ProjectFiles $buildFiles -PassthroughArgs $passthrough) {
             $summaries = @(Get-GenerateLogSummaries -BaseDir $base.Dir)
             if (($summaries.Count -gt 0) -and $base.Announce) {
                 Write-Output "[INFO] Logs under staging folder: $($base.Dir)"

--- a/plugins/webworks-agent-skills/skills/automap/tests/test-wrapper-args.ps1
+++ b/plugins/webworks-agent-skills/skills/automap/tests/test-wrapper-args.ps1
@@ -40,6 +40,11 @@ Set-Content -LiteralPath $job -Encoding Ascii -Value @'
 <Job name="Sample Job"><Targets><Target name="Target A" build="True"/><Target name="Target B" build="False"/></Targets></Job>
 '@
 
+$composition = Join-Path $work 'sample.wacj'
+Set-Content -LiteralPath $composition -Encoding Ascii -Value @'
+<CompositionJob name="Sample Composition" version="1.0"><Jobs><Job path="sample.waj" role="shell"/></Jobs><Destination name="Mirror"/></CompositionJob>
+'@
+
 $argsFile = Join-Path $work 'stub-args.txt'
 $env:STUB_OUT = $argsFile
 $env:STUB_EXIT = '0'
@@ -155,6 +160,30 @@ Assert 'build failure: reported with code' ($r.Output -match '\[ERROR\] Build fa
 # 12. -ExePath without a value: exit 2.
 $r = Invoke-Wrapper @('-ExePath')
 Assert 'dangling -ExePath: exit 2' ($r.ExitCode -eq 2) $r.Output
+
+# 13. Composition job (.wacj): recognized, native semantics, no target guard.
+$r = Invoke-Wrapper @('-ExePath', $stub, '--', '--dryrun', $composition)
+Assert 'wacj: exit 0' ($r.ExitCode -eq 0) $r.Output
+Assert 'wacj: nothing injected' (-not ($r.StubArgs -match '(^| )-n( |$)') -and -not ($r.StubArgs -match '--skip-reports')) $r.StubArgs
+Assert 'wacj: --dryrun forwarded verbatim' ($r.StubArgs -match '--dryrun') $r.StubArgs
+Assert 'wacj: native-semantics info line' ($r.Output -match '\[INFO\] Composition job \(\.wacj\)') $r.Output
+
+# 14. Composition job with explicit -NoDefaults: no redundant info line.
+$r = Invoke-Wrapper @('-ExePath', $stub, '-NoDefaults', '--', $composition)
+Assert 'wacj -NoDefaults: exit 0' ($r.ExitCode -eq 0) $r.Output
+Assert 'wacj -NoDefaults: no info line' (-not ($r.Output -match '\[INFO\] Composition job')) $r.Output
+
+# 15. Composition log scan: <job name>-log.txt beside the .wacj is summarized.
+$compositionLog = Join-Path $work 'Sample Composition-log.txt'
+Set-Content -LiteralPath $compositionLog -Encoding Ascii -Value @'
+Composition job 'Sample Composition' started.
+[Warning] parcel 'Extra' has no descriptor; omitted.
+[Error] Destination 'Mirror' is not defined in deploy.prefs, the --deploysettings overlay, or inline in the composition job.
+'@
+$r = Invoke-Wrapper @('-ExePath', $stub, '--', $composition)
+Assert 'wacj log scan: counts reported' ($r.Output -match '\[ERROR\] 1 warning\(s\), 1 error\(s\) in Sample Composition-log\.txt') $r.Output
+Assert 'wacj log scan: exit code unaffected' ($r.ExitCode -eq 0) $r.Output
+Remove-Item -LiteralPath $compositionLog -ErrorAction SilentlyContinue
 
 # --- Results ---------------------------------------------------------------
 


### PR DESCRIPTION
Closes #140.

The wrapper's job-file allowlist predated AutoMap Composition Jobs (2026.1), so every `.wacj` run failed with `[ERROR] No project or job file (.wep, .wrp, .waj, .wxsp) found in arguments` and composition runs had to bypass the wrapper.

## Behavior

- `.wacj` joins the recognized extensions.
- **A composition implies `-NoDefaults`**: `-n` would fight the run's purpose (a compose IS deployment), `--skip-reports` has nothing to skip, and the explicit `-t` requirement doesn't apply (output targets belong to member builds). The wrapper announces this on an `[INFO]` line and points at `--dryrun` as the native rehearsal switch. With an explicit `-NoDefaults`, no redundant info line.
- **Composition log scan**: the post-run scan now summarizes `<job name>-log.txt` beside the `.wacj` (job `name` attribute, file-name fallback) with `[Warning]`/`[Error]` line counts — observational, never alters the exit code. `.wacj` files are excluded from the `generate.log` scan bases.
- Docs updated: wrapper usage text, SKILL.md (four-jobs list, Run a Build examples, Safe Defaults exemption), cli-reference.md extension list.

## Verification

- `test-wrapper-args.ps1`: 34/34 (three new `.wacj` cases: native semantics + info line + verbatim `--dryrun` forwarding; `-NoDefaults` dedup; log-scan summary with exit code unaffected). `test-log-scan.ps1`: 6/6.
- Real run against the trunk debug AutoMap (post-r35984) on the epublisher-tests `federation-lab/compat/legacy-spelling.wacj` fixture:
  ```
  [INFO] Composition job (.wacj): native CLI semantics (no injected flags, no target requirement); pass --dryrun to rehearse the compose.
  [SUCCESS] Build completed in 10s
  === EXIT: 0 ===
  ```

Context: discovered while landing the EPUB2868 Destination rename (#139, trunk r35984).

🤖 Generated with [Claude Code](https://claude.com/claude-code)