### PR TITLE
Closes #142: Update epublisher, automap, and reverb2 skills for ePublisher 2026.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "webworks-agent-skills",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "owner": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/.claude-plugin/plugin.json
+++ b/plugins/webworks-agent-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webworks-agent-skills",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "author": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/skills/automap/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/automap/SKILL.md
@@ -127,7 +127,7 @@ Unless `-NoDefaults` is given, the wrapper injects these **native AutoMap flags*
 
 | Injected flag | Skipped when | Purpose |
 |---------------|--------------|---------|
-| `-n` (nodeploy) | `-n`/`--nodeploy` already present, or deploy intent signaled (`-d`/`--deployfolder`, `-l`/`--cleandeploy`, `--deploysettings`, `--deployscope`) | Prevent accidental deployment |
+| `-n` (nodeploy) | `-n`/`--nodeploy` already present, or deploy intent signaled (`-d`/`--deployfolder`, `-l`/`--cleandeploy`, `--deploysettings`, `--deployscope`, `--destination`, `--dryrun`) | Prevent accidental deployment |
 | `--skip-reports` | already present | Faster builds *(2025.1+ — use `-NoDefaults` with older versions)* |
 
 And one requirement: **an explicit `-t`/`--target` must be present**, so a job file's full `build="True"` set (or a project's every target) never builds by accident. Waive it with `-AllTargets` (defaults still apply) or `-NoDefaults` (verbatim native behavior). On violation the wrapper exits 2 and lists the file's targets.
@@ -457,7 +457,7 @@ powershell -ExecutionPolicy Bypass -File "$WRAPPER" -ExePath "C:\dev\WebWorks.Au
 **Solutions:**
 1. Read `generate.log` for the specific error lines — `grep -nE '\[ERROR\]|\[WARN\]' "<project-or-staging>/Logs/<target>/generate.log"`. AutoMap's stderr also passes through the wrapper, so genuine errors surface inline (see [Post-Build Log Scan](#post-build-log-scan)).
 2. Verify source documents exist and are accessible
-3. Open project in ePublisher Administrator to check for issues
+3. Open project in ePublisher Designer (`.wep`) or Express (`.wrp`) to check for issues
 4. Try a clean build (`-c`)
 
 ### "No target specified" (exit 2)

--- a/plugins/webworks-agent-skills/skills/automap/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/automap/SKILL.md
@@ -38,7 +38,7 @@ Job files inherit format configuration from a **job origin** referenced by `<Pro
 
 **For job origin modes and job file details, see:** references/job-file-guide.md
 
-**Composition Jobs (new in 2026.1):** a `.wacj` (run by the same `WebWorks.Automap.exe`) assembles independently built and deployed Reverb 2.0 parcels into one site under a shared shell — recompose takes seconds, no content rebuild. Related 2026.1 machinery: per-target **deploy scope** (`--deployscope`), **inline destination definitions** plus the `--deploysettings` overlay, **Amazon S3 + CloudFront** destinations, and the global `--dryrun` switch. **Grammar, precedence, S3 behavior, and failure modes:** references/composition-jobs.md
+**Composition Jobs (new in 2026.1):** a `.wacj` (run by the same `WebWorks.Automap.exe`) assembles independently built and deployed Reverb 2.0 parcels into one site under a shared shell — recompose takes seconds, no content rebuild. Each member's `build` flag picks the archetype: **federated** (`build="false"`, the member's own job publishes it) or **derivative** (`build="true"`, the composition builds it and forwards `--destination` so it deploys to the *composition's* destination). Related 2026.1 machinery: per-target **deploy scope** (`--deployscope`), **inline destination definitions** plus the `--deploysettings` overlay, **Amazon S3 + CloudFront** destinations, and the global `--dryrun` switch. **Grammar, output-target selection, precedence, S3 behavior, and failure modes:** references/composition-jobs.md
 </overview>
 
 <usage>
@@ -219,6 +219,8 @@ python scripts/list-job-targets.py job.waj
 python scripts/list-job-targets.py --enabled job.waj
 ```
 
+All four tools accept `.wacj` composition jobs as well as `.waj` (2026.1+): parse/validate/list dispatch on the root element (`<Job>` vs `<CompositionJob>`), `validate-job.py --check-members` is the composition preflight, and `create-job.py --template --composition` emits a composition config template. See references/composition-jobs.md's Tooling section.
+
 ### Stationery Relationship
 
 Job files reference their origin via `<Project path="..."/>`:
@@ -226,6 +228,10 @@ Job files reference their origin via `<Project path="..."/>`:
 - All format settings inherited from the origin (Stationery `.wxsp`, or a `.wep`/`.wrp` project)
 - Targets can override conditions, variables, settings
 - A `.wep`/`.wrp` origin builds **in place** (its own documents, the job's `<Files>` ignored) unless `useAsStationery="True"` stages it as a **stationery** (job documents injected) — see the three job-origin modes in references/job-file-guide.md
+
+### Job-Stored Build Options (2026.1+)
+
+A `.waj` can carry `<Options skipReports="True" verboseLogging="False"/>`. These **combine with** the equivalent CLI switches rather than being overridden by them: either `skipReports` or `--skip-reports` skips reports; either clearing `verboseLogging` or passing `-q` quiets the run. A scheduled task passes no flags, so the stored options are what it honors. The wrapper's unconditional `--skip-reports` injection is therefore harmless but also uninformative about what the job declares — use `-NoDefaults` when a run must match the job exactly. See references/job-file-guide.md.
 </job_files>
 
 <cli_reference>
@@ -262,6 +268,8 @@ All native flags pass through unchanged — in any form the AutoMap CLI itself a
 | `-d, --deployfolder <path>` | Deploy to a specific folder (suppresses the `-n` default) |
 | `-l, --cleandeploy` | Clean deploy location first (suppresses the `-n` default) |
 | `-s, --stagingdir <dir>` | Staging directory for job-file (`.waj`) builds; output lands at `<dir>/<JobName>/Output/<target>/` |
+| `--destination=<name>` | Deploy every built target to the named destination instead of its own. Ignored when `-d` is given. Suppresses the `-n` default. *(2026.1+)* |
+| `-q, --quiet` | Suppress the engine's progress messages in the console and job log; warnings and errors still print. Combines with a job's **Verbose logging** option. *(2026.1+)* |
 
 **For the complete native CLI reference with examples, see:** references/cli-reference.md
 </cli_reference>
@@ -275,10 +283,10 @@ All native flags pass through unchanged — in any form the AutoMap CLI itself a
 | `Find-AutomapInstallation.ps1` | Find AutoMap installation (registry, then filesystem) |
 | `Invoke-Automap.ps1` | Execute builds (the execution interface) |
 | `parse-stationery.py` | Extract formats/settings from Stationery |
-| `create-job.py` | Create job files interactively or from config |
-| `parse-job.py` | Parse existing job files |
-| `validate-job.py` | Validate job files before building |
-| `list-job-targets.py` | List targets with build status |
+| `create-job.py` | Create job files (`.waj` and `.wacj`) interactively or from config |
+| `parse-job.py` | Parse existing job files (`.waj` and `.wacj`) |
+| `validate-job.py` | Validate job files before building (`--check-members` for compositions) |
+| `list-job-targets.py` | List targets with build status (members for a `.wacj`) |
 
 Both PowerShell scripts run on Windows PowerShell 5.1 (preinstalled on Windows) and later; `powershell -ExecutionPolicy Bypass -File` works under the default `Restricted` policy without changing user state.
 </scripts>
@@ -288,9 +296,10 @@ Both PowerShell scripts run on Windows PowerShell 5.1 (preinstalled on Windows) 
 ## Reference Files
 
 - `cli-reference.md` - Complete CLI options and syntax
-- `cli-vs-administrator.md` - When to use CLI vs GUI
+- `cli-vs-administrator.md` - When to use CLI vs GUI; Administrator capabilities (destinations, preview, scheduling)
+- `composition-jobs.md` - `.wacj` composition jobs, federated vs. derivative members, destinations, dry run
 - `installation-detection.md` - Installation paths and detection logic
-- `job-file-guide.md` - Job file structure and Stationery inheritance
+- `job-file-guide.md` - Job file structure, origin modes, build options, Stationery inheritance
 </references>
 
 <requirements>
@@ -333,6 +342,10 @@ After a successful build (exit 0), the wrapper scans each target's `generate.log
 - Job files (`.waj`): scans under the staging folder — `<stagingDir>/<JobName>/Logs/<target>/generate.log` — using the `-s`/`--stagingdir` value from the arguments, or the default staging folder (`%USERPROFILE%\Documents\WebWorks ePublisher AutoMap\Staging`). An `[INFO]` line announces the staging location when counts are found there.
 - Targets with non-zero counts get a one-line summary (`[WARNING]` on stdout when only warnings, `[ERROR]` on stderr when any errors). Clean targets emit nothing.
 - Exit codes are unchanged — the scan is observational. A successful build that records warnings still exits 0.
+
+**Caveat — the scan matches English markers only.** `[WARN]`/`[ERROR]` are localized: a German install writes `[WARNUNG]`/`[FEHLER]`, French `[AVERTISSEMENT]`/`[ERREUR]`, Japanese the kanji equivalents. The scan's patterns are hard-coded English, so on a non-English install it reports 0/0 for logs that are full of marked lines. **Do not read a zero count on such a machine as a clean build** — check the exit code, or grep the log for the console's own tokens.
+
+For a `.wacj`, the scanned `<job name>-log.txt` also contains **relayed member-build lines** that keep their markers. Those belong to the member's own ledger, so the wrapper's count is deliberately looser than the composition's own closing tally — see references/composition-jobs.md.
 
 ```text
 [SUCCESS] Build completed in 43s

--- a/plugins/webworks-agent-skills/skills/automap/references/cli-reference.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/cli-reference.md
@@ -122,13 +122,26 @@ All options below belong after the `--` separator and are forwarded to `WebWorks
 - **Impact**: Output copied to specified path instead of project default. Signals deploy intent — the wrapper will not inject `-n`.
 - **Note**: Must have write permissions to deployment path
 
+**`--destination=<name>`** *(2026.1+)*
+- **Purpose**: Deploy **every built target in the run** to the named destination instead of each target's own. The name resolves through the same precedence a declared destination does — inline definitions (job file, then `--deploysettings` overlay), then `deploy.prefs`.
+- **Use When**: Redirecting a whole run to one destination without editing the job (CI promotion, a staging mirror); it is also the mechanism a composition uses to make `build="true"` members deploy to the *composition's* destination.
+- **Impact**: Signals deploy intent — the wrapper will not inject `-n`. **Ignored when `-d`/`--deployfolder` is given** (the folder override wins; `--destination` only substitutes a *name*).
+- **Log**: `Destination override (--destination): deploying target "<target>" to "<name>".` — emitted only when the name differs from the target's own. The resolution itself logs `Destination '<name>' resolved from <source>.`
+- **Example**: `-t "WebWorks Reverb 2.0" --destination="StagingMirror" project.wep`
+
 **`--deployscope <everything|groups|shell>`** *(2026.1+)*
 - **Purpose**: Override the deploy scope declared on the target
 - **Use When**: Layer-scoped deployments (e.g., publishing only group parcels, or only the shell)
+- **Note**: Applies to **target builds only**. On a `.wacj` it is parsed and has no effect — member builds receive a scope derived from each member's `role`. See composition-jobs.md.
 
 **`--deploysettings <file>`** *(2026.1+)*
 - **Purpose**: XML file of inline destination definitions (deploy.prefs entry schema, file/s3 actions only) overlaying deploy.prefs by name
 - **Use When**: CI environments where deploy.prefs is not configured on the machine
+
+**`--dryrun`** *(2026.1+)*
+- **Purpose**: Force every deployment in this run dry
+- **Impact**: An S3 destination prints its would-be DELETE / PUT / INVALIDATE sets and makes no AWS call; a transport with no dry-run support skips deployment with an explicit log line. A `.wacj` against a non-S3 destination skips the in-place compose. Signals deploy intent — the wrapper will not inject `-n`.
+- **Note**: There is deliberately **no opposite switch** — a destination declared dry cannot be forced live from the CLI.
 
 ### Staging Folder (Job Files)
 
@@ -158,6 +171,16 @@ When AutoMap builds a Stationery-based job file (`.waj`), it stages a temporary 
 - **Use When**: CI/CD builds, agentic workflows, or iterative development where reports not needed
 - **Impact**: Faster builds, reduced file system output
 - **Trade-off**: No build reports generated (errors and warnings still recorded in `generate.log`)
+- **Combines with the job file**: a `.waj` can store the same intent as the **Skip reports** build option (`<Options skipReports="True"/>`). The two are ORed — *either* source skips reports. The switch never turns a job's stored option back on.
+
+### Console Output
+
+**`-q, --quiet`** *(2026.1+)*
+- **Purpose**: Suppress the generation engine's step-by-step progress messages in the console and the job log
+- **Use When**: Scheduled or CI runs where only milestones, warnings, and errors matter
+- **Impact**: Warnings, errors, and the CLI's own milestone messages still print. The per-target `generate.log` is a separate sink and **always keeps full detail**. A quiet run announces itself once: `Suppressing build progress messages (requested via --quiet or the job's build options)`.
+- **Combines with the job file**: a `.waj` can store the same intent as the **Verbose logging** build option (`<Options verboseLogging="False"/>`). The two are ANDed — *either* source quiets the run, so a job that leaves Verbose logging selected can still be run quietly from a script. See [job-file-guide.md](./job-file-guide.md#build-options-skip-reports--verbose-logging).
+- **Relation to the wrapper**: `-q` is a *native* switch that changes what AutoMap emits; the wrapper's stdout suppression (see [Output Behavior](#output-behavior)) discards AutoMap's stdout at the wrapper boundary regardless. Under the wrapper the two overlap, and `-q` adds nothing an agent can observe — pass it when the *job log* (or a `-NoDefaults`/direct run's console) should be quiet, not to quiet the wrapper.
 
 ### Notification
 
@@ -185,6 +208,8 @@ The wrapper suppresses AutoMap's streaming stdout (banner, per-pipeline progress
 ```
 
 There is no verbose/streaming wrapper mode. To investigate a reported count or failure, **read `generate.log`** (below). To watch live progress interactively — a human need — run `WebWorks.Automap.exe` directly.
+
+This suppression is a wrapper behavior and is **not** the native `-q`/`--quiet` switch: the wrapper discards stdout it receives, while `-q` stops AutoMap from producing the progress stream in the first place (and therefore also trims the job log). Under the wrapper they overlap; see [`-q, --quiet`](#console-output) for when the native switch still earns its place.
 
 ## Example Commands
 
@@ -273,6 +298,8 @@ grep -nE '\[ERROR\]|\[WARN\]' "<project-or-staging>/Logs/<target>/generate.log"
 - **Job files** (`.waj`): the log is under the staging folder — `<stagingDir>/<JobName>/Logs/<target>/generate.log` (see [Staging Folder (Job Files)](#staging-folder-job-files)).
 
 The patterns below are the tokens used in `generate.log` and AutoMap's console output.
+
+> **Markers are localized.** `[WARN]` / `[ERROR]` are the *English-install* spellings. The same resources drive every log in the product, so a German install writes `[WARNUNG]` / `[FEHLER]`, a French one `[AVERTISSEMENT]` / `[ERREUR]`, and a Japanese one the kanji equivalents. The wrapper's post-build scan matches the English tokens only, so on a non-English install its per-target counts read 0 even when the log is full of marked lines. On such a machine, grep for the console's own tokens, or fall back to the process exit code. (2026.1 extended the same markers from `generate.log` to the job and composition logs.)
 
 ### Error Patterns
 
@@ -430,6 +457,4 @@ The only script-relevant cases are flags that interact with the wrapper's defaul
 
 ---
 
-**Version**: 3.5.0
-**Last Updated**: 2026-07-11
-**Target**: ePublisher 2024.1+ AutoMap CLI (--skip-reports requires 2025.1+, --version requires 2025.1 build 4652+)
+**Target**: ePublisher AutoMap CLI, 2024.1 through 2026.1. Version-gated options are marked inline: `--skip-reports` requires 2025.1+, `--version` requires 2025.1 build 4652+, and `--deployscope` / `--deploysettings` / `--destination` / `--dryrun` / `-q` require 2026.1+. The plugin version that ships this document is in `.claude-plugin/plugin.json`.

--- a/plugins/webworks-agent-skills/skills/automap/references/cli-reference.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/cli-reference.md
@@ -46,7 +46,7 @@ Unless `-NoDefaults` is given, the wrapper injects these **native** flags and re
 
 | Injected flag | Skipped when | Purpose |
 |---------------|--------------|---------|
-| `-n` (nodeploy) | `-n`/`--nodeploy` already present, or deploy intent signaled: `-d`/`--deployfolder`, `-l`/`--cleandeploy`, `--deploysettings`, `--deployscope` | Prevents accidental deployment during development |
+| `-n` (nodeploy) | `-n`/`--nodeploy` already present, or deploy intent signaled: `-d`/`--deployfolder`, `-l`/`--cleandeploy`, `--deploysettings`, `--deployscope`, `--destination`, `--dryrun` | Prevents accidental deployment during development |
 | `--skip-reports` | already present | Faster builds *(2025.1+; use `-NoDefaults` with older versions)* |
 
 **Explicit-target requirement:** unless `-NoDefaults` or `-AllTargets` is given, the arguments must include `-t` or `--target`. Otherwise the wrapper exits 2 and lists the file's available targets (for `.waj`, annotating which are `build="True"` enabled). This prevents a job file's full enabled set — or a project's every target — from building by accident.

--- a/plugins/webworks-agent-skills/skills/automap/references/cli-vs-administrator.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/cli-vs-administrator.md
@@ -18,16 +18,28 @@ Understanding the distinction is important for automation and integration.
 
 **Example Usage:**
 ```cmd
-"C:\Program Files\WebWorks\ePublisher\2024.1\ePublisher AutoMap\WebWorks.Automap.exe" -c -n -t "WebWorks Reverb 2.0" project.wep
+"C:\Program Files\WebWorks\ePublisher\<version>\ePublisher AutoMap\WebWorks.Automap.exe" -c -n -t "WebWorks Reverb 2.0" project.wep
 ```
 
-**Command-Line Arguments:**
-- `-c` - Clean build (remove cached files)
-- `-n` - No deploy (skip copying to deployment location)
-- `-l` - Clean deploy (remove existing files at deployment location)
-- `-t "Target Name"` - Build specific target only
-- `--deployfolder "Path"` - Override deployment destination
-- `<project-file>` - Path to .wep, .wrp, or .wxsp project file
+`<version>` is the installed release (`2024.1`, `2025.1`, `2026.1`, ...). Do not
+hard-code it — use `Find-AutomapInstallation.ps1`, or better, the wrapper.
+
+**Input files it accepts:**
+
+| Extension | What it is |
+|-----------|------------|
+| `.wep`, `.wrp` | Designer / Express project — builds every target unless `-t` narrows it |
+| `.wxsp` | Stationery |
+| `.waj` | AutoMap job — builds its `build="True"` set unless `-t` overrides |
+| `.wacj` | AutoMap **composition job** *(2026.1+)* — composes already-deployed output; generation options do not apply |
+
+One executable runs all of them, dispatching on the root element for the two
+job kinds (`<Job>` vs `<CompositionJob>`).
+
+**Command-Line Arguments:** the option surface is documented once, in
+[cli-reference.md](./cli-reference.md#native-command-options) — including the
+2026.1 additions (`-q`/`--quiet`, `--deployscope`, `--deploysettings`,
+`--destination`, `--dryrun`). It is not repeated here.
 
 ### WebWorks.Automap.Administrator.exe (UI)
 
@@ -41,15 +53,93 @@ Understanding the distinction is important for automation and integration.
 **Example Usage:**
 ```cmd
 # Launches GUI application
-"C:\Program Files\WebWorks\ePublisher\2024.1\ePublisher AutoMap\WebWorks.Automap.Administrator.exe"
+"C:\Program Files\WebWorks\ePublisher\<version>\ePublisher AutoMap\WebWorks.Automap.Administrator.exe"
 ```
 
 **Features:**
-- Create and configure AutoMap jobs
-- Schedule automated builds
-- Manage job templates
+- Create and configure AutoMap jobs (publishing and composition)
+- Schedule automated builds through the Windows Task Scheduler
+- Manage the Jobs folder, staging folder, and file mappings
 - Configure build options visually
 - Test job configurations interactively
+- Define and edit deploy destinations
+- Preview deployed output in a browser
+
+### Administrator capabilities added in 2026.1
+
+Four additions change what "only the GUI can do" means. Know them before
+telling a user something requires hand-editing a file.
+
+**Composition jobs are first-class.** `File > New Job` offers a third intent —
+**Compose published parcels into a website (Composition Job)** — which creates
+a `.wacj` in the Jobs folder and opens a composition editor (members grid with
+role and Build, **Output target:** combo, destination, Merge Settings). Full
+detail: [composition-jobs.md](./composition-jobs.md#authoring-a-composition-in-the-automap-administrator).
+
+**Deploy Destinations moved to the Edit menu.** `Edit > Deploy Destinations...`
+opens the destination editor **without opening a job or selecting a target** —
+destinations are shared state, not job-owned, so they no longer hide behind a
+target's configuration page. Adding an entry offers **Folder** and **Amazon
+S3**; entries created for other transports remain editable there.
+
+- Designer and Express gained the same top-level access this release (their own
+  **Edit** menus, plus a **Deploy Destinations** toolbar button). All three
+  consoles read and write **one shared list, stored per Windows user** on the
+  machine (`deploy.prefs`).
+- Separately, a job can carry its own destination **definitions** on the job
+  editor's **Job Deploy Destinations** page. Those travel with the job file and
+  win over a same-named local destination when the job runs. Folder and Amazon
+  S3 only — no credentials are stored.
+- The target's **Deploy to** list labels where each name comes from:
+  `<name> (this job)` for a job-inline definition, `<name> (local)` for one from
+  this computer's `deploy.prefs`.
+- A name that resolves to **neither** is still listed, as
+  `<name> (not defined on this computer)`. This is deliberate: hiding it would
+  read as "this job has no destination" and would discard the name on the next
+  save. **The name is preserved on save, and the label reports only what *this
+  computer* knows** — a build server that defines the name runs the job without
+  complaint. Treat the label as a local-resolution report, not as a defect in
+  the job.
+
+**Preview Output in Browser.** A `Job` menu command sitting immediately beside
+**Explore Output** (right-click reaches it too). Explore opens the deployed
+*files* — a folder, or the S3 console; Preview opens the deployed *site*. It
+drops down one entry per deploying target for a publishing job, or the single
+destination for a composition job; a target the job does not generate is listed
+as *(not generated)* and cannot be selected.
+
+| Destination | What opens |
+|-------------|------------|
+| Folder | the entry document directly, as a `file://` URL. The entry document name comes from the deployed shell record when one is present, else `index.html`. |
+| Amazon S3 | an address **derived at click time**, first success wins: (1) the CloudFront distribution's domain, read with one authenticated `GetDistribution` call, when the destination has a distribution ID; (2) the S3 static-website endpoint; (3) the virtual-hosted REST address of the entry object. |
+
+- **Every rung is verified before the browser opens**, but not identically:
+  rung 1 is verified by the authenticated `GetDistribution` call itself (so it
+  works for private buckets and is not probed further), rungs 2 and 3 are
+  HEAD-probed — which is what lets the failure message distinguish "not public"
+  (403) from "not found" and from "website hosting is not enabled".
+- **Nothing about the serving URL is persisted.** No new fields exist on the
+  destination; every address is recomputed per click. It is therefore
+  explicitly a *preview*, not necessarily the production URL — custom domains
+  and CDN configuration are outside ePublisher's knowledge. Presigned URLs are
+  deliberately never attempted (a signature covers one object; Reverb output
+  fetches many).
+- When no rung succeeds, the dialog reports **which derivations failed and
+  why** rather than a bare error.
+- A target that deploys with **Groups** scope publishes only the content layer,
+  so the destination carries no site entry page of *its* making. On an S3
+  destination the preview reports that scope instead of deriving a misleading
+  address. On a Folder destination it opens **the job's own group entry page**
+  when the destination has chrome to render it (a shell deployed there), and
+  otherwise explains why there is nothing to open. Preview the composition job
+  for that destination, or deploy a shell there.
+
+**Job-level build options.** The job editor's **Job Info** tab has a **Build
+options** area (**Skip reports**, **Verbose logging**) whose values are stored
+in the job file, so they apply on a schedule, from **Run**, and from a bare CLI
+invocation alike. They **combine with** the equivalent CLI switches rather than
+being overridden by them — see
+[job-file-guide.md](./job-file-guide.md#build-options-skip-reports--verbose-logging).
 
 ## When to Use Each
 
@@ -66,11 +156,12 @@ Understanding the distinction is important for automation and integration.
 
 ### Use Administrator (WebWorks.Automap.Administrator.exe) for:
 
-✅ Creating new AutoMap jobs
+✅ Creating new AutoMap jobs, including composition jobs (`.wacj`)
 ✅ Configuring job settings and parameters
 ✅ Setting up build schedules
 ✅ Testing job configurations interactively
-✅ Managing job templates
+✅ Defining and editing deploy destinations (`Edit > Deploy Destinations...`)
+✅ Previewing deployed output in a browser
 ✅ Visual configuration of complex builds
 ✅ Learning AutoMap features
 
@@ -89,16 +180,16 @@ how detection succeeds.
 
 ```bash
 # Detection finds Administrator
-Found: C:\Program Files\WebWorks\ePublisher\2024.1\ePublisher AutoMap\WebWorks.Automap.Administrator.exe
+Found: C:\Program Files\WebWorks\ePublisher\2026.1\ePublisher AutoMap\WebWorks.Automap.Administrator.exe
 
 # Script normalizes to CLI
-Returns: C:\Program Files\WebWorks\ePublisher\2024.1\ePublisher AutoMap\WebWorks.Automap.exe
+Returns: C:\Program Files\WebWorks\ePublisher\2026.1\ePublisher AutoMap\WebWorks.Automap.exe
 ```
 
 ## Installation Directory Structure
 
 ```
-C:\Program Files\WebWorks\ePublisher\2024.1\ePublisher AutoMap\
+C:\Program Files\WebWorks\ePublisher\<version>\ePublisher AutoMap\
 ├── WebWorks.Automap.exe                    ← CLI (for automation)
 ├── WebWorks.Automap.Administrator.exe      ← UI (for job management)
 ├── [supporting DLLs and resources]
@@ -120,40 +211,41 @@ WebWorks naming conventions.
 
 **Example:**
 ```
-C:\Program Files\WebWorks\ePublisher\2024.1\ePublisher AutoMap\WebWorks.Automap.exe
-                                                ^^^^^^^^                 ^^^^^^^
-                                               capital M              lowercase m
+C:\Program Files\WebWorks\ePublisher\<version>\ePublisher AutoMap\WebWorks.Automap.exe
+                                                 ^^^^^^^^                 ^^^^^^^
+                                                capital M              lowercase m
 ```
 
 ## Exit Codes
 
-### CLI Executable Exit Codes
+| Code | Meaning | Who returns it |
+|------|---------|----------------|
+| 0 | Success — the run completed and reported no errors | CLI (and wrapper) |
+| 1 | Failure — the run reported errors | CLI (and wrapper) |
+| 2 | Invalid arguments / no target specified | wrapper only |
+| 3 | AutoMap installation not detected | wrapper only |
+| 4 | Project file not found | wrapper only |
 
-| Code | Meaning | Description |
-|------|---------|-------------|
-| 0 | Success | Build completed successfully |
-| 1 | Failure | Build failed (errors occurred) |
-| 2 | Invalid Arguments | Command-line arguments were invalid |
-| 3 | Not Found | AutoMap installation not detected |
-| 4 | File Not Found | Project file does not exist |
+The CLI's own contract is 0/1. Codes 2–4 are the wrapper's, raised before
+AutoMap is ever launched. A scheduled task that runs a job through the launcher
+therefore only ever records `0x0` or `0x1` (plus `0x41301` while running).
 
 ### Using Exit Codes in Scripts
 
 ```bash
 #!/bin/bash
 
-# Execute AutoMap build
-automap_path="/c/Program Files/WebWorks/ePublisher/2024.1/ePublisher AutoMap/WebWorks.Automap.exe"
-"$automap_path" -c -n project.wep
+WRAPPER="<skill-dir>/scripts/Invoke-Automap.ps1"
+powershell -ExecutionPolicy Bypass -File "$WRAPPER" -- -t "WebWorks Reverb 2.0" project.wep
 
 # Check exit code
-if [ $? -eq 0 ]; then
-    echo "Build succeeded"
-    exit 0
-else
-    echo "Build failed"
-    exit 1
-fi
+case $? in
+    0) echo "Build succeeded" ;;
+    2) echo "Bad arguments (no target?)"; exit 2 ;;
+    3) echo "AutoMap not installed"; exit 3 ;;
+    4) echo "Project file not found"; exit 4 ;;
+    *) echo "Build failed"; exit 1 ;;
+esac
 ```
 
 ## Common Use Cases
@@ -205,24 +297,71 @@ done
 echo "All projects built successfully"
 ```
 
-### Scheduled Build Task
+### Scheduled Builds
+
+There are two ways to run AutoMap on a schedule. Prefer the first.
+
+**1. Let the Administrator own the schedule (jobs).** For a `.waj` or `.wacj`
+in the Jobs folder, use `Job > Schedule Job`. The Administrator registers a
+Windows Task Scheduler task named `waj <job name>` whose action is the
+**version-independent launcher** — `<ProgramFiles>\WebWorks\ePublisher\WebWorks.AutoMap.exe`
+— not the versioned CLI. That indirection is the point: the task survives an
+ePublisher upgrade without being re-created, because only the launcher's
+configuration is rewritten per release.
+
+Consequences worth knowing:
+
+- **The running process is the launcher.** In Task Manager it appears as
+  **WebWorks ePublisher AutoMap Launcher**. Match on that name for
+  process-based monitoring or "is a job running" checks — not on
+  `WebWorks.Automap.exe`, which is the child it spawns.
+- **`Last Run Result` is the job's verdict.** The CLI's exit code propagates
+  through the launcher to the Task Scheduler:
+
+  | `Last Run Result` | Meaning |
+  |-------------------|---------|
+  | `0x0` | the run completed and reported no errors |
+  | `0x1` | the run completed but reported errors — read the job log |
+  | `0x41301` | the task is still running |
+
+  Checking this column is cheaper than opening the log, and it is reliable as
+  of 2026.1: earlier launchers could lose the exit code entirely when a console
+  text selection froze output, which also silently skipped the next scheduled
+  run under the default single-instance policy.
+- **The task action embeds an absolute, bitness-specific launcher path.** With
+  an x86 and an x64 install coexisting, a pre-existing task keeps firing
+  whichever install created it. The Administrator's Schedule… dialog is the
+  full task editor (Actions tab included) — fix it there. To diagnose which
+  install actually ran, read the `Running WebWorks ePublisher AutoMap version …`
+  line in the job log.
+- **Build behavior belongs in the job, not the command line.** A scheduled task
+  invokes the CLI with no flags, so the job's stored
+  [build options](./job-file-guide.md#build-options-skip-reports--verbose-logging)
+  (Skip reports, Verbose logging) are what a scheduled run honors.
+
+**2. Schedule your own script (projects, or CI-shaped work).** For a `.wep`/`.wrp`
+that is not registered as a job, schedule a script that calls the wrapper — not
+`WebWorks.Automap.exe` directly, which skips installation detection, the safe
+defaults, and the post-build log scan:
 
 ```powershell
-# Windows Task Scheduler PowerShell script
+# Windows Task Scheduler action: powershell.exe -ExecutionPolicy Bypass -File C:\ci\nightly.ps1
 
-$AutoMapCLI = "C:\Program Files\WebWorks\ePublisher\2024.1\ePublisher AutoMap\WebWorks.Automap.exe"
+$Wrapper     = "<skill-dir>\scripts\Invoke-Automap.ps1"
 $ProjectFile = "C:\projects\my-proj\my-proj.wep"
 
-# Execute build
-& $AutoMapCLI -c -l -t "WebWorks Reverb 2.0" $ProjectFile
+# Production semantics: deploy per the target's configuration, generate reports
+& powershell -ExecutionPolicy Bypass -File $Wrapper -NoDefaults -- -c -l -t "WebWorks Reverb 2.0" $ProjectFile
 
-# Email notification based on exit code
 if ($LASTEXITCODE -eq 0) {
     Send-MailMessage -To "team@company.com" -Subject "Build Succeeded" -Body "Daily build completed successfully"
 } else {
     Send-MailMessage -To "team@company.com" -Subject "Build Failed" -Body "Daily build failed with exit code $LASTEXITCODE"
 }
 ```
+
+Exit the script with `$LASTEXITCODE` so the Task Scheduler's `Last Run Result`
+stays meaningful.
 
 ## Troubleshooting
 
@@ -257,17 +396,35 @@ if ($LASTEXITCODE -eq 0) {
 **Solution:**
 - Use `$?` immediately after AutoMap execution
 - Verify CLI executable is being used (not Administrator)
-- Check wrapper script's `execute_automap()` function
+- For a scheduled job, read `Last Run Result` in the Task Scheduler rather than
+  inferring from the console; a pre-2026.1 launcher could lose the exit code
+  when a console text selection froze output
+
+### Scheduled Job Never Runs Again After One Bad Run
+
+**Problem:** A scheduled job ran once, the window stayed open, and later
+triggers silently did nothing.
+
+**Cause:** A pre-2026.1 launcher whose console was put into text-selection mode
+blocked output forever, so no exit code was recorded. With the default
+single-instance policy, the Task Scheduler treats the task as still running and
+skips subsequent triggers.
+
+**Solution:**
+1. Press Esc in the console (its title carries a `Select ` prefix), or end the
+   task
+2. Upgrade — 2026.1 disables QuickEdit for the run's duration and captures the
+   exit code before draining output
 
 ## Best Practices
 
 ### For Automation Scripts
 
-1. **Always use CLI executable** - Never use Administrator for automation
+1. **Go through `Invoke-Automap.ps1`** - Never invoke the Administrator for automation, and do not build a manual `WebWorks.Automap.exe` invocation either; the wrapper owns installation detection, safe defaults, and the log scan
 2. **Capture exit codes** - Check return value after execution
 3. **Use absolute paths** - Avoid relying on PATH environment variable
 4. **Validate project files** - Check file exists before execution
-5. **Log output** - Capture stdout/stderr for troubleshooting
+5. **Put build behavior in the job** - A scheduled task passes no flags, so a job's stored build options are what it honors
 6. **Handle errors gracefully** - Provide clear error messages
 7. **Test in target environment** - Verify headless execution works
 
@@ -275,12 +432,14 @@ if ($LASTEXITCODE -eq 0) {
 
 1. **Use Administrator for configuration** - Easier to set up complex jobs
 2. **Test jobs interactively first** - Verify settings before automation
-3. **Export job configurations** - Save templates for reuse
+3. **Preview before publishing** - `Job > Preview Output in Browser` confirms the deployed site actually serves
 4. **Document custom settings** - Record non-default options used
 
 ## Related Documentation
 
+- [cli-reference.md](./cli-reference.md) - The complete native option surface
+- [composition-jobs.md](./composition-jobs.md) - `.wacj` grammar and the composition editor
+- [job-file-guide.md](./job-file-guide.md) - Job file structure, origin modes, build options
 - [installation-detection.md](./installation-detection.md) - How detection works
-- AutoMap Wrapper Script - Usage and examples
 - WebWorks ePublisher User Guide - Official documentation
 

--- a/plugins/webworks-agent-skills/skills/automap/references/composition-jobs.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/composition-jobs.md
@@ -512,6 +512,8 @@ The skill's Python tools understand `.wacj` as well as `.waj`:
   build flag and the output target each composes through, the site-TOC spec,
   and the destination (with inline definitions). `--json` adds
   `"kind": "composition"`; `--config` exports a config for `create-job.py`.
+  The Merge Settings `mode` is reported with the Administrator's labels:
+  `automatic`, `custom`, `custom+include-new`.
 - `python scripts/validate-job.py composition.wacj` — grammar preflight:
   member `path`/`role`/`build`, MergeSettings mode and spec, `<Destination>`
   (missing name fails; the pre-release `<DeployTarget>` spelling warns; an

--- a/plugins/webworks-agent-skills/skills/automap/references/composition-jobs.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/composition-jobs.md
@@ -2,9 +2,10 @@
 
 > **Applies to ePublisher 2026.1 and later** (new in 2026.1). Earlier versions
 > do not recognize `.wacj` files, the `deployScope` attribute, inline
-> `<DeploySettings>`, or the `--deployscope` / `--deploysettings` / `--dryrun`
-> options. Check the installed version before recommending any of this —
-> see the epublisher skill's `references/version-compatibility.md`.
+> `<DeploySettings>`, or the `--deployscope` / `--deploysettings` /
+> `--destination` / `--dryrun` options. Check the installed version before
+> recommending any of this — see the epublisher skill's
+> `references/version-compatibility.md`.
 
 Federated parcel composition assembles independently built and deployed
 WebWorks Reverb 2.0 outputs (parcels) into one site under a shared shell.
@@ -34,10 +35,10 @@ element):
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <CompositionJob name="product-docs" version="1.0">
-  <Jobs>
+  <Jobs target="Web Help">
     <Job path="shell\shell.waj"       role="shell"/>
     <Job path="install\install.waj"   role="parcel" build="true"/>
-    <Job path="admin\admin.wep"       role="parcel"/>
+    <Job path="admin\admin.wep"       role="parcel" target="Online Docs"/>
   </Jobs>
 
   <MergeSettings>
@@ -51,16 +52,27 @@ element):
 </CompositionJob>
 ```
 
-- **`<Job path role build>`** — members are `.waj` jobs or `.wep`/`.wrp`
-  projects. `role` is `shell` or `parcel`. `build` defaults to **false**
-  (compose-only; member output is already deployed). A `build="true"` member
-  is built first, in its own process, with `--deployscope` derived from its
-  role (`shell` → shell, `parcel` → groups) so a composition-driven federation
-  cannot be mis-scoped.
+- **`<Jobs target>`** — the composition-wide **output target**, pushed down to
+  every member. Optional; omit it to auto-detect per member. See
+  [Output target selection](#output-target-selection-determinant).
+- **`<Job path role build target>`** — members are `.waj` jobs or `.wep`/`.wrp`
+  projects. `role` is `shell`, `parcel`, or `infer` (the default when the
+  attribute is absent or unrecognized). `target` is a per-member override of
+  `Jobs/@target`. `build` defaults to **false** and is the seam between the two
+  composition archetypes — see [Federated vs. derivative
+  members](#federated-vs-derivative-members).
 - **`<MergeSettings>`** — the composed site TOC. `<Group name>` references a
-  deployed parcel **by group name**; `<TOC name>` nests groups under folders.
-  `discover="true"` composes every parcel found in the mirror instead
-  (DISCOVERY mode); declared groups plus `discover` is the hybrid. The root
+  deployed parcel **by group name**; `<TOC name>` nests groups under
+  containers. Three modes, named as the Administrator's Merge Settings area
+  names them:
+
+  | Mode | Grammar | Administrator label |
+  |------|---------|---------------------|
+  | **Automatic** | omit `<MergeSettings>` entirely | **Automatic (compose every parcel found at the destination)** |
+  | **Custom** | declare `<Group>` / `<TOC>` placements | **Custom** |
+  | Custom + include-new | `<MergeSettings discover="true">` plus placements | Custom, with **Also include newly published parcels not listed above** checked |
+
+  A declared group with no deployed output is warned once and omitted. The root
   `title` attribute is accepted for `.waj` grammar parity but unused (warned):
   the composed site's title is shell chrome.
 - **`<Destination name>`** — the shared destination. (2026.1 pre-release
@@ -69,6 +81,136 @@ element):
   the composition job's own inline `<DeploySettings>` → a `--deploysettings`
   overlay file → the machine's deploy preferences (`deploy.prefs`), with a
   drift warning when an inline definition shadows a differing preference.
+
+## Federated vs. derivative members
+
+The `build` flag on each member decides **who publishes that member**, and it
+is the only setting that changes what a composition fundamentally does. One
+`.wacj` may mix both kinds, member by member.
+
+| `build` | Archetype | Who builds and deploys the member | Where its output lands |
+|---------|-----------|-----------------------------------|------------------------|
+| absent / `"false"` | **Federated** | the member's own job, on its own cadence | wherever that job's target declares — which had better be this composition's destination |
+| `"true"` | **Derivative** | the composition, in a separate process | **this composition's destination**, overriding the member job's own |
+
+**Derivative (self-contained) mode.** A `build="true"` member is built before
+the compose, in its own process, with these switches forwarded:
+
+| Forwarded switch | Value | Why |
+|------------------|-------|-----|
+| `--target=` | the member's selected output target | build exactly the federation target, not the member's whole enabled set |
+| `--destination=` | the composition's `<Destination name>` | the member deploys to the *composition's* destination, whatever its own job names |
+| `--deployscope=` | derived from `role` (`shell` → `shell`, `parcel` → `groups`; `infer` → omitted) | a composition-driven federation cannot be mis-scoped |
+| `--deploysettings=` | a temp overlay of the CLI overlay + the composition's inline definitions | the member process resolves the destination name without `deploy.prefs` seeding |
+| `--dryrun` | present when the composition run is dry | the rehearsal reaches member builds too |
+
+Together these make the run **self-contained**: nothing about the member job's
+own destination or scope declarations can send its output somewhere the
+compose will not read. A `role="infer"` member is the exception — no scope
+override is forwarded, so the member project's own declared scope applies.
+
+Log line: `Building member job: <path> (deploys to this composition's destination '<name>').`
+
+**Federated mode has no such override**, so the composition cross-checks it up
+front and warns (it does not fail) when an *unbuilt* member's job would deploy
+the selected target somewhere else, or nowhere:
+
+```text
+Member 'admin': its job deploys output target 'Web Help' to destination 'TeamMirror',
+not to this composition's destination 'ProductionMirror'. Output deployed by that job
+will not appear at this composition's destination.
+
+Member 'admin': its job declares no destination for output target 'Web Help', so its
+output does not deploy anywhere this composition can read. Deploy that target to
+destination 'ProductionMirror', or check Build for this member in the composition.
+```
+
+Built members are skipped by this check — they deploy to the composition's
+destination regardless.
+
+**Authoring defaults differ from editor defaults.** The grammar default is
+`build="false"`: a hand-authored member is federated unless it opts in. The
+AutoMap Administrator's composition editor adds new members with **Build
+checked** — the derivative posture a learning user expects. Neither is wrong;
+know which one produced the file you are reading.
+
+## Output target selection (determinant)
+
+Every member composes through one **output target**. Selection runs for every
+member *before anything is built*, so a doomed composition fails in seconds
+instead of after minutes of member builds.
+
+Per-member precedence, highest first:
+
+1. the member's own `<Job target="...">` attribute — *"member override"*
+2. the composition-wide `<Jobs target="...">` — *"composition target"*
+3. auto-detection — *"auto-detected"*
+
+Each selection is logged: `Member '<name>': output target '<target>' (<format>, <source>).`
+
+**Auto-detection is never a silent first-match.** The candidate universe is the
+member's compose-capable targets — for a `.waj` member, the targets its **job
+declares** (each resolved against the stationery by name), preferring the
+active `build="True"` subset; for a `.wep`/`.wrp` member, the project's targets
+with no active-subset step. Exactly one candidate selects. Two or more is an
+error listing them by name:
+
+```text
+Member 'admin' has 2 active compose-capable targets: 'Web Help', 'Online Docs'.
+Select one with the composition-wide target (<Jobs target="...">) or this member's
+<Job target="..."/> attribute.
+```
+
+**Compose-capable means the format declares the composition contract** in
+`format.wwfmt` — today, WebWorks Reverb 2.0 only. A selected target on any
+other format fails:
+
+```text
+Member 'admin' target 'Print PDF' uses PDF - XSL-FO, which does not support composition.
+The composition needs a WebWorks Reverb 2.0 (compose-capable) target.
+```
+
+and when the member has no compose-capable target at all:
+
+```text
+Member 'admin' has no compose-capable output target (target 'Print PDF' uses PDF - XSL-FO;
+target 'Word' uses Microsoft Word). The composition needs a WebWorks Reverb 2.0
+(compose-capable) target on every member.
+```
+
+**Names may vary; formats may not.** Two teams' differently named targets
+compose fine as long as both are the same format. Heterogeneity is rejected:
+
+```text
+Composition members must all use the same output format; found: 'shell' -> WebWorks Reverb 2.0;
+'admin' -> PDF - XSL-FO. Member target names may vary across teams, but every member must
+produce the same compose-capable format.
+```
+
+**Stationery drift** in a member's declared target is the same hard error the
+member's own build would raise, surfaced before any build and prefixed with the
+member name: `Member 'admin': Target "Web Help" is not defined by the job's
+stationery (<path>). Resave the stationery with this target, or remove or rename
+the job target, then run again.` (See job-file-guide.md's [Job Target Missing
+from the Stationery](./job-file-guide.md#job-target-missing-from-the-stationery).)
+
+**Second line of defense at compose time.** Selection validates *targets*;
+harvest validates what is actually *deployed*. A deployed parcel whose
+descriptor records a different format name or version than the shell's is
+**warned and skipped** — the skew case where a parcel was deployed earlier by
+another team or another product version. Descriptors that predate format
+identity being recorded are tolerated, not skipped.
+
+```text
+Member 'admin' group 'Administration Guide': the output deployed at the destination
+was published by Web Help 2025.1, but this composition's shell uses Web Help 2026.1,
+so it cannot be included. Rebuild and redeploy it with the current version, then run
+this composition again.
+```
+
+The composed site loads with the remaining parcels.
+
+## Identity and tolerance
 
 **Group names are the durable identity.** Parcel GroupIDs regenerate across
 rebuilds and re-stagings; composition harvests whatever GID each deployed
@@ -83,27 +225,72 @@ rebuild and redeploy the shell.
 ## Running
 
 ```powershell
-& $automapExe composition.wacj                       # compose only
-& $automapExe composition.wacj --deployscope=shell   # NOT valid — scope belongs to member builds
+& $automapExe composition.wacj              # compose (and build any build="true" members)
+& $automapExe composition.wacj --dryrun     # rehearse
 ```
 
 - Exit code 0 on success; non-zero on error (undefined destination, missing
-  shell descriptor, member build failure).
-- A job-style log is written beside the file: `<name>-log.txt`.
-- Expected success lines: `Harvested N parcel descriptor(s) from the mirror`,
-  `Composed #parcels (N parcel(s)) into index.html`, `Composed cache key: ...`,
-  `Composition complete: N parcel(s), M warning(s).`
+  shell descriptor, member target selection failure, member build failure).
+- A job-style log is written beside the file: `<name>-log.txt` — same framing
+  convention as a `.waj` log, so the two cannot drift.
 
-Options forwarded to `build="true"` member builds: `--deployscope` (from
-role), `--deploysettings` (merged inline + overlay definitions), `--dryrun`,
-and `-t`/`--target` semantics apply per member job.
+**Which CLI options actually apply.** A `.wacj` composes output that member
+jobs already built and deployed, so generation options have nothing to act on.
+They are **parsed and ignored**, not rejected:
+
+| Option | On a `.wacj` |
+|--------|--------------|
+| `--dryrun` | applies — forces the run dry and is forwarded to member builds |
+| `--deploysettings` | applies — the overlay participates in `<Destination>` name resolution and is forwarded to member builds |
+| `-t` / `--target` | ignored; each member's target comes from [output target selection](#output-target-selection-determinant) |
+| `--deployscope` | ignored; each built member's scope is derived from its `role` and cannot be overridden from the CLI |
+| `-c`, `-n`, `-d`, `-l`, `--skip-reports` | ignored — no content is generated |
+| `-q` / `--quiet` | no effect: a composition log is not the generation engine's progress stream, and the switch is not forwarded to member builds |
+
+The wrapper knows this: it runs a `.wacj` with native semantics automatically
+(no injected flags, no target requirement).
+
+**Expected log shape** (English install; markers are localized elsewhere):
+
+```text
+Composition job 'product-docs' started at 9:14:02 AM, 2026-08-01.
+Member 'shell': output target 'Web Help' (WebWorks Reverb 2.0, auto-detected).
+Destination 'ProductionMirror' resolved from the composition job's inline definitions.
+Found deployed output for 3 group(s) at destination 'ProductionMirror'.
+Composed 3 group(s) into index.html.
+Composed cache key: <hash>
+Composition complete: 3 group(s), 0 warning(s).
+3 group(s) composed, 0 warning(s), 0 error(s) reported.
+```
+
+### Log semantics: relayed member lines are not the composition's
+
+A composition builds each `build="true"` member in a **separate process** and
+relays that process's console output — stdout and stderr — into its own log, so
+a member's warnings and errors are visible where you are already reading. Those
+relayed lines keep their `[WARN]` / `[ERROR]` markers, but they are written to
+the composition log at Info severity: **they belong to the member's own log and
+its own count, and the composition's summary does not include them.**
+
+So a composition log can legitimately *show* more marked lines than its closing
+tally counts. Both numbers are right — every ledger counts only its own entries,
+and nothing is double-counted across ledgers. When a relayed warning needs
+attention, open that member's own log (or its `generate.log`) to see it in
+context.
+
+The wrapper's post-build scan of `<name>-log.txt` counts marked lines, so for a
+composition with built members its counts are the *visible* marks, relayed ones
+included — deliberately looser than the composition's own tally.
 
 ## Deploy scope
 
 Every target declares which slice a deployment publishes. In the project it
 is the Target Settings **Deploy** field; in a `.waj` it is the optional
 `deployScope` attribute on `<Target>`; on the CLI it is `--deployscope`.
-CLI overrides job attribute overrides project declaration.
+CLI overrides job attribute overrides project declaration — **for a target
+build**. A composition's own run ignores `--deployscope` entirely and derives
+each built member's scope from its `role`, which is why a composition-driven
+federation cannot be mis-scoped from the command line.
 
 | Value | Publishes | Use for |
 |-------|-----------|---------|
@@ -148,17 +335,39 @@ entry schema — references stay by name:
 ```
 
 - Precedence per name: **job file's own inline > `--deploysettings` overlay
-  file > deploy.prefs.** The log records which source resolved each name and
-  warns when an inline definition shadows a differing preference (the drift
-  detector).
+  file > deploy.prefs.** An inline definition **wins outright** over a
+  same-named `deploy.prefs` entry — it does not merge with it.
+- **Every resolution is logged**, so the winning source is never a guess:
+
+  ```text
+  Destination 'ProductionMirror' resolved from the composition job's inline definitions.
+  Destination 'ProductionMirror' resolved from the --deploysettings file 'ci\destinations.xml'.
+  ```
+
+  Silence on this line means the name came from `deploy.prefs`.
+- **Drift detector.** When the winning inline definition differs in content
+  from a same-named lower-precedence one, the run warns and says which it used:
+
+  ```text
+  Inline destination definition 'ProductionMirror' (from the composition job) shadows a
+  different definition of the same name in deploy.prefs; using the inline definition.
+  ```
+
+  Identical definitions are silent — the warning fires on *difference*, not on
+  mere duplication.
+- **Unresolvable is an error**, before any member build:
+  `Destination 'ProductionMirror' is not defined in deploy.prefs, the --deploysettings overlay, or inline in the composition job.`
 - `--deploysettings=<file>` takes the same `<DeploySetting>` entries from an
   XML file — the CI seeding mechanism. A composition forwards its merged
   inline definitions to member builds automatically (they are separate
   processes), so name-only member jobs run on unseeded machines.
 - **Security guardrail:** only secret-free transports may be inline — Folder
   (`Action="file"`) and Amazon S3 (`Action="s3"`). WebDAV (`Action="http"`)
-  embeds credentials and is rejected at parse time with a clear error, as are
-  custom actions. Those stay in deploy.prefs.
+  **embeds encrypted credentials and is rejected at parse time**, as are custom
+  actions. The rejection happens at job load, *before any build starts*, so a
+  job that tries it never partially runs. Those transports stay in
+  `deploy.prefs`, where the credentials are machine-local state rather than
+  version-controlled content.
 
 ## Amazon S3 + CloudFront destinations
 
@@ -191,6 +400,89 @@ deploying machine.
   deliberately no opposite switch — a setting declared dry cannot be forced
   live from the CLI.
 
+**What `--dryrun` does to a `.wacj` depends on the destination's transport.**
+An S3 compose already runs against a local `.compose-staging` mirror, so it can
+rehearse faithfully; every other transport composes *in place*, so the only
+honest rehearsal is to not compose at all:
+
+| Destination | `--dryrun` behavior |
+|-------------|---------------------|
+| Amazon S3 | the resolved setting is forced dry for the run; the full compose runs against the staging mirror, and the would-be GET / PUT / INVALIDATE sets print. Member builds still run (dry). |
+| Folder (or any non-S3) | member builds run (dry), then **the compose is skipped** and the run exits 0 |
+
+The skip is explicit, not silent:
+
+```text
+Dry run (--dryrun): forcing S3 destination 'ProductionMirror' dry for this run.
+Dry run (--dryrun): destination 'ProductionMirror' is composed in place (the 'file'
+transport has no dry-run support); skipping the compose.
+```
+
+So `--dryrun` against a folder destination validates member selection, member
+builds, and destination resolution — but tells you nothing about the compose
+itself. To rehearse a folder compose, point a scratch destination at a copy of
+the mirror and run for real.
+
+## Authoring a composition in the AutoMap Administrator
+
+A `.wacj` is plain XML and can be written by hand, but 2026.1 gives it a
+first-class creation path. Compositions are ordinary rows in the jobs grid:
+same name namespace, same Jobs-folder layout
+(`<jobsdir>\<name>\<name>.wacj`), same scheduled-task plumbing, same
+`<name>-log.txt`. Schedule / Run / Stop / View Log / Rename / Duplicate /
+Delete all behave as they do for a `.waj`.
+
+**Creating.** **File > New Job** offers a third intent beside the two
+publishing ones:
+
+> Compose published parcels into a website (Composition Job)
+
+Unlike the other two, it has no file picker — a composition is *born in the
+Jobs folder*, not derived from an external file. Naming it opens the
+composition editor.
+
+**The composition editor** maps 1:1 onto the grammar:
+
+| Editor control | Grammar it writes |
+|----------------|-------------------|
+| **Member Jobs** grid — Member (path), Role, Build | `<Job path role build>` |
+| read-only **Target** column | a member's `<Job target="...">`, when present |
+| **Output target:** combo | `<Jobs target="...">` |
+| **Deployment** — *Defined in this job* / *Deploy Destinations* | inline `<DeploySettings>` inside `<Destination>` / a name-only `<Destination>` |
+| **Merge Settings** — Automatic / Custom (+ include-new checkbox) | omitted `<MergeSettings>` / declared placements / `discover="true"` |
+
+- **Add...** is a dropdown, not a file dialog: it lists the publishing jobs in
+  the Jobs folder by name. Jobs already added appear **checked and disabled**,
+  so a duplicate member is not reachable. A separator and **Browse...** sit at
+  the bottom for a job or project stored anywhere else (filter:
+  `*.waj;*.wep;*.wrp`). With no jobs in the Jobs folder, Add... falls straight
+  through to Browse.
+- Members added here get **Build checked** — the derivative default.
+- **Output target:** defaults to **(automatic)** and offers only target names
+  whose format is compose-capable. A per-member `target=` override in the file
+  is never edited away: the **Target** column appears only when some member
+  declares one, and is read-only, making the override visible rather than
+  silent. Change or remove it by editing the `.wacj`.
+- A destination the composition references but this computer does not define
+  is still listed, labeled `<name> (not defined on this computer)`, and stays
+  selected on save.
+- **Add Group** is seeded from the local members' group names and **Add
+  Container** from the container names their Merge Settings declare, but free
+  text stays available in both — a federated parcel may have no local member.
+  Entering a name that is known only as a *container* under Add Group is
+  warned, not silently accepted.
+
+**Adopting a hand-authored `.wacj`.** There is no import mechanism (matching
+`.waj`): drop the file in as `<jobsdir>\<name>\<name>.wacj` and the next
+refresh discovers it. Run or Schedule lazily creates its scheduled task.
+Whoever places the file owns its member paths — the reader rebases relative
+paths against the `.wacj`'s own location.
+
+**Round-trip fidelity.** Opening and saving a hand-authored file preserves
+nested `<TOC>` containers, inline `<DeploySettings>`, and extra inline
+definitions beyond the referenced one. **XML comments are not preserved** once
+the editor saves. Keep commentary outside the file if it matters.
+
 ## Failure behavior
 
 - A failed deploy is an **error**: it reaches the per-target error count and
@@ -203,6 +495,43 @@ deploying machine.
   — the shell was never deployed to that mirror (or the path points at an
   empty directory); rebuild and redeploy the shell.
 - An inline WebDAV definition fails at job load, before any build starts.
+
+**Ordered before any member build** (so a doomed run costs seconds, not
+minutes): member file existence → [output target
+selection](#output-target-selection-determinant) and same-format validation →
+destination name resolution → unbuilt-member destination cross-check
+(warnings). Member builds run only after all of those pass; a member build that
+exits non-zero stops the run with
+`Member build failed (exit <n>): <path>`.
+
+## Tooling
+
+The skill's Python tools understand `.wacj` as well as `.waj`:
+
+- `python scripts/parse-job.py composition.wacj` — members with their role,
+  build flag and the output target each composes through, the site-TOC spec,
+  and the destination (with inline definitions). `--json` adds
+  `"kind": "composition"`; `--config` exports a config for `create-job.py`.
+- `python scripts/validate-job.py composition.wacj` — grammar preflight:
+  member `path`/`role`/`build`, MergeSettings mode and spec, `<Destination>`
+  (missing name fails; the pre-release `<DeployTarget>` spelling warns; an
+  inline `Action="http"` WebDAV definition fails). Add `--check-members` to
+  check member files exist and to cross-check each `.waj` member's declared
+  targets and destination against the composition's.
+- `python scripts/list-job-targets.py composition.wacj` — one line per member
+  with its selected target and how it was selected (`member override` /
+  `composition target` / `auto-detect`). `--enabled` / `--disabled` filter on
+  `build`.
+- `python scripts/create-job.py --template --composition > config.json`, then
+  `python scripts/create-job.py --config config.json --output composition.wacj`
+  — generates a `.wacj` that matches the product writer's conventions (role
+  `infer`, `build="false"` and `discover="false"` omitted; a container title
+  equal to its name omitted). Note: `--output` must be relative to the current
+  directory.
+
+Reference fixtures: `tests/fixtures/composition-federation/composition.wacj`
+(valid federation) and `tests/fixtures/composition-invalid/broken.wacj`
+(defect catalogue).
 
 ## Related
 

--- a/plugins/webworks-agent-skills/skills/automap/references/job-file-guide.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/job-file-guide.md
@@ -674,7 +674,7 @@ The inline job `<MergeSettings>` is applied onto the staged project's `<FormatCo
 
 ### Skeleton Master Pattern
 
-A **skeleton master** is a job whose groups carry only minimal stub content, built solely to produce the merged master TOC and the output shell (parcel containers + titles). The real content is built separately — one or more "satellite" parcel jobs — then joined to the master **by group name**. This supports updating individual parcels without rebuilding the whole merged output (the Reverb merge-settings / deploy-set workflow).
+A **skeleton master** is a job whose groups carry only minimal stub content, built solely to produce the merged master TOC and the output shell (parcel containers + titles). The real content is built separately — one or more "satellite" parcel jobs — then joined to the master **by group name**. This supports updating individual parcels without rebuilding the whole merged output (federated parcel composition — see composition-jobs.md).
 
 - Give each group at least one stub document. An empty group fails group verification and produces no TOC entry; empty containers are pruned.
 - The master is authoritative for the TOC hierarchy and the title overrides — both live only in `<MergeSettings>`. A standalone parcel build cannot reproduce them.

--- a/plugins/webworks-agent-skills/skills/automap/references/job-file-guide.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/job-file-guide.md
@@ -9,6 +9,7 @@
 - [XML Structure](#xml-structure)
 - [Element Reference](#element-reference)
 - [Output Location (Staging Folder)](#output-location-staging-folder)
+- [Build Options (Skip reports / Verbose logging)](#build-options-skip-reports--verbose-logging)
 - [Creating Job Files](#creating-job-files)
 - [Target Configuration](#target-configuration)
 - [Merge Settings (Multivolume / Merged TOC)](#merge-settings-multivolume--merged-toc)
@@ -92,11 +93,34 @@ The `<Project>` element's `path` decides where the build's format configuration 
 |---|----------------------------|-------------------|----------|
 | 1 | Stationery (`.wxsp`) | n/a (ignored) | Stage a fresh project from the Stationery, inject the job's `<Files>` and target overrides, then build. *(Existing behavior — the common case.)* |
 | 2 | Project (`.wep`, `.wrp`) | absent / `"False"` | **Build in place.** AutoMap builds the referenced project using *its own* documents and configuration; the job's `<Files>` are **ignored**. *(Existing behavior.)* |
-| 3 | Project (`.wep`, `.wrp`) | `"True"` | **Project used as a stationery (new in 2026.1).** AutoMap uses the live project directly as a stationery: it stages a fresh project from the project's format configuration (stripping the project's own documents, `ProjectID`, and `<Origin>`), injects the job's `<Files>` and target overrides, then builds — exactly like mode 1, but sourced from a Designer/Express project instead of a generated Stationery. |
+| 3 | Project (`.wep`, `.wrp`) | `"True"` | **Project used as a stationery (new in 2026.1).** AutoMap uses the live project directly as a stationery: it stages a fresh project from the project's format configuration (stripping the project's own documents, document groups, **merge settings**, `ProjectID`, and `<Origin>`), injects the job's `<Files>` and target overrides, then builds — exactly like mode 1, but sourced from a Designer/Express project instead of a generated Stationery. |
 
 ### Why mode 3 exists
 
-Mode 3 removes the manual **"Save As Stationery"** step from CI. Instead of regenerating a `.wxsp` every time the design changes, the job points straight at the live Designer/Express project and synchronizes from it on every build. A Designer `.wep` carries no `<format>.base` snapshots, so its transforms resolve from the Designer installation — the same way a hollow stationery would. (See the epublisher skill's `references/file-resolver-guide.md` for the `.base` resolution hierarchy.)
+Mode 3 removes the manual **"Save As Stationery"** step from CI. Instead of regenerating a `.wxsp` every time the design changes, the job points straight at the live Designer/Express project and synchronizes from it on every build. Without it, a design change that never reached the Stationery is a build that silently publishes the previous design.
+
+### What the origin supplies, and what it does not
+
+The origin project supplies the **design**: output formats, targets and target settings, styles, and any format/target overrides it carries. Everything publication-specific comes from the job.
+
+Not carried into the build: the origin's own **source documents**, **document groups**, and **merge settings**. A design project that holds sample documents for previewing therefore cannot leak those samples — or their TOC arrangement — into the job's output. A job that needs a multivolume TOC declares its own `<MergeSettings>` on the target (see [Merge Settings (Multivolume / Merged TOC)](#merge-settings-multivolume--merged-toc)).
+
+### Keep the installation and the design project on the same version
+
+A design project used as a stationery does **not** carry its own copy of the output format files — a Designer `.wep` has no `<format>.base` snapshots, so its transforms resolve from the ePublisher installation that runs the job, the same way a hollow stationery's would. (See the epublisher skill's `references/file-resolver-guide.md` for the `.base` resolution hierarchy.)
+
+**Keep the installation that runs your jobs at the same version as the one the design project is maintained in.** A version mismatch resolves the design against a different format build than the designer sees. That is silent fidelity drift, not a build error — nothing in the log flags it.
+
+### Creating one: the two New Job intents
+
+In the AutoMap Administrator, both mode 2 and mode 3 name a `.wep`/`.wrp` file; the intent selected on the **New Job** window decides which one you get, and AutoMap records the difference in the job file:
+
+| New Job option | Origin picker | Resulting mode |
+|----------------|---------------|----------------|
+| **Create a new publishing job** | *Choose ePublisher stationery or project* — accepts `.wxsp`, `.wep`, `.wrp` | mode 1 for a `.wxsp`; **mode 3** (`useAsStationery="True"`) for a `.wep`/`.wrp` |
+| **Automate an existing project** | *Choose ePublisher project* — accepts `.wep`, `.wrp` | **mode 2** (build in place) |
+
+The picker for the first option is the tell: one field, one filter, three extensions. Selecting a project there routes through the stationery wizard — the one with the Files page — because the job still supplies its own documents.
 
 ### Staging behavior
 
@@ -238,6 +262,25 @@ The attribute selects which of the three [Job Origin Modes (Stationery vs Projec
 1. The Stationery is on a **different drive** than the job file (no shared path root exists)
 2. The Stationery is on a **different network share**
 3. The job file and the Stationery share **only the drive letter or share root** as a common ancestor — a relative path technically works but is long and unmaintainable (e.g. `..\..\..\..\Other\Tree\main.wxsp`), so absolute is preferable
+
+### `<Options>` Element
+
+*(2026.1+)* Optional direct child of `<Job>`, written after `<Project>`. Stores the job's **build options** — behavior that travels with the job file, so it applies however the job runs: on its schedule, from **Run**, or from a direct CLI invocation. See [Build Options (Skip reports / Verbose logging)](#build-options-skip-reports--verbose-logging).
+
+| Attribute | Required | Description | Values | Default |
+|-----------|----------|-------------|--------|---------|
+| `skipReports` | No | Skip report generation for every target the job builds | `"True"`, `"False"` | `False` |
+| `verboseLogging` | No | Record the generation engine's step-by-step progress in the console and job log | `"True"`, `"False"` | `True` |
+
+```xml
+<Job name="nightly" version="1.0">
+  <Project path="stationery\main.wxsp" />
+  <Options skipReports="True" verboseLogging="False" />
+  ...
+</Job>
+```
+
+**Written only when non-default.** A job that keeps both defaults carries no `<Options>` element at all, so jobs saved before the element existed load unchanged and round-trip byte-stable. On load, `skipReports` is true only for an explicit `"true"`; `verboseLogging` is false only for an explicit `"false"`.
 
 ### `<Files>` Element
 
@@ -388,6 +431,36 @@ powershell -ExecutionPolicy Bypass -File "<skill-dir>/scripts/Invoke-Automap.ps1
 
 ---
 
+## Build Options (Skip reports / Verbose logging)
+
+*(2026.1+)* A job can store two build options in the job file itself, in the [`<Options>` element](#options-element). The AutoMap Administrator exposes them on the job editor's **Job Info** tab, in the **Build options** area. Because they live in the job, they apply on a schedule, from **Run**, and from a direct command-line invocation alike — which matters because a scheduled task invokes the CLI with no flags at all.
+
+| Build option | Job attribute | Default | Effect |
+|--------------|---------------|---------|--------|
+| **Skip reports** | `skipReports="True"` | cleared | Skips report generation for every target the job builds. Reports add time, so this shortens large conversions. |
+| **Verbose logging** | `verboseLogging="False"` | selected | Clearing it omits the generation engine's step-by-step progress messages from the console and the job log, leaving milestone, warning, and error messages. |
+
+### The stored option and the CLI switch combine — they do not override
+
+Each option has an equivalent CLI switch, and the two sources are **combined**, never resolved as a precedence:
+
+| Sources | Rule | Result |
+|---------|------|--------|
+| `skipReports="True"` **or** `--skip-reports` | OR | reports are skipped |
+| `verboseLogging="False"` **or** `-q` / `--quiet` | either quiets | progress messages suppressed |
+
+So a job that stores Skip reports skips reports even on a bare `WebWorks.Automap.exe job.waj`, and a job that leaves Verbose logging selected can still be run quietly from a script. Neither switch can turn a stored option back *on* — there is no `--with-reports` and no un-quiet switch.
+
+> **Note:** Clearing Verbose logging affects the console and the job log only. The per-target `generate.log` is a separate sink and always keeps full detail.
+
+### Consequence for the wrapper
+
+`Invoke-Automap.ps1` injects `--skip-reports` unconditionally (unless already present, or `-NoDefaults` is given). Given the OR rule, that injection is **idempotent with a job's stored option** — a job with `skipReports="True"` behaves the same either way, and a job with the option cleared still gets reports skipped for that run because the switch was passed. The wrapper's `[INFO]` line reports the injected flag, not the job's stored option, so a job that stores Skip reports shows no extra signal. When you need a run's report behavior to match exactly what the job declares (verifying a scheduled task's output, for example), use `-NoDefaults`.
+
+The wrapper never injects `-q`. Its own stdout suppression is a separate mechanism — see cli-reference.md's [Console Output](./cli-reference.md#console-output).
+
+---
+
 ## Creating Job Files
 
 ### Using Scripts
@@ -407,6 +480,8 @@ python scripts/create-job.py --config config.json --output job.waj
 # 3. Validate the result
 python scripts/validate-job.py --check-stationery job.waj
 ```
+
+`validate-job.py` and `parse-job.py` dispatch on the root element (`<Job>` vs `<CompositionJob>`) and report a rename when the file extension and root disagree. For `.wacj` composition jobs, see composition-jobs.md's Tooling section.
 
 ### Configuration File Format
 
@@ -704,6 +779,20 @@ fi
 1. Format names are case-sensitive
 2. List available formats: `python scripts/parse-stationery.py stationery.wxsp`
 3. Update the `format` attribute to match exactly
+
+### Job Target Missing from the Stationery
+
+**Error**: `Target "<name>" is not defined by the job's stationery (<path>). Resave the stationery with this target, or remove or rename the job target, then run again.`
+
+Distinct from [Invalid Format Name](#invalid-format-name) above: there the target's `format` attribute names a format the Stationery lacks; here the **target itself** — a `<Target name="...">` the job declares — has no same-named target in the Stationery. The job declares *how* a target builds; the Stationery declares *what* exists. The two have drifted, usually because a target was renamed or removed in the Stationery after the job was written.
+
+**This is a hard error as of 2026.1.** Earlier versions silently recreated the missing target using the output format's **default settings**. The job kept producing output, but that output was configured with format defaults rather than the Stationery author's settings, and nothing indicated the substitution. The error message names both the target and the Stationery so the drift is unambiguous.
+
+**Solutions**:
+1. Resave the Stationery with that target, or
+2. Remove or rename the job target so the two agree, then run again
+
+A composition raises the same error, with the same remedy wording, for a member's declared target — but **before any member build starts**, prefixed with `Member '<name>': `. See composition-jobs.md.
 
 ### Document Not Found
 

--- a/plugins/webworks-agent-skills/skills/automap/scripts/Invoke-Automap.ps1
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/Invoke-Automap.ps1
@@ -38,7 +38,8 @@ separator; everything after -- is always forwarded verbatim):
 Default flags injected unless -NoDefaults:
   -n               unless -n/--nodeploy already present, or deploy intent
                    is signaled (-d/--deployfolder, -l/--cleandeploy,
-                   --deploysettings, --deployscope).
+                   --deploysettings, --deployscope, --destination,
+                   --dryrun).
   --skip-reports   unless already present (requires ePublisher 2025.1+;
                    use -NoDefaults with older versions).
 And an explicit -t/--target is required unless -NoDefaults or -AllTargets.
@@ -221,8 +222,8 @@ function Get-CompositionLogSummary {
     $warnCount = 0
     $errorCount = 0
     try {
-        $warnCount = @(Select-String -LiteralPath $logFile -Pattern '[Warning]' -SimpleMatch).Count
-        $errorCount = @(Select-String -LiteralPath $logFile -Pattern '[Error]' -SimpleMatch).Count
+        $warnCount = @(Select-String -LiteralPath $logFile -Pattern '[WARN]' -SimpleMatch).Count
+        $errorCount = @(Select-String -LiteralPath $logFile -Pattern '[ERROR]' -SimpleMatch).Count
     }
     catch {
         return $null
@@ -409,7 +410,9 @@ function Invoke-Main {
                 ($token -ceq '--deployfolder') -or ($token -clike '--deployfolder=*') -or
                 ($token -ceq '--cleandeploy') -or
                 ($token -ceq '--deploysettings') -or ($token -clike '--deploysettings=*') -or
-                ($token -ceq '--deployscope') -or ($token -clike '--deployscope=*')) {
+                ($token -ceq '--deployscope') -or ($token -clike '--deployscope=*') -or
+                ($token -ceq '--destination') -or ($token -clike '--destination=*') -or
+                ($token -ceq '--dryrun')) {
                 $deployIntent = $true
             }
         }

--- a/plugins/webworks-agent-skills/skills/automap/scripts/create-job.py
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/create-job.py
@@ -54,7 +54,8 @@ from lib.wacj import (  # noqa: E402
     DEPLOY_ACTION_ATTR, DEPLOY_CONFIGURATION_ELEMENT, DEPLOY_SETTING_ELEMENT,
     DEPLOY_SETTING_NAME_ATTR, DEPLOY_SETTINGS_ELEMENT, DESTINATION_ELEMENT,
     GROUP_ELEMENT, JOB_ELEMENT, JOBS_ELEMENT, MEMBER_EXTENSIONS,
-    MERGE_SETTINGS_ELEMENT, ROLE_INFER, ROLES, TOC_ELEMENT,
+    MERGE_SETTINGS_ELEMENT, MODE_CUSTOM, MODE_CUSTOM_INCLUDE_NEW, ROLE_INFER,
+    ROLES, TOC_ELEMENT,
 )
 
 # Exit codes
@@ -469,8 +470,8 @@ def generate_composition_xml(config: dict) -> str:
             if member_config.get('target'):
                 member.set('target', member_config['target'])
 
-    # Discovery mode is expressed by the ABSENCE of MergeSettings; an empty
-    # element is spec mode with an empty spec.
+    # Automatic mode is expressed by the ABSENCE of MergeSettings; an empty
+    # element is Custom mode with an empty spec.
     merge_config = config.get('mergeSettings')
     if merge_config is not None:
         merge = SubElement(composition, MERGE_SETTINGS_ELEMENT)
@@ -513,8 +514,9 @@ def generate_composition_template() -> dict:
             {'path': 'shell.waj', 'role': 'shell', 'build': False, 'target': ''},
             {'path': 'parcel-a.waj', 'role': 'parcel', 'build': False, 'target': ''}
         ],
-        # Omit "mergeSettings" entirely for discovery mode (the parcel set is
-        # discovered from the mirror); set "discover": true for hybrid mode.
+        # Omit "mergeSettings" entirely for Automatic mode (compose every
+        # parcel found at the destination); keep it for Custom mode, and set
+        # "discover": true to also include newly published parcels not listed.
         'mergeSettings': {
             'title': '',
             'discover': False,
@@ -551,9 +553,9 @@ def print_composition_summary(config: dict) -> None:
 
     merge = config.get('mergeSettings')
     if merge is None:
-        print("\nSite TOC: (none - discovery mode)")
+        print("\nSite TOC: (none - Automatic: compose every parcel found at the destination)")
     else:
-        mode = 'hybrid' if merge.get('discover') else 'spec'
+        mode = MODE_CUSTOM_INCLUDE_NEW if merge.get('discover') else MODE_CUSTOM
         print(f"\nSite TOC ({mode} mode): {len(merge.get('spec', []))} top-level nodes")
 
     destination = config.get('destination', {})

--- a/plugins/webworks-agent-skills/skills/automap/scripts/create-job.py
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/create-job.py
@@ -2,7 +2,8 @@
 """
 create-job.py
 
-Create AutoMap job files (.waj) interactively or from a configuration file.
+Create AutoMap job files (.waj) and composition job files (.wacj)
+interactively or from a configuration file.
 
 Usage:
     # Interactive mode (prompts for all input)
@@ -14,11 +15,16 @@ Usage:
     # Generate config template
     python create-job.py --template --stationery path/to/stationery.wxsp
 
+    # Generate a composition job config template, then build the .wacj
+    python create-job.py --template --composition > composition-config.json
+    python create-job.py --config composition-config.json -o composition.wacj
+
 Features:
     - Interactive workflow for job creation
     - Config file mode for scripted creation
     - Validates against Stationery formats
     - Generates valid AutoMap job XML
+    - Generates composition job XML (members, site TOC spec, destination)
     - Preview before writing
 
 Exit Codes:
@@ -39,6 +45,17 @@ from xml.etree.ElementTree import Element, SubElement, tostring  # For creating 
 from pathlib import Path
 from typing import Optional
 from xml.dom import minidom
+
+# The .wacj grammar lives beside this script in lib/wacj.py so every AutoMap
+# tool shares one definition of the composition element vocabulary.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from lib.wacj import (  # noqa: E402
+    ACTION_WEBDAV, COMPOSITION_EXTENSION, COMPOSITION_ROOT,
+    DEPLOY_ACTION_ATTR, DEPLOY_CONFIGURATION_ELEMENT, DEPLOY_SETTING_ELEMENT,
+    DEPLOY_SETTING_NAME_ATTR, DEPLOY_SETTINGS_ELEMENT, DESTINATION_ELEMENT,
+    GROUP_ELEMENT, JOB_ELEMENT, JOBS_ELEMENT, MEMBER_EXTENSIONS,
+    MERGE_SETTINGS_ELEMENT, ROLE_INFER, ROLES, TOC_ELEMENT,
+)
 
 # Exit codes
 EXIT_SUCCESS = 0
@@ -306,19 +323,245 @@ def generate_job_xml(config: dict) -> str:
                 setting_elem.set('name', setting.get('name', ''))
                 setting_elem.set('value', setting.get('value', ''))
 
-    # Convert to string with pretty printing
-    xml_str = tostring(job, encoding='unicode')
+    return pretty_xml(job)
+
+
+def pretty_xml(root: Element) -> str:
+    """Serialize an element tree with an indented, declaration-first layout."""
+    xml_str = tostring(root, encoding='unicode')
     dom = minidom.parseString(xml_str)
-    pretty_xml = dom.toprettyxml(indent='  ', encoding=None)
+    pretty = dom.toprettyxml(indent='  ', encoding=None)
 
     # Remove extra blank lines and fix declaration
-    lines = pretty_xml.split('\n')
+    lines = pretty.split('\n')
     # Replace first line with proper declaration
     lines[0] = '<?xml version="1.0" encoding="utf-8"?>'
     # Remove empty lines
     lines = [line for line in lines if line.strip()]
 
     return '\n'.join(lines)
+
+
+def is_composition_config(config: dict) -> bool:
+    """True when a config describes a composition job (.wacj), not a .waj."""
+    return config.get('kind') == 'composition' or 'members' in config
+
+
+def validate_composition_config(config: dict) -> list[str]:
+    """Validate a composition job configuration before XML generation."""
+    errors = []
+
+    if not config.get('name', '').strip():
+        errors.append("Composition name cannot be empty")
+
+    members = config.get('members', [])
+    if not members:
+        errors.append("At least one member job is required")
+
+    for i, member in enumerate(members, start=1):
+        path = (member.get('path') or '').strip()
+        if not path:
+            errors.append(f"Member {i} path cannot be empty")
+        elif Path(path).suffix.lower() not in MEMBER_EXTENSIONS:
+            errors.append(
+                f"Member {i} path '{path}' must be one of: "
+                f"{', '.join(MEMBER_EXTENSIONS)}")
+
+        role = (member.get('role') or ROLE_INFER).strip().lower()
+        if role not in ROLES:
+            errors.append(
+                f"Member {i} role '{role}' is invalid (expected: {', '.join(ROLES)})")
+
+    destination = config.get('destination', {})
+    if not (destination.get('name') or '').strip():
+        errors.append("Destination name cannot be empty - the composition "
+                      "resolves its shared mirror from it")
+
+    seen = set()
+    for i, setting in enumerate(destination.get('deploySettings', []), start=1):
+        name = (setting.get('name') or '').strip()
+        if not name:
+            errors.append(f"Inline destination definition {i} name cannot be empty")
+            continue
+        if name in seen:
+            errors.append(f"Duplicate inline destination definition '{name}'")
+        seen.add(name)
+        if (setting.get('action') or '').strip().lower() == ACTION_WEBDAV:
+            errors.append(
+                f"Inline destination definition '{name}' uses the WebDAV "
+                "('http') action; WebDAV definitions embed credentials and "
+                "cannot be stored in job files")
+
+    errors.extend(_validate_spec_nodes(
+        config.get('mergeSettings', {}).get('spec', [])))
+
+    return errors
+
+
+def _validate_spec_nodes(nodes: list, path: str = 'spec') -> list[str]:
+    """Validate a site-TOC spec tree (<TOC> containers and <Group> leaves)."""
+    errors = []
+
+    for i, node in enumerate(nodes, start=1):
+        label = f"{path}[{i}]"
+        kind = node.get('kind', 'group')
+        if kind not in ('group', 'container'):
+            errors.append(f"{label} kind '{kind}' is invalid (expected group or container)")
+        if not (node.get('name') or '').strip():
+            errors.append(f"{label} name cannot be empty")
+        if kind == 'container':
+            errors.extend(_validate_spec_nodes(node.get('children', []), f"{label}.children"))
+
+    return errors
+
+
+def _append_spec_nodes(parent: Element, nodes: list) -> None:
+    """Emit <TOC>/<Group> spec nodes under a parent element."""
+    for node in nodes:
+        name = node.get('name', '')
+        title = node.get('title', '')
+
+        if node.get('kind', 'group') == 'container':
+            toc = SubElement(parent, TOC_ELEMENT)
+            toc.set('name', name)
+            # A container's title falls back to its name on load, so an equal
+            # title round-trips through omission.
+            if title and title != name:
+                toc.set('title', title)
+            _append_spec_nodes(toc, node.get('children', []))
+        else:
+            group = SubElement(parent, GROUP_ELEMENT)
+            group.set('name', name)
+            if title:
+                group.set('title', title)
+
+
+def generate_composition_xml(config: dict) -> str:
+    """Generate composition job (.wacj) XML from configuration.
+
+    Mirrors CompositionJobWriter: attributes carrying the reader's default
+    (role infer, build false, discover false) are omitted, so a generated file
+    stays as lean as a hand-authored one.
+    """
+    composition = Element(COMPOSITION_ROOT)
+    composition.set('name', config.get('name', 'untitled'))
+    composition.set('version', '1.0')
+
+    members = config.get('members', [])
+    if members:
+        jobs = SubElement(composition, JOBS_ELEMENT)
+        if config.get('outputTarget'):
+            jobs.set('target', config['outputTarget'])
+
+        for member_config in members:
+            member = SubElement(jobs, JOB_ELEMENT)
+            member.set('path', member_config.get('path', ''))
+
+            role = (member_config.get('role') or ROLE_INFER).strip().lower()
+            if role != ROLE_INFER:
+                member.set('role', role)
+
+            # build defaults to false: a hand-authored member is federated
+            # (built by its own job) unless it opts in.
+            if member_config.get('build'):
+                member.set('build', 'true')
+
+            if member_config.get('target'):
+                member.set('target', member_config['target'])
+
+    # Discovery mode is expressed by the ABSENCE of MergeSettings; an empty
+    # element is spec mode with an empty spec.
+    merge_config = config.get('mergeSettings')
+    if merge_config is not None:
+        merge = SubElement(composition, MERGE_SETTINGS_ELEMENT)
+        if merge_config.get('title'):
+            merge.set('title', merge_config['title'])
+        if merge_config.get('discover'):
+            merge.set('discover', 'true')
+        _append_spec_nodes(merge, merge_config.get('spec', []))
+
+    destination_config = config.get('destination', {})
+    deploy_settings = destination_config.get('deploySettings', [])
+    if destination_config.get('name') or deploy_settings:
+        destination = SubElement(composition, DESTINATION_ELEMENT)
+        destination.set('name', destination_config.get('name', ''))
+
+        if deploy_settings:
+            settings = SubElement(destination, DEPLOY_SETTINGS_ELEMENT)
+            for setting_config in deploy_settings:
+                setting = SubElement(settings, DEPLOY_SETTING_ELEMENT)
+                setting.set(DEPLOY_SETTING_NAME_ATTR, setting_config.get('name', ''))
+                setting.set(DEPLOY_ACTION_ATTR, setting_config.get('action', ''))
+                configuration = setting_config.get('configuration', {})
+                if configuration:
+                    config_elem = SubElement(setting, DEPLOY_CONFIGURATION_ELEMENT)
+                    for key, value in configuration.items():
+                        config_elem.set(key, str(value))
+
+    return pretty_xml(composition)
+
+
+def generate_composition_template() -> dict:
+    """Generate a composition job config template."""
+    return {
+        'kind': 'composition',
+        'name': 'my-composition',
+        # Composition-wide output target pushed down to every member; leave
+        # empty to auto-detect each member's single compose-capable target.
+        'outputTarget': 'WebWorks Reverb 2.0',
+        'members': [
+            {'path': 'shell.waj', 'role': 'shell', 'build': False, 'target': ''},
+            {'path': 'parcel-a.waj', 'role': 'parcel', 'build': False, 'target': ''}
+        ],
+        # Omit "mergeSettings" entirely for discovery mode (the parcel set is
+        # discovered from the mirror); set "discover": true for hybrid mode.
+        'mergeSettings': {
+            'title': '',
+            'discover': False,
+            'spec': [
+                {'kind': 'container', 'name': 'Guides', 'title': 'Guides', 'children': [
+                    {'kind': 'group', 'name': 'Parcel A', 'title': 'Parcel A'}
+                ]}
+            ]
+        },
+        'destination': {
+            'name': 'ProductionMirror',
+            # Optional inline definition; without it the name must resolve
+            # from the --deploysettings overlay or deploy.prefs.
+            'deploySettings': []
+        }
+    }
+
+
+def print_composition_summary(config: dict) -> None:
+    """Print a human-readable summary of a composition configuration."""
+    print(f"\n{'='*60}")
+    print(f"Composition: {config['name']} (version 1.0)")
+    print(f"Output target: {config.get('outputTarget') or '(auto-detect per member)'}")
+    print('='*60)
+
+    members = config.get('members', [])
+    built = sum(1 for m in members if m.get('build'))
+    print(f"\nMembers ({len(members)} total, {built} built by this composition):")
+    for member in members:
+        status = "[BUILD]" if member.get('build') else "[READ]"
+        target = member.get('target') or config.get('outputTarget') or '(auto-detect)'
+        print(f"  {status} {member.get('path', '')} "
+              f"[role: {member.get('role', ROLE_INFER)}] -> {target}")
+
+    merge = config.get('mergeSettings')
+    if merge is None:
+        print("\nSite TOC: (none - discovery mode)")
+    else:
+        mode = 'hybrid' if merge.get('discover') else 'spec'
+        print(f"\nSite TOC ({mode} mode): {len(merge.get('spec', []))} top-level nodes")
+
+    destination = config.get('destination', {})
+    print(f"\nDestination: {destination.get('name', '')}")
+    for setting in destination.get('deploySettings', []):
+        print(f"  Inline definition: {setting.get('name', '')} [{setting.get('action', '')}]")
+
+    print('\n' + '='*60)
 
 
 def interactive_collect_groups() -> list[dict]:
@@ -606,7 +849,8 @@ def ensure_utf8() -> None:
 def main() -> int:
     ensure_utf8()
     parser = argparse.ArgumentParser(
-        description='Create AutoMap job files (.waj) interactively or from configuration.',
+        description='Create AutoMap job (.waj) and composition job (.wacj) '
+                    'files interactively or from configuration.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Exit Codes:
@@ -625,6 +869,10 @@ Examples:
 
     # Generate config template
     %(prog)s --template --stationery path/to/stationery.wxsp > template.json
+
+    # Composition job (.wacj): template, then generate
+    %(prog)s --template --composition > composition-config.json
+    %(prog)s --config composition-config.json --output composition.wacj
 """
     )
 
@@ -633,9 +881,12 @@ Examples:
     parser.add_argument('-c', '--config', metavar='FILE',
                         help='Path to job configuration JSON file')
     parser.add_argument('-o', '--output', metavar='FILE',
-                        help='Output path for job file (default: <name>.waj)')
+                        help='Output path for job file (default: <name>.waj / <name>.wacj)')
     parser.add_argument('-t', '--template', action='store_true',
                         help='Generate a config template from Stationery (output to stdout)')
+    parser.add_argument('--composition', action='store_true',
+                        help='Operate on a composition job (.wacj); with '
+                             '--template emits a composition config template')
     parser.add_argument('--no-preview', action='store_true',
                         help='Skip XML preview (config mode only)')
     parser.add_argument('-y', '--yes', action='store_true',
@@ -645,6 +896,12 @@ Examples:
 
     # Template mode
     if args.template:
+        # A composition references member jobs, not a Stationery, so its
+        # template needs no --stationery.
+        if args.composition:
+            print(json.dumps(generate_composition_template(), indent=2))
+            return EXIT_SUCCESS
+
         if not args.stationery:
             log_error("--stationery is required with --template")
             return EXIT_ARG_ERROR
@@ -665,24 +922,34 @@ Examples:
             return EXIT_FILE_ERROR
 
         try:
-            with open(config_path, encoding='utf-8') as f:
+            # utf-8-sig also decodes plain UTF-8; Windows editors and
+            # PowerShell 5.1's Set-Content write a BOM that json.load rejects.
+            with open(config_path, encoding='utf-8-sig') as f:
                 config = json.load(f)
         except json.JSONDecodeError as e:
             log_error(f"Invalid JSON in config file: {e}")
             return EXIT_FILE_ERROR
 
+        # Composition job configs describe member jobs instead of a Stationery
+        # and its targets, so they validate and generate through their own path.
+        composition = args.composition or is_composition_config(config)
+
         # Validate config
-        errors = validate_config(config)
+        errors = (validate_composition_config(config) if composition
+                  else validate_config(config))
         if errors:
             for error in errors:
                 log_error(error)
             return EXIT_VALIDATION_ERROR
 
         # Generate XML
-        xml_content = generate_job_xml(config)
+        xml_content = (generate_composition_xml(config) if composition
+                       else generate_job_xml(config))
 
         # Preview unless skipped
         if not args.no_preview and not args.yes:
+            if composition:
+                print_composition_summary(config)
             print(f"\n{CYAN}Generated XML:{NC}\n")
             print(xml_content)
             print()
@@ -691,7 +958,9 @@ Examples:
                 return EXIT_CANCELLED
 
         # Determine output path
-        output_path = args.output if args.output else f"{config.get('name', 'job')}.waj"
+        default_extension = COMPOSITION_EXTENSION if composition else '.waj'
+        output_path = (args.output if args.output
+                       else f"{config.get('name', 'job')}{default_extension}")
 
         # Validate output path to prevent directory traversal
         try:
@@ -776,6 +1045,11 @@ Examples:
         return EXIT_SUCCESS
 
     # No valid mode specified
+    if args.composition:
+        log_error("--composition requires --config or --template "
+                  "(there is no interactive composition mode)")
+        return EXIT_ARG_ERROR
+
     parser.print_help()
     return EXIT_ARG_ERROR
 

--- a/plugins/webworks-agent-skills/skills/automap/scripts/lib/wacj.py
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/lib/wacj.py
@@ -36,7 +36,7 @@ Grammar (2026.1)::
 Reader defaults that the tools must reproduce: an unrecognized ``role`` is
 ``infer``; ``build`` defaults to ``False`` (a hand-authored member is federated
 unless it opts in); ``discover`` defaults to ``False``; a missing
-``<MergeSettings>`` means discovery mode.
+``<MergeSettings>`` means Automatic mode.
 """
 
 from pathlib import Path
@@ -84,10 +84,15 @@ ACTION_FOLDER = 'file'
 ACTION_S3 = 's3'
 ACTION_WEBDAV = 'http'
 
-# Composition modes implied by <MergeSettings> (CompositionJob.Mode)
-MODE_DISCOVERY = 'discovery'
-MODE_SPEC = 'spec'
-MODE_HYBRID = 'hybrid'
+# Composition modes implied by <MergeSettings> (CompositionJob.Mode), named as
+# the Administrator's Merge Settings area names them:
+#   Automatic        - omit <MergeSettings>; compose every parcel at the destination
+#   Custom           - declared <Group>/<TOC> placements
+#   Custom + include-new - discover="true" plus placements ("Also include newly
+#                      published parcels not listed above")
+MODE_AUTOMATIC = 'automatic'
+MODE_CUSTOM = 'custom'
+MODE_CUSTOM_INCLUDE_NEW = 'custom+include-new'
 
 # How a member's output target was selected
 TARGET_SOURCE_MEMBER = 'member override'
@@ -256,7 +261,7 @@ def extract_composition_info(root: Element, job_path: str) -> dict:
             'discover': False,
             'spec': [],
         },
-        'mode': MODE_DISCOVERY,
+        'mode': MODE_AUTOMATIC,
         'destination': {
             'declared': False,
             'element': '',
@@ -308,7 +313,7 @@ def extract_composition_info(root: Element, job_path: str) -> dict:
                 'targetSource': target_source,
             })
 
-    # Merge settings (site TOC spec). Absence means discovery mode.
+    # Merge settings (site TOC spec). Absence means Automatic mode.
     merge_elem = root.find(MERGE_SETTINGS_ELEMENT)
     if merge_elem is not None:
         discover = parse_bool(merge_elem.get('discover'), False)
@@ -320,7 +325,7 @@ def extract_composition_info(root: Element, job_path: str) -> dict:
             'spec': [node for node in (_spec_node(child) for child in merge_elem)
                      if node is not None],
         }
-        info['mode'] = MODE_HYBRID if discover else MODE_SPEC
+        info['mode'] = MODE_CUSTOM_INCLUDE_NEW if discover else MODE_CUSTOM
 
     # Shared federated destination.
     destination_elem, destination_tag = find_destination(root)

--- a/plugins/webworks-agent-skills/skills/automap/scripts/lib/wacj.py
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/lib/wacj.py
@@ -1,0 +1,338 @@
+"""WebWorks AutoMap Composition Job (.wacj) grammar.
+
+One definition of the .wacj element/attribute vocabulary, shared by the AutoMap
+skill's Python tools (parse-job.py, validate-job.py, list-job-targets.py,
+create-job.py) so the grammar cannot drift between them.
+
+Grounded in the shipped product source:
+
+    Automap/Core/CompositionJobXmlElements.cs   element + attribute names
+    Automap/Core/CompositionJobReader.cs        load semantics and defaults
+    Automap/Core/CompositionJobWriter.cs        what a writer emits vs. omits
+    Automap/Core/CompositionJobRunner.cs        run-time diagnostics
+    Publish/Core/Deployment/InlineDeploySettings.cs   inline destination policy
+
+Grammar (2026.1)::
+
+    <CompositionJob name="..." version="1.0">
+      <Jobs target="composition-wide output target">
+        <Job path="..." role="shell|parcel|infer" build="True|False" target="..."/>
+      </Jobs>
+      <MergeSettings title="..." discover="True|False">
+        <TOC name="..." title="...">
+          <Group name="..." title="..."/>
+        </TOC>
+        <Group name="..." title="..."/>
+      </MergeSettings>
+      <Destination name="...">              <!-- legacy spelling: <DeployTarget> -->
+        <DeploySettings>
+          <DeploySetting Name="..." Action="file|s3|...">
+            <Configuration Value="..." Region="..." Distribution="..."/>
+          </DeploySetting>
+        </DeploySettings>
+      </Destination>
+    </CompositionJob>
+
+Reader defaults that the tools must reproduce: an unrecognized ``role`` is
+``infer``; ``build`` defaults to ``False`` (a hand-authored member is federated
+unless it opts in); ``discover`` defaults to ``False``; a missing
+``<MergeSettings>`` means discovery mode.
+"""
+
+from pathlib import Path
+from typing import Optional
+from xml.etree.ElementTree import Element  # For type hints only
+
+# File extensions
+COMPOSITION_EXTENSION = '.wacj'
+JOB_EXTENSION = '.waj'
+PROJECT_EXTENSIONS = ('.wep', '.wrp')
+MEMBER_EXTENSIONS = (JOB_EXTENSION,) + PROJECT_EXTENSIONS
+
+# Root elements (AutoMap dispatches on these, not on the extension)
+COMPOSITION_ROOT = 'CompositionJob'
+JOB_ROOT = 'Job'
+
+# Member jobs
+JOBS_ELEMENT = 'Jobs'
+JOB_ELEMENT = 'Job'
+
+# Member roles. An unrecognized value loads as ROLE_INFER.
+ROLE_SHELL = 'shell'
+ROLE_PARCEL = 'parcel'
+ROLE_INFER = 'infer'
+ROLES = (ROLE_SHELL, ROLE_PARCEL, ROLE_INFER)
+
+# Merge settings (site TOC spec) - the same inner grammar as a .waj target
+MERGE_SETTINGS_ELEMENT = 'MergeSettings'
+TOC_ELEMENT = 'TOC'
+GROUP_ELEMENT = 'Group'
+SPEC_ELEMENTS = (TOC_ELEMENT, GROUP_ELEMENT)
+
+# Shared federated destination
+DESTINATION_ELEMENT = 'Destination'
+DESTINATION_LEGACY_ELEMENT = 'DeployTarget'
+DEPLOY_SETTINGS_ELEMENT = 'DeploySettings'
+DEPLOY_SETTING_ELEMENT = 'DeploySetting'
+DEPLOY_CONFIGURATION_ELEMENT = 'Configuration'
+DEPLOY_SETTING_NAME_ATTR = 'Name'
+DEPLOY_ACTION_ATTR = 'Action'
+
+# Deployment actions. WebDAV definitions embed credentials and are rejected
+# inline (InlineDeploySettings.EnforcePolicy); anything else is a custom action.
+ACTION_FOLDER = 'file'
+ACTION_S3 = 's3'
+ACTION_WEBDAV = 'http'
+
+# Composition modes implied by <MergeSettings> (CompositionJob.Mode)
+MODE_DISCOVERY = 'discovery'
+MODE_SPEC = 'spec'
+MODE_HYBRID = 'hybrid'
+
+# How a member's output target was selected
+TARGET_SOURCE_MEMBER = 'member override'
+TARGET_SOURCE_COMPOSITION = 'composition target'
+TARGET_SOURCE_AUTO = 'auto-detect'
+
+
+def is_composition_path(path: str) -> bool:
+    """True when the path names a composition job file (.wacj)."""
+    return Path(path).suffix.lower() == COMPOSITION_EXTENSION
+
+
+def parses_as_bool(value: Optional[str]) -> bool:
+    """True when .NET Boolean.TryParse would accept the attribute value.
+
+    The reader uses Boolean.TryParse and silently falls back to the default,
+    so a value like build="yes" loads as False; tools warn instead of guessing.
+    """
+    if value is None:
+        return False
+    return value.strip().lower() in ('true', 'false')
+
+
+def parse_bool(value: Optional[str], default: bool = False) -> bool:
+    """Parse an attribute with .NET Boolean.TryParse semantics."""
+    if not parses_as_bool(value):
+        return default
+    return value.strip().lower() == 'true'
+
+
+def normalize_role(value: Optional[str]) -> str:
+    """Map a declared role to the value the reader loads (unknown -> infer)."""
+    if value is None:
+        return ROLE_INFER
+    lowered = value.strip().lower()
+    if lowered in (ROLE_SHELL, ROLE_PARCEL):
+        return lowered
+    return ROLE_INFER
+
+
+def role_is_recognized(value: Optional[str]) -> bool:
+    """True when the declared role is one the grammar names (or is absent)."""
+    if value is None or value.strip() == '':
+        return True
+    return value.strip().lower() in ROLES
+
+
+def member_display_name(member_path: str) -> str:
+    """The member name as the product logs it: the file name without extension."""
+    return Path(member_path).stem if member_path else ''
+
+
+def _spec_node(elem: Element) -> Optional[dict]:
+    """Convert a <TOC>/<Group> element into a spec node (other tags ignored)."""
+    if elem.tag == TOC_ELEMENT:
+        return {
+            'kind': 'container',
+            'name': elem.get('name', ''),
+            # A container's title falls back to its name on load.
+            'title': elem.get('title', '') or elem.get('name', ''),
+            'children': [node for node in (_spec_node(child) for child in elem)
+                         if node is not None],
+        }
+    if elem.tag == GROUP_ELEMENT:
+        return {
+            'kind': 'group',
+            'name': elem.get('name', ''),
+            'title': elem.get('title', ''),
+        }
+    return None
+
+
+def spec_group_names(nodes: list) -> list:
+    """Every group (leaf) name in a spec tree, in document order."""
+    names = []
+    for node in nodes:
+        if node['kind'] == 'container':
+            names.extend(spec_group_names(node['children']))
+        else:
+            names.append(node['name'])
+    return names
+
+
+def iter_spec(nodes: list, depth: int = 0):
+    """Yield (depth, node) for every node in a spec tree, depth-first."""
+    for node in nodes:
+        yield depth, node
+        if node['kind'] == 'container':
+            yield from iter_spec(node['children'], depth + 1)
+
+
+def unknown_spec_children(merge_elem: Optional[Element]) -> list:
+    """Tag names under <MergeSettings> the reader ignores (nested included)."""
+    unknown = []
+
+    def walk(parent: Element) -> None:
+        for child in parent:
+            if child.tag in SPEC_ELEMENTS:
+                if child.tag == TOC_ELEMENT:
+                    walk(child)
+            elif isinstance(child.tag, str):
+                unknown.append(child.tag)
+
+    if merge_elem is not None:
+        walk(merge_elem)
+    return unknown
+
+
+def find_destination(root: Element):
+    """Return (element, tag) for <Destination>, falling back to <DeployTarget>.
+
+    The current spelling wins when both are present, matching the reader.
+    """
+    elem = root.find(DESTINATION_ELEMENT)
+    if elem is not None:
+        return elem, DESTINATION_ELEMENT
+
+    elem = root.find(DESTINATION_LEGACY_ELEMENT)
+    if elem is not None:
+        return elem, DESTINATION_LEGACY_ELEMENT
+
+    return None, ''
+
+
+def extract_deploy_settings(destination_elem: Optional[Element]) -> list:
+    """Inline destination definitions carried by <Destination>."""
+    settings = []
+
+    if destination_elem is None:
+        return settings
+
+    settings_elem = destination_elem.find(DEPLOY_SETTINGS_ELEMENT)
+    if settings_elem is None:
+        return settings
+
+    for setting_elem in settings_elem.findall(DEPLOY_SETTING_ELEMENT):
+        config_elem = setting_elem.find(DEPLOY_CONFIGURATION_ELEMENT)
+        settings.append({
+            'name': setting_elem.get(DEPLOY_SETTING_NAME_ATTR, ''),
+            'action': setting_elem.get(DEPLOY_ACTION_ATTR, ''),
+            'configuration': dict(config_elem.attrib) if config_elem is not None else {},
+        })
+
+    return settings
+
+
+def extract_composition_info(root: Element, job_path: str) -> dict:
+    """Extract everything the .wacj grammar carries, with reader defaults applied.
+
+    Lenient by design: malformed input (a member with no path, a missing
+    destination) is reported in the returned structure rather than raised, so
+    parse-job.py can describe a file that validate-job.py rejects.
+    """
+    job_dir = Path(job_path).parent
+
+    info = {
+        'kind': 'composition',
+        'name': root.get('name', ''),
+        'version': root.get('version', ''),
+        'outputTarget': '',
+        'hasJobsElement': False,
+        'members': [],
+        'mergeSettings': {
+            'present': False,
+            'title': '',
+            'discover': False,
+            'spec': [],
+        },
+        'mode': MODE_DISCOVERY,
+        'destination': {
+            'declared': False,
+            'element': '',
+            'legacySpelling': False,
+            'name': '',
+            'deploySettingsDeclared': False,
+            'deploySettings': [],
+        },
+    }
+
+    # Members. Jobs/@target is the composition-wide output target pushed down to
+    # every member; Job/@target is a per-member override.
+    jobs_elem = root.find(JOBS_ELEMENT)
+    if jobs_elem is not None:
+        info['hasJobsElement'] = True
+        info['outputTarget'] = jobs_elem.get('target', '')
+
+        for member_elem in jobs_elem.findall(JOB_ELEMENT):
+            member_path = member_elem.get('path', '')
+            role_declared = member_elem.get('role')
+            build_declared = member_elem.get('build')
+            member_target = member_elem.get('target', '')
+
+            if member_target:
+                effective_target = member_target
+                target_source = TARGET_SOURCE_MEMBER
+            elif info['outputTarget']:
+                effective_target = info['outputTarget']
+                target_source = TARGET_SOURCE_COMPOSITION
+            else:
+                effective_target = ''
+                target_source = TARGET_SOURCE_AUTO
+
+            resolved = str(job_dir / member_path) if member_path else ''
+
+            info['members'].append({
+                'path': member_path,
+                'pathResolved': resolved,
+                'exists': bool(resolved) and Path(resolved).exists(),
+                'displayName': member_display_name(member_path),
+                'role': normalize_role(role_declared),
+                'roleDeclared': role_declared or '',
+                'roleRecognized': role_is_recognized(role_declared),
+                'build': parse_bool(build_declared, False),
+                'buildDeclared': build_declared or '',
+                'buildRecognized': build_declared is None or parses_as_bool(build_declared),
+                'target': member_target,
+                'effectiveTarget': effective_target,
+                'targetSource': target_source,
+            })
+
+    # Merge settings (site TOC spec). Absence means discovery mode.
+    merge_elem = root.find(MERGE_SETTINGS_ELEMENT)
+    if merge_elem is not None:
+        discover = parse_bool(merge_elem.get('discover'), False)
+        info['mergeSettings'] = {
+            'present': True,
+            'title': merge_elem.get('title', ''),
+            'discover': discover,
+            'discoverDeclared': merge_elem.get('discover', ''),
+            'spec': [node for node in (_spec_node(child) for child in merge_elem)
+                     if node is not None],
+        }
+        info['mode'] = MODE_HYBRID if discover else MODE_SPEC
+
+    # Shared federated destination.
+    destination_elem, destination_tag = find_destination(root)
+    if destination_elem is not None:
+        settings_elem = destination_elem.find(DEPLOY_SETTINGS_ELEMENT)
+        info['destination'] = {
+            'declared': True,
+            'element': destination_tag,
+            'legacySpelling': destination_tag == DESTINATION_LEGACY_ELEMENT,
+            'name': destination_elem.get('name', ''),
+            'deploySettingsDeclared': settings_elem is not None,
+            'deploySettings': extract_deploy_settings(destination_elem),
+        }
+
+    return info

--- a/plugins/webworks-agent-skills/skills/automap/scripts/list-job-targets.py
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/list-job-targets.py
@@ -2,7 +2,8 @@
 """
 list-job-targets.py
 
-List targets from AutoMap job files (.waj) with build status and configuration.
+List targets from AutoMap job files (.waj) with build status and configuration,
+or member jobs and their selected output target from a composition job (.wacj).
 
 Usage:
     python list-job-targets.py [OPTIONS] <job-file>
@@ -11,6 +12,8 @@ Features:
     - List all targets with build status
     - Filter by enabled/disabled status
     - Show detailed configuration
+    - Composition jobs (.wacj): list members with their role, build flag and
+      the output target each one composes through
     - JSON output option
 
 Exit Codes:
@@ -29,6 +32,14 @@ import defusedxml.ElementTree as ET
 from xml.etree.ElementTree import Element  # For type hints only
 from pathlib import Path
 from typing import Optional
+
+# The .wacj grammar lives beside this script in lib/wacj.py so every AutoMap
+# tool shares one definition of the composition element vocabulary.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from lib.wacj import (  # noqa: E402
+    COMPOSITION_EXTENSION, COMPOSITION_ROOT, JOB_EXTENSION,
+    TARGET_SOURCE_AUTO, extract_composition_info, is_composition_path,
+)
 
 # Exit codes
 EXIT_SUCCESS = 0
@@ -57,8 +68,9 @@ def validate_job_file(job_file: str) -> bool:
         log_error(f"Job file not found: {job_file}")
         return False
 
-    if path.suffix.lower() != '.waj':
+    if path.suffix.lower() not in (JOB_EXTENSION, COMPOSITION_EXTENSION):
         log_error(f"Invalid job file extension: {job_file}")
+        log_error(f"Expected: {JOB_EXTENSION} or {COMPOSITION_EXTENSION}")
         return False
 
     return True
@@ -236,6 +248,48 @@ def output_json(targets: list[dict]) -> None:
     print(json.dumps(targets, indent=2))
 
 
+def member_target_label(member: dict) -> str:
+    """The output target a member composes through, with its selection source."""
+    if member['targetSource'] == TARGET_SOURCE_AUTO:
+        return "(auto-detect)"
+    return f"{member['effectiveTarget']} ({member['targetSource']})"
+
+
+def output_members_simple(members: list[dict]) -> None:
+    """Output member paths with build status and selected target."""
+    for member in members:
+        status = "[BUILD]" if member['build'] else "[READ]"
+        print(f"{status} {member['path']} -> {member_target_label(member)}")
+
+
+def output_members(info: dict, members: list[dict], detailed: bool = False) -> None:
+    """Output composition members in a table (optionally with full detail)."""
+    print(f"\n{CYAN}Composition:{NC} {info['name'] or '(unnamed)'}")
+    print(f"{BLUE}Output target:{NC} {info['outputTarget'] or '(auto-detect per member)'}")
+    print(f"{BLUE}Destination:{NC} {info['destination']['name'] or '(none declared)'}")
+
+    built = sum(1 for m in members if m['build'])
+    print(f"\n{CYAN}Members ({len(members)} total, {built} built by this composition):{NC}\n")
+
+    for member in members:
+        if member['build']:
+            status = f"{GREEN}[BUILD]{NC}"
+        else:
+            status = f"{YELLOW}[READ]{NC}"
+
+        print(f"  {status} {member['path'] or '(no path)'}")
+        print(f"          Target: {member_target_label(member)}")
+        print(f"          Role: {member['role']}")
+
+        if detailed:
+            print(f"          Exists: {'Yes' if member['exists'] else 'No'}")
+            print(f"          Resolved: {member['pathResolved'] or '(none)'}")
+            if not member['roleRecognized']:
+                print(f"          Declared role: {member['roleDeclared']} (unrecognized)")
+
+        print()
+
+
 def ensure_utf8() -> None:
     """Make this tool Unicode-safe regardless of the caller's environment.
 
@@ -255,7 +309,8 @@ def ensure_utf8() -> None:
 def main() -> int:
     ensure_utf8()
     parser = argparse.ArgumentParser(
-        description='List targets from AutoMap job files (.waj).',
+        description='List targets from AutoMap job files (.waj), or members '
+                    'from a composition job (.wacj).',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Exit Codes:
@@ -267,6 +322,9 @@ Exit Codes:
 Examples:
     # List all targets
     %(prog)s job.waj
+
+    # List composition members and the target each composes through
+    %(prog)s composition.wacj
 
     # Show only enabled targets
     %(prog)s --enabled job.waj
@@ -286,11 +344,13 @@ Examples:
     )
 
     parser.add_argument('job_file', metavar='job-file',
-                        help='Path to .waj job file')
+                        help='Path to .waj job file or .wacj composition job file')
     parser.add_argument('-e', '--enabled', action='store_true',
-                        help='Show only enabled targets (build="True")')
+                        help='Show only enabled targets, or members the '
+                             'composition builds (build="True")')
     parser.add_argument('-d', '--disabled', action='store_true',
-                        help='Show only disabled targets (build="False")')
+                        help='Show only disabled targets, or members the '
+                             'composition only reads (build="False")')
     parser.add_argument('--detailed', action='store_true',
                         help='Show detailed configuration for each target')
     parser.add_argument('-s', '--simple', action='store_true',
@@ -307,6 +367,45 @@ Examples:
     # Parse XML
     root = parse_job_xml(args.job_file)
     if root is None:
+        return EXIT_FILE_ERROR
+
+    # Composition job (.wacj): the unit is a member job and the output target
+    # it composes through, not a build target of this file.
+    if is_composition_path(args.job_file):
+        if root.tag != COMPOSITION_ROOT:
+            log_error(f"Expected <{COMPOSITION_ROOT}> in a {COMPOSITION_EXTENSION} "
+                      f"file, found <{root.tag}>")
+            return EXIT_FILE_ERROR
+
+        info = extract_composition_info(root, args.job_file)
+        members = info['members']
+
+        if not members:
+            log_error("No member jobs found in composition job file")
+            return EXIT_NO_TARGETS
+
+        # For a member, "enabled" means the composition (re)builds it.
+        if args.enabled:
+            members = [m for m in members if m['build']]
+        elif args.disabled:
+            members = [m for m in members if not m['build']]
+
+        if not members:
+            print("No members match the filter criteria")
+            return EXIT_SUCCESS
+
+        if args.json:
+            output_json(members)
+        elif args.simple:
+            output_members_simple(members)
+        else:
+            output_members(info, members, detailed=args.detailed)
+
+        return EXIT_SUCCESS
+
+    if root.tag == COMPOSITION_ROOT:
+        log_error(f"This is a composition job (<{COMPOSITION_ROOT}>) in a "
+                  f"{JOB_EXTENSION} file; rename it to {COMPOSITION_EXTENSION}")
         return EXIT_FILE_ERROR
 
     # Get job info

--- a/plugins/webworks-agent-skills/skills/automap/scripts/parse-job.py
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/parse-job.py
@@ -40,7 +40,7 @@ from typing import Optional
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from lib.wacj import (  # noqa: E402
     COMPOSITION_EXTENSION, COMPOSITION_ROOT, JOB_EXTENSION, JOB_ROOT,
-    MODE_DISCOVERY, MODE_HYBRID, TARGET_SOURCE_AUTO,
+    MODE_AUTOMATIC, MODE_CUSTOM_INCLUDE_NEW, TARGET_SOURCE_AUTO,
     extract_composition_info, is_composition_path, iter_spec,
 )
 
@@ -273,9 +273,9 @@ def output_composition_human(info: dict) -> None:
     print(f"\n{GREEN}Composition Job:{NC} {info['name'] or '(unnamed)'} (version {version})")
 
     mode_note = {
-        MODE_DISCOVERY: 'parcel set discovered from the mirror',
-        MODE_HYBRID: 'declared spec plus discovered extras',
-    }.get(info['mode'], 'parcel set is exactly the declared spec')
+        MODE_AUTOMATIC: 'compose every parcel found at the destination',
+        MODE_CUSTOM_INCLUDE_NEW: 'declared placements plus newly published parcels',
+    }.get(info['mode'], 'compose exactly the declared placements')
     print(f"{BLUE}Mode:{NC} {info['mode']} ({mode_note})")
 
     output_target = info['outputTarget'] or '(auto-detect per member)'
@@ -302,12 +302,12 @@ def output_composition_human(info: dict) -> None:
     merge = info['mergeSettings']
     print(f"\n{CYAN}Site TOC (MergeSettings):{NC}")
     if not merge['present']:
-        print("  (none - discovery mode)")
+        print("  (none - Automatic: compose every parcel found at the destination)")
     else:
         if merge['title']:
             print(f"  Title: {merge['title']} (accepted for grammar parity; not used by composition)")
         if merge['discover']:
-            print("  Discover: True (declared spec plus discovered extras)")
+            print("  Discover: True (also include newly published parcels not listed above)")
         if not merge['spec']:
             print("  (empty spec)")
         for depth, node in iter_spec(merge['spec']):
@@ -373,7 +373,7 @@ def output_composition_config(info: dict) -> None:
         },
     }
 
-    # MergeSettings is omitted entirely in discovery mode - its absence is the
+    # MergeSettings is omitted entirely in Automatic mode - its absence is the
     # mode, so a round-trip must not invent an empty element.
     if info['mergeSettings']['present']:
         config['mergeSettings'] = {

--- a/plugins/webworks-agent-skills/skills/automap/scripts/parse-job.py
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/parse-job.py
@@ -2,7 +2,8 @@
 """
 parse-job.py
 
-Parse AutoMap job files (.waj) to extract configuration information.
+Parse AutoMap job files (.waj) and composition job files (.wacj) to extract
+configuration information.
 
 Usage:
     python parse-job.py [OPTIONS] <job-file>
@@ -12,6 +13,8 @@ Features:
     - Extract Stationery reference path
     - List all document groups and documents
     - List all targets with configuration
+    - Composition jobs (.wacj): members, roles, output target selection,
+      site-TOC spec (MergeSettings) and the shared destination
     - JSON output option for programmatic use
     - Export config for use with create-job.py
 
@@ -31,6 +34,15 @@ import defusedxml.ElementTree as ET
 from xml.etree.ElementTree import Element  # For type hints only
 from pathlib import Path
 from typing import Optional
+
+# The .wacj grammar lives beside this script in lib/wacj.py so every AutoMap
+# tool shares one definition of the composition element vocabulary.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from lib.wacj import (  # noqa: E402
+    COMPOSITION_EXTENSION, COMPOSITION_ROOT, JOB_EXTENSION, JOB_ROOT,
+    MODE_DISCOVERY, MODE_HYBRID, TARGET_SOURCE_AUTO,
+    extract_composition_info, is_composition_path, iter_spec,
+)
 
 # Exit codes
 EXIT_SUCCESS = 0
@@ -65,9 +77,34 @@ def validate_job_file(job_file: str) -> bool:
         log_error(f"Job file not found: {job_file}")
         return False
 
-    if path.suffix.lower() != '.waj':
+    if path.suffix.lower() not in (JOB_EXTENSION, COMPOSITION_EXTENSION):
         log_error(f"Invalid job file extension: {job_file}")
-        log_error("Expected: .waj")
+        log_error(f"Expected: {JOB_EXTENSION} or {COMPOSITION_EXTENSION}")
+        return False
+
+    return True
+
+
+def check_root_matches_extension(root: Element, job_file: str) -> bool:
+    """Confirm the root element matches the file extension.
+
+    AutoMap dispatches on the root element (<Job> vs <CompositionJob>), so a
+    mismatch is worth naming rather than parsing the wrong grammar.
+    """
+    composition_path = is_composition_path(job_file)
+
+    if composition_path and root.tag != COMPOSITION_ROOT:
+        log_error(f"Expected <{COMPOSITION_ROOT}> in a {COMPOSITION_EXTENSION} "
+                  f"file, found <{root.tag}>")
+        return False
+
+    if not composition_path and root.tag != JOB_ROOT:
+        if root.tag == COMPOSITION_ROOT:
+            log_error(f"This is a composition job (<{COMPOSITION_ROOT}>) in a "
+                      f"{JOB_EXTENSION} file; rename it to {COMPOSITION_EXTENSION}")
+        else:
+            log_error(f"Expected <{JOB_ROOT}> in a {JOB_EXTENSION} file, "
+                      f"found <{root.tag}>")
         return False
 
     return True
@@ -92,6 +129,9 @@ def extract_job_info(root: Element, job_path: str) -> dict:
 
     # Basic job info
     job_info = {
+        # Discriminates a publishing job from a composition job (.wacj) for
+        # consumers that accept either shape.
+        'kind': 'job',
         'name': root.get('name', 'Unknown'),
         'version': root.get('version', '1.0'),
         'stationery': '',
@@ -227,6 +267,74 @@ def output_human_readable(job_info: dict) -> None:
     print()
 
 
+def output_composition_human(info: dict) -> None:
+    """Output composition job (.wacj) information in human-readable format."""
+    version = info['version'] or '1.0'
+    print(f"\n{GREEN}Composition Job:{NC} {info['name'] or '(unnamed)'} (version {version})")
+
+    mode_note = {
+        MODE_DISCOVERY: 'parcel set discovered from the mirror',
+        MODE_HYBRID: 'declared spec plus discovered extras',
+    }.get(info['mode'], 'parcel set is exactly the declared spec')
+    print(f"{BLUE}Mode:{NC} {info['mode']} ({mode_note})")
+
+    output_target = info['outputTarget'] or '(auto-detect per member)'
+    print(f"{BLUE}Output target:{NC} {output_target}")
+
+    # Members
+    members = info['members']
+    built = sum(1 for m in members if m['build'])
+    print(f"\n{CYAN}Members ({len(members)} total, {built} built by this composition):{NC}")
+
+    for member in members:
+        status = f"{GREEN}[BUILD]{NC}" if member['build'] else f"{YELLOW}[READ]{NC}"
+        exists = f"{GREEN}exists{NC}" if member['exists'] else f"{YELLOW}not found{NC}"
+        print(f"\n  {status} {member['path'] or '(no path)'} [{exists}]")
+        print(f"         Role: {member['role']}"
+              + ("" if member['roleRecognized']
+                 else f" (declared \"{member['roleDeclared']}\", unrecognized)"))
+        if member['targetSource'] == TARGET_SOURCE_AUTO:
+            print(f"         Target: (auto-detect)")
+        else:
+            print(f"         Target: {member['effectiveTarget']} ({member['targetSource']})")
+
+    # Site TOC spec
+    merge = info['mergeSettings']
+    print(f"\n{CYAN}Site TOC (MergeSettings):{NC}")
+    if not merge['present']:
+        print("  (none - discovery mode)")
+    else:
+        if merge['title']:
+            print(f"  Title: {merge['title']} (accepted for grammar parity; not used by composition)")
+        if merge['discover']:
+            print("  Discover: True (declared spec plus discovered extras)")
+        if not merge['spec']:
+            print("  (empty spec)")
+        for depth, node in iter_spec(merge['spec']):
+            indent = '  ' + ('  ' * (depth + 1))
+            if node['kind'] == 'container':
+                print(f"{indent}{node['name'] or '(unnamed)'}/")
+            else:
+                title = f" ({node['title']})" if node['title'] else ''
+                print(f"{indent}- {node['name'] or '(unnamed)'}{title}")
+
+    # Destination
+    destination = info['destination']
+    print(f"\n{CYAN}Destination:{NC}")
+    if not destination['declared']:
+        print(f"  {YELLOW}(none declared){NC}")
+    else:
+        legacy = ' (legacy <DeployTarget> spelling)' if destination['legacySpelling'] else ''
+        print(f"  {destination['name'] or '(unnamed)'}{legacy}")
+        for setting in destination['deploySettings']:
+            action = setting['action'] or '(no action)'
+            print(f"    Inline definition: {setting['name'] or '(unnamed)'} [{action}]")
+            for key, value in setting['configuration'].items():
+                print(f"      {key}: {value}")
+
+    print()
+
+
 def output_json(job_info: dict) -> None:
     """Output job information in JSON format."""
     print(json.dumps(job_info, indent=2))
@@ -241,6 +349,39 @@ def output_config(job_info: dict) -> None:
         'groups': job_info['groups'],
         'targets': job_info['targets']
     }
+    print(json.dumps(config, indent=2))
+
+
+def output_composition_config(info: dict) -> None:
+    """Output a composition in create-job.py compatible config format."""
+    config = {
+        'kind': 'composition',
+        'name': info['name'],
+        'outputTarget': info['outputTarget'],
+        'members': [
+            {
+                'path': member['path'],
+                'role': member['role'],
+                'build': member['build'],
+                'target': member['target'],
+            }
+            for member in info['members']
+        ],
+        'destination': {
+            'name': info['destination']['name'],
+            'deploySettings': info['destination']['deploySettings'],
+        },
+    }
+
+    # MergeSettings is omitted entirely in discovery mode - its absence is the
+    # mode, so a round-trip must not invent an empty element.
+    if info['mergeSettings']['present']:
+        config['mergeSettings'] = {
+            'title': info['mergeSettings']['title'],
+            'discover': info['mergeSettings']['discover'],
+            'spec': info['mergeSettings']['spec'],
+        }
+
     print(json.dumps(config, indent=2))
 
 
@@ -263,7 +404,7 @@ def ensure_utf8() -> None:
 def main() -> int:
     ensure_utf8()
     parser = argparse.ArgumentParser(
-        description='Parse AutoMap job files (.waj) to extract configuration.',
+        description='Parse AutoMap job (.waj) and composition job (.wacj) files.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Exit Codes:
@@ -275,6 +416,9 @@ Exit Codes:
 Examples:
     # Show job configuration
     %(prog)s job.waj
+
+    # Show composition members, site TOC spec and destination
+    %(prog)s composition.wacj
 
     # JSON output
     %(prog)s --json job.waj
@@ -288,7 +432,7 @@ Examples:
     )
 
     parser.add_argument('job_file', metavar='job-file',
-                        help='Path to .waj job file')
+                        help='Path to .waj job file or .wacj composition job file')
     parser.add_argument('-j', '--json', action='store_true',
                         help='Output in JSON format (includes metadata)')
     parser.add_argument('-c', '--config', action='store_true',
@@ -308,6 +452,27 @@ Examples:
     root = parse_job_xml(args.job_file)
     if root is None:
         return EXIT_PARSE_ERROR
+
+    if not check_root_matches_extension(root, args.job_file):
+        return EXIT_PARSE_ERROR
+
+    # Composition job (.wacj): a distinct artifact that references .waj/.wep
+    # members, so it carries a different grammar than a publishing job.
+    if is_composition_path(args.job_file):
+        composition = extract_composition_info(root, args.job_file)
+
+        log_verbose(f"Composition name: {composition['name']}", args.verbose)
+        log_verbose(f"Found {len(composition['members'])} members", args.verbose)
+        log_verbose(f"Composition mode: {composition['mode']}", args.verbose)
+
+        if args.config:
+            output_composition_config(composition)
+        elif args.json:
+            output_json(composition)
+        else:
+            output_composition_human(composition)
+
+        return EXIT_SUCCESS
 
     # Extract job info
     job_info = extract_job_info(root, args.job_file)

--- a/plugins/webworks-agent-skills/skills/automap/scripts/validate-job.py
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/validate-job.py
@@ -2,7 +2,8 @@
 """
 validate-job.py
 
-Validate AutoMap job files (.waj) for correctness before building.
+Validate AutoMap job files (.waj) and composition job files (.wacj) for
+correctness before building.
 
 Usage:
     python validate-job.py [OPTIONS] <job-file>
@@ -14,6 +15,9 @@ Features:
     - Target configuration validation
     - Optional document existence check
     - Optional format name validation against Stationery
+    - Composition jobs (.wacj): member/role/build grammar, output target
+      selection, MergeSettings spec, destination and inline destination
+      definitions, plus an optional cross-check of .waj members
 
 Exit Codes:
     0 - All validations passed
@@ -30,6 +34,17 @@ import defusedxml.ElementTree as ET
 from xml.etree.ElementTree import Element  # For type hints only
 from pathlib import Path
 from typing import Optional
+
+# The .wacj grammar lives beside this script in lib/wacj.py so every AutoMap
+# tool shares one definition of the composition element vocabulary.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from lib.wacj import (  # noqa: E402
+    ACTION_WEBDAV, COMPOSITION_EXTENSION, COMPOSITION_ROOT, JOB_EXTENSION,
+    JOB_ROOT, MEMBER_EXTENSIONS, MERGE_SETTINGS_ELEMENT, MODE_DISCOVERY,
+    ROLE_SHELL, TARGET_SOURCE_AUTO, TARGET_SOURCE_COMPOSITION,
+    TARGET_SOURCE_MEMBER, extract_composition_info, is_composition_path,
+    iter_spec, spec_group_names, unknown_spec_children,
+)
 
 # Exit codes
 EXIT_SUCCESS = 0
@@ -88,6 +103,30 @@ def print_result(result: ValidationResult) -> None:
         print(f"  {YELLOW}[WARN]{NC} {warning}")
 
 
+def print_report(results: list, job_file: str, verbose: bool) -> int:
+    """Print the validation report and return the process exit code."""
+    print(f"\n{BLUE}Validation Results:{NC} {job_file}\n")
+
+    for result in results:
+        if verbose or not result.passed or result.warnings:
+            print_result(result)
+
+    passed = sum(1 for r in results if r.passed)
+    total = len(results)
+    warnings = sum(len(r.warnings) for r in results)
+
+    print()
+    if passed == total:
+        if warnings:
+            print(f"{GREEN}Validation: PASSED{NC} ({passed}/{total} checks, {warnings} warnings)")
+        else:
+            print(f"{GREEN}Validation: PASSED{NC} ({passed}/{total} checks)")
+        return EXIT_SUCCESS
+
+    print(f"{RED}Validation: FAILED{NC} ({total - passed}/{total} checks failed)")
+    return EXIT_VALIDATION_FAILED
+
+
 def validate_file_exists(job_file: str) -> ValidationResult:
     """Check that the job file exists."""
     result = ValidationResult("Job file exists")
@@ -96,8 +135,10 @@ def validate_file_exists(job_file: str) -> ValidationResult:
     if not path.exists():
         return result.fail_check(f"File not found: {job_file}")
 
-    if path.suffix.lower() != '.waj':
-        return result.fail_check(f"Invalid extension: {path.suffix} (expected .waj)")
+    if path.suffix.lower() not in (JOB_EXTENSION, COMPOSITION_EXTENSION):
+        return result.fail_check(
+            f"Invalid extension: {path.suffix} "
+            f"(expected {JOB_EXTENSION} or {COMPOSITION_EXTENSION})")
 
     return result.pass_check(path.name)
 
@@ -120,8 +161,13 @@ def validate_root_element(root: Element) -> ValidationResult:
     """Check that the root element is Job with required attributes."""
     result = ValidationResult("Job element valid")
 
-    if root.tag != 'Job':
-        return result.fail_check(f"Expected <Job>, found <{root.tag}>")
+    if root.tag == COMPOSITION_ROOT:
+        return result.fail_check(
+            f"This is a composition job (<{COMPOSITION_ROOT}>) in a "
+            f"{JOB_EXTENSION} file; rename it to {COMPOSITION_EXTENSION}")
+
+    if root.tag != JOB_ROOT:
+        return result.fail_check(f"Expected <{JOB_ROOT}>, found <{root.tag}>")
 
     name = root.get('name')
     version = root.get('version')
@@ -328,6 +374,357 @@ def validate_target_formats(root: Element, stationery_path: Path) -> ValidationR
         return result.fail_check("No valid formats")
 
 
+def validate_composition_root(root: Element) -> ValidationResult:
+    """Check the <CompositionJob> root element and its attributes."""
+    result = ValidationResult("CompositionJob element valid")
+
+    if root.tag == JOB_ROOT:
+        return result.fail_check(
+            f"This is a publishing job (<{JOB_ROOT}>) in a "
+            f"{COMPOSITION_EXTENSION} file; rename it to {JOB_EXTENSION}")
+
+    if root.tag != COMPOSITION_ROOT:
+        return result.fail_check(f"Expected <{COMPOSITION_ROOT}>, found <{root.tag}>")
+
+    name = root.get('name')
+    version = root.get('version')
+
+    # The name drives the composition log file name (<name>-log.txt beside the
+    # .wacj), so an unnamed composition logs to "-log.txt".
+    if not name:
+        return result.fail_check(
+            f"Missing 'name' attribute on {COMPOSITION_ROOT} element "
+            "(it names the composition log file)")
+
+    if not version:
+        result.add_warning("Missing 'version' attribute (writers emit 1.0)")
+
+    return result.pass_check(f"name=\"{name}\" version=\"{version or '1.0'}\"")
+
+
+def validate_composition_members(info: dict) -> ValidationResult:
+    """Check <Jobs>/<Job> member references and their attributes."""
+    result = ValidationResult("Member jobs")
+
+    if not info['hasJobsElement']:
+        return result.fail_check(
+            "Missing <Jobs> element - a composition with no members cannot "
+            "resolve the shell format")
+
+    members = info['members']
+    if not members:
+        return result.fail_check("No <Job> elements found under <Jobs>")
+
+    missing_path = 0
+    seen_paths = {}
+
+    for index, member in enumerate(members, start=1):
+        label = member['displayName'] or f"member {index}"
+
+        if not member['path']:
+            missing_path += 1
+            result.add_warning(f"Member {index} is missing its 'path' attribute")
+            continue
+
+        key = member['path'].lower()
+        if key in seen_paths:
+            result.add_warning(
+                f"Duplicate member path: {member['path']} "
+                f"(also member {seen_paths[key]})")
+        else:
+            seen_paths[key] = index
+
+        suffix = Path(member['path']).suffix.lower()
+        if suffix not in MEMBER_EXTENSIONS:
+            result.add_warning(
+                f"Member '{label}' has an unexpected extension "
+                f"'{suffix or '(none)'}' (expected {', '.join(MEMBER_EXTENSIONS)})")
+
+        if not member['roleRecognized']:
+            result.add_warning(
+                f"Member '{label}' has an unrecognized role "
+                f"\"{member['roleDeclared']}\" - it loads as \"infer\" "
+                "(expected shell, parcel or infer)")
+
+        if not member['buildRecognized']:
+            result.add_warning(
+                f"Member '{label}' has a non-boolean build "
+                f"\"{member['buildDeclared']}\" - it loads as False "
+                "(expected True or False)")
+
+    shells = [m for m in members if m['role'] == ROLE_SHELL]
+    if not shells:
+        result.add_warning(
+            "No member declares role=\"shell\" - the first member is used to "
+            "resolve the shell format")
+    elif len(shells) > 1:
+        result.add_warning(
+            f"{len(shells)} members declare role=\"shell\" - the first one is "
+            "used to resolve the shell format")
+
+    if missing_path:
+        return result.fail_check(
+            f"{missing_path} of {len(members)} members are missing 'path'")
+
+    built = sum(1 for m in members if m['build'])
+    return result.pass_check(
+        f"{len(members)} members ({built} built by this composition)")
+
+
+def validate_composition_member_paths(info: dict) -> ValidationResult:
+    """Check that every member job/project file exists on disk."""
+    result = ValidationResult("Member paths")
+
+    members = [m for m in info['members'] if m['path']]
+    if not members:
+        return result.pass_check("(no members)")
+
+    missing = [m['path'] for m in members if not m['exists']]
+    found = len(members) - len(missing)
+
+    for path in missing[:5]:
+        result.add_warning(f"Not found: {path}")
+    if len(missing) > 5:
+        result.add_warning(f"... and {len(missing) - 5} more missing")
+
+    if not missing:
+        return result.pass_check(f"All {found} members found")
+    if found:
+        return result.pass_check(f"{found} found, {len(missing)} missing")
+    return result.fail_check(f"All {len(missing)} members missing")
+
+
+def validate_composition_target_selection(info: dict) -> ValidationResult:
+    """Report how each member's output target is selected."""
+    result = ValidationResult("Output target selection")
+
+    members = info['members']
+    if not members:
+        return result.pass_check("(no members)")
+
+    counts = {
+        TARGET_SOURCE_MEMBER: 0,
+        TARGET_SOURCE_COMPOSITION: 0,
+        TARGET_SOURCE_AUTO: 0,
+    }
+    for member in members:
+        counts[member['targetSource']] += 1
+
+    parts = [f"{count} {source}" for source, count in counts.items() if count]
+
+    composition_target = info['outputTarget'] or '(none)'
+    return result.pass_check(
+        f"Jobs/@target={composition_target}; " + ", ".join(parts))
+
+
+def validate_composition_merge_settings(info: dict, root: Element) -> ValidationResult:
+    """Check <MergeSettings> - the composition's site TOC spec."""
+    result = ValidationResult("Site TOC (MergeSettings)")
+
+    merge = info['mergeSettings']
+    if not merge['present']:
+        # Absence IS discovery mode, not an omission.
+        return result.pass_check(f"{MODE_DISCOVERY} mode (no <MergeSettings>)")
+
+    if merge['title']:
+        result.add_warning(
+            f"MergeSettings title '{merge['title']}' is accepted for grammar "
+            "parity but is not used by composition (the composed site's title "
+            "comes from the shell project's build)")
+
+    if merge.get('discoverDeclared') and not merge['discover'] \
+            and merge['discoverDeclared'].strip().lower() != 'false':
+        result.add_warning(
+            f"Non-boolean discover \"{merge['discoverDeclared']}\" - it loads "
+            "as False (expected True or False)")
+
+    for tag in sorted(set(unknown_spec_children(root.find(MERGE_SETTINGS_ELEMENT)))):
+        result.add_warning(
+            f"<{tag}> under <MergeSettings> is ignored (expected <TOC> or <Group>)")
+
+    unnamed = 0
+    names = []
+    for _, node in iter_spec(merge['spec']):
+        if not node['name']:
+            unnamed += 1
+        elif node['kind'] == 'group':
+            names.append(node['name'])
+
+    if unnamed:
+        result.add_warning(f"{unnamed} <TOC>/<Group> node(s) missing 'name'")
+
+    duplicates = sorted({name for name in names if names.count(name) > 1})
+    for name in duplicates:
+        result.add_warning(
+            f"Group '{name}' is declared more than once - the compose treats "
+            "duplicate group names as one")
+
+    group_count = len(spec_group_names(merge['spec']))
+    return result.pass_check(f"{info['mode']} mode, {group_count} groups declared")
+
+
+def validate_composition_destination(info: dict) -> ValidationResult:
+    """Check <Destination> and any inline destination definitions."""
+    result = ValidationResult("Destination")
+
+    destination = info['destination']
+    if not destination['declared']:
+        return result.fail_check(
+            "Missing <Destination name=\"...\"/> - the composition cannot "
+            "resolve the shared federated destination")
+
+    if destination['legacySpelling']:
+        result.add_warning(
+            "<DeployTarget> is the pre-release spelling of <Destination>, read "
+            "for one release; saving the job writes <Destination>")
+
+    if not destination['name']:
+        return result.fail_check(
+            f"<{destination['element']}> is missing its 'name' attribute")
+
+    seen = {}
+    for setting in destination['deploySettings']:
+        name = setting['name']
+        if not name:
+            return result.fail_check(
+                "An inline destination definition is missing its Name attribute")
+
+        if name in seen:
+            return result.fail_check(f"Duplicate inline destination definition '{name}'")
+        seen[name] = True
+
+        if setting['action'] == ACTION_WEBDAV:
+            return result.fail_check(
+                f"Inline destination definition '{name}' uses the WebDAV "
+                "('http') action; WebDAV definitions embed credentials and "
+                "cannot be stored in job files - define it in deploy.prefs")
+
+        if not setting['action']:
+            result.add_warning(
+                f"Inline destination definition '{name}' has no Action "
+                "attribute (it loads as a custom action)")
+
+    if destination['deploySettings'] and destination['name'] not in seen:
+        result.add_warning(
+            f"Inline definitions are present but none is named "
+            f"'{destination['name']}' - that name must resolve from the "
+            "--deploysettings overlay or deploy.prefs")
+
+    inline = f", {len(destination['deploySettings'])} inline definition(s)" \
+        if destination['deploySettings'] else ""
+    return result.pass_check(f"{destination['name']}{inline}")
+
+
+def validate_composition_member_jobs(info: dict) -> ValidationResult:
+    """Cross-check .waj members against the composition's selections.
+
+    Mirrors two run-time checks statically: the selected output target must be
+    one the member's job declares (CompositionTargetSelector.ResolveExplicit),
+    and an unbuilt member's own job should deploy that target to the
+    composition's destination (CompositionJobRunner.WarnOnMemberDestinationMismatch).
+    """
+    result = ValidationResult("Member job cross-check")
+
+    destination_name = info['destination']['name']
+    checked = 0
+    mismatched_targets = []
+
+    for member in info['members']:
+        if not member['path'] or not member['exists']:
+            continue
+        if Path(member['path']).suffix.lower() != JOB_EXTENSION:
+            # A .wep/.wrp member's target universe is the project's targets,
+            # which needs the format installation to resolve.
+            continue
+
+        try:
+            member_root = ET.parse(member['pathResolved']).getroot()
+        except Exception as exp:
+            result.add_warning(f"Member '{member['displayName']}': unreadable ({exp})")
+            continue
+
+        if member_root.tag != JOB_ROOT:
+            result.add_warning(
+                f"Member '{member['displayName']}': expected <{JOB_ROOT}>, "
+                f"found <{member_root.tag}>")
+            continue
+
+        checked += 1
+
+        targets_elem = member_root.find('Targets')
+        target_elems = targets_elem.findall('Target') if targets_elem is not None else []
+        declared = [t.get('name', '') for t in target_elems]
+
+        selected = member['effectiveTarget']
+        if selected and declared and selected not in declared:
+            mismatched_targets.append(member['displayName'])
+            result.add_warning(
+                f"Member '{member['displayName']}' has no output target named "
+                f"'{selected}' (from {member['targetSource']}). Its job "
+                f"declares: {', '.join(declared) or '(none)'}")
+            continue
+
+        if not selected:
+            continue
+
+        # A built member deploys to the composition's destination regardless,
+        # so only unbuilt members are cross-checked.
+        if member['build']:
+            continue
+
+        selected_elem = next((t for t in target_elems if t.get('name', '') == selected), None)
+        if selected_elem is None:
+            continue
+
+        member_destination = (selected_elem.get('destination')
+                              or selected_elem.get('deployTarget') or '')
+
+        if not member_destination:
+            result.add_warning(
+                f"Member '{member['displayName']}': its job declares no "
+                f"destination for output target '{selected}', so its output "
+                "does not deploy anywhere this composition can read")
+        elif destination_name and member_destination.lower() != destination_name.lower():
+            result.add_warning(
+                f"Member '{member['displayName']}': its job deploys output "
+                f"target '{selected}' to destination '{member_destination}', "
+                f"not to this composition's destination '{destination_name}'")
+
+    if mismatched_targets:
+        return result.fail_check(
+            f"{len(mismatched_targets)} member(s) do not declare the selected "
+            "output target")
+
+    if not checked:
+        return result.pass_check("(no .waj members to cross-check)")
+
+    return result.pass_check(f"{checked} .waj members cross-checked")
+
+
+def run_composition_checks(root: Element, job_file: str,
+                           check_members: bool) -> list:
+    """Run every .wacj check and return the results in report order."""
+    results = []
+
+    result = validate_composition_root(root)
+    results.append(result)
+    if not result.passed:
+        return results
+
+    info = extract_composition_info(root, job_file)
+
+    results.append(validate_composition_members(info))
+    if check_members:
+        results.append(validate_composition_member_paths(info))
+    results.append(validate_composition_target_selection(info))
+    results.append(validate_composition_merge_settings(info, root))
+    results.append(validate_composition_destination(info))
+    if check_members:
+        results.append(validate_composition_member_jobs(info))
+
+    return results
+
+
 def ensure_utf8() -> None:
     """Make this tool Unicode-safe regardless of the caller's environment.
 
@@ -347,7 +744,7 @@ def ensure_utf8() -> None:
 def main() -> int:
     ensure_utf8()
     parser = argparse.ArgumentParser(
-        description='Validate AutoMap job files (.waj) for correctness.',
+        description='Validate AutoMap job (.waj) and composition job (.wacj) files.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Exit Codes:
@@ -368,15 +765,24 @@ Examples:
 
     # Full validation
     %(prog)s --check-documents --check-stationery job.waj
+
+    # Composition job grammar only
+    %(prog)s composition.wacj
+
+    # Composition job plus member existence and .waj cross-check
+    %(prog)s --check-members composition.wacj
 """
     )
 
     parser.add_argument('job_file', metavar='job-file',
-                        help='Path to .waj job file')
+                        help='Path to .waj job file or .wacj composition job file')
     parser.add_argument('-d', '--check-documents', action='store_true',
-                        help='Check that referenced documents exist')
+                        help='Check that referenced documents exist (.waj)')
     parser.add_argument('-s', '--check-stationery', action='store_true',
-                        help='Validate format names against Stationery')
+                        help='Validate format names against Stationery (.waj)')
+    parser.add_argument('-m', '--check-members', action='store_true',
+                        help='Check member jobs exist and cross-check their '
+                             'output target and destination (.wacj)')
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='Show all checks including passed ones')
 
@@ -385,7 +791,6 @@ Examples:
     job_dir = job_path.parent
 
     results = []
-    all_passed = True
 
     # Check 1: File exists
     result = validate_file_exists(args.job_file)
@@ -402,71 +807,41 @@ Examples:
             print_result(r)
         return EXIT_VALIDATION_FAILED
 
+    # Composition jobs (.wacj) reference member jobs instead of documents and
+    # targets, so they run their own check sequence.
+    if is_composition_path(args.job_file):
+        # --check-documents is the .waj spelling of the same intent, so it also
+        # turns on the member checks.
+        check_members = args.check_members or args.check_documents
+        results.extend(run_composition_checks(root, args.job_file, check_members))
+        return print_report(results, args.job_file, args.verbose)
+
     # Check 3: Root element
-    result = validate_root_element(root)
-    results.append(result)
-    if not result.passed:
-        all_passed = False
+    results.append(validate_root_element(root))
 
     # Check 4: Project element
-    result = validate_project_element(root, job_dir)
-    results.append(result)
-    if not result.passed:
-        all_passed = False
+    results.append(validate_project_element(root, job_dir))
 
     # Get stationery path for later checks
     project = root.find('Project')
     stationery_path = job_dir / project.get('path', '') if project is not None else Path()
 
     # Check 5: Files element
-    result = validate_files_element(root)
-    results.append(result)
-    if not result.passed:
-        all_passed = False
+    results.append(validate_files_element(root))
 
     # Check 6: Document existence (optional)
     if args.check_documents:
-        result = validate_documents_exist(root, job_dir)
-        results.append(result)
-        if not result.passed:
-            all_passed = False
+        results.append(validate_documents_exist(root, job_dir))
 
     # Check 7: Targets element
-    result = validate_targets_element(root)
-    results.append(result)
-    if not result.passed:
-        all_passed = False
+    results.append(validate_targets_element(root))
 
     # Check 8: Format validation (optional)
     if args.check_stationery:
-        result = validate_target_formats(root, stationery_path)
-        results.append(result)
-        if not result.passed:
-            all_passed = False
+        results.append(validate_target_formats(root, stationery_path))
 
     # Print results
-    print(f"\n{BLUE}Validation Results:{NC} {args.job_file}\n")
-
-    for result in results:
-        if args.verbose or not result.passed or result.warnings:
-            print_result(result)
-
-    # Summary
-    passed = sum(1 for r in results if r.passed)
-    total = len(results)
-    warnings = sum(len(r.warnings) for r in results)
-
-    print()
-    if all_passed:
-        if warnings:
-            print(f"{GREEN}Validation: PASSED{NC} ({passed}/{total} checks, {warnings} warnings)")
-        else:
-            print(f"{GREEN}Validation: PASSED{NC} ({passed}/{total} checks)")
-        return EXIT_SUCCESS
-    else:
-        failed = total - passed
-        print(f"{RED}Validation: FAILED{NC} ({failed}/{total} checks failed)")
-        return EXIT_VALIDATION_FAILED
+    return print_report(results, args.job_file, args.verbose)
 
 
 if __name__ == '__main__':

--- a/plugins/webworks-agent-skills/skills/automap/scripts/validate-job.py
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/validate-job.py
@@ -40,7 +40,7 @@ from typing import Optional
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from lib.wacj import (  # noqa: E402
     ACTION_WEBDAV, COMPOSITION_EXTENSION, COMPOSITION_ROOT, JOB_EXTENSION,
-    JOB_ROOT, MEMBER_EXTENSIONS, MERGE_SETTINGS_ELEMENT, MODE_DISCOVERY,
+    JOB_ROOT, MEMBER_EXTENSIONS, MERGE_SETTINGS_ELEMENT, MODE_AUTOMATIC,
     ROLE_SHELL, TARGET_SOURCE_AUTO, TARGET_SOURCE_COMPOSITION,
     TARGET_SOURCE_MEMBER, extract_composition_info, is_composition_path,
     iter_spec, spec_group_names, unknown_spec_children,
@@ -523,8 +523,8 @@ def validate_composition_merge_settings(info: dict, root: Element) -> Validation
 
     merge = info['mergeSettings']
     if not merge['present']:
-        # Absence IS discovery mode, not an omission.
-        return result.pass_check(f"{MODE_DISCOVERY} mode (no <MergeSettings>)")
+        # Absence IS Automatic mode, not an omission.
+        return result.pass_check(f"{MODE_AUTOMATIC} mode (no <MergeSettings>)")
 
     if merge['title']:
         result.add_warning(

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-federation/composition.wacj
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-federation/composition.wacj
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Realistic composition job (.wacj) fixture: a shell member plus two parcel
+  members composed into one federated Reverb mirror.
+
+  Exercises the whole shipped grammar:
+    Jobs/@target          composition-wide output target pushed down to members
+    Job/@path|@role|@build|@target
+                          shell.waj is read (federated, built by its own job),
+                          parcel-a.waj is rebuilt by this composition
+                          (derivative), parcel-b.wep overrides the output
+                          target name ("names may vary, formats may not")
+    MergeSettings         SPEC mode: a <TOC> container plus a top-level <Group>
+    Destination           the shared mirror, with an inline definition so the
+                          job is a whole artifact under version control
+-->
+<CompositionJob name="Product Docs" version="1.0">
+  <Jobs target="WebWorks Reverb 2.0">
+    <Job path="shell.waj" role="shell" />
+    <Job path="parcel-a.waj" role="parcel" build="true" />
+    <Job path="parcel-b.wep" role="parcel" target="Online Docs" />
+  </Jobs>
+
+  <MergeSettings>
+    <TOC name="Guides" title="Guides">
+      <Group name="Parcel A" title="Parcel A" />
+    </TOC>
+    <Group name="Parcel B" title="Parcel B" />
+  </MergeSettings>
+
+  <Destination name="ProductionMirror">
+    <DeploySettings>
+      <DeploySetting Name="ProductionMirror" Action="file">
+        <Configuration Value="C:\mirrors\product-docs" />
+      </DeploySetting>
+    </DeploySettings>
+  </Destination>
+</CompositionJob>

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-federation/composition.wacj
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-federation/composition.wacj
@@ -10,7 +10,7 @@
                           parcel-a.waj is rebuilt by this composition
                           (derivative), parcel-b.wep overrides the output
                           target name ("names may vary, formats may not")
-    MergeSettings         SPEC mode: a <TOC> container plus a top-level <Group>
+    MergeSettings         Custom mode: a <TOC> container plus a top-level <Group>
     Destination           the shared mirror, with an inline definition so the
                           job is a whole artifact under version control
 -->

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-federation/parcel-a.waj
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-federation/parcel-a.waj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Parcel member of composition.wacj, marked build="true" there: the composition
+  rebuilds it and passes its own destination down, so this job declares no
+  destination of its own. Its <Group> name is the parcel's federation identity,
+  the name the composition's MergeSettings places in the site TOC.
+-->
+<Job name="parcel-a" version="1.0">
+  <Project path="..\..\sample.wxsp" />
+  <Files>
+    <Group name="Parcel A">
+      <Document path="docs\intro.md" />
+    </Group>
+  </Files>
+  <Targets>
+    <Target name="WebWorks Reverb 2.0"
+            format="WebWorks Reverb 2.0"
+            formatType="Application"
+            build="True"
+            destination=""
+            deployScope="groups"
+            cleanOutput="False" />
+  </Targets>
+</Job>

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-federation/parcel-b.wep
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-federation/parcel-b.wep
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="urn:WebWorks-Publish-Project" Version="1.1.2.0"
+         ProjectID="Kq7ZmR2wXbA" RuntimeVersion="2026.1" FormatVersion="{Current}">
+  <!--
+    Direct-project parcel member of composition.wacj: a full Designer project
+    that owns its own groups, referenced by the .wacj without a .waj wrapper.
+    Its output target is named "Online Docs" while its format is the same
+    WebWorks Reverb 2.0 every member composes through - the .wacj names it with
+    Job/@target ("names may vary, formats may not").
+  -->
+  <Formats>
+    <Format TargetName="Online Docs" Name="WebWorks Reverb 2.0" Type="Application" TargetID="Rn4TgQbVe_M">
+      <OutputDirectory>Output\Online Docs</OutputDirectory>
+    </Format>
+  </Formats>
+  <Groups>
+    <Group Name="Parcel B" Type="normal" Included="true" GroupID="Zt8HpLcNdK4" />
+  </Groups>
+</Project>

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-federation/shell.waj
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-federation/shell.waj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Shell member of composition.wacj: chrome only (no <Files>), so its build
+  produces the empty #parcels shell the composition splices parcels into. It
+  deploys the shell layer to the composition's shared destination, so the
+  composition can read its output without rebuilding it.
+-->
+<Job name="shell" version="1.0">
+  <Project path="..\..\sample.wxsp" />
+  <Targets>
+    <Target name="WebWorks Reverb 2.0"
+            format="WebWorks Reverb 2.0"
+            formatType="Application"
+            build="True"
+            destination="ProductionMirror"
+            deployScope="shell"
+            cleanOutput="False" />
+  </Targets>
+</Job>

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-invalid/broken.wacj
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-invalid/broken.wacj
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Deliberately malformed composition job: every defect here is one a hand
+  edit produces, and validate-job.py must name it rather than let AutoMap
+  fail minutes into a run.
+
+    Job with no @path            -> FAIL (the reader throws on load)
+    role="member"                -> WARN (unrecognized; loads as "infer")
+    build="yes"                  -> WARN (not a boolean; loads as False)
+    MergeSettings @title         -> WARN (accepted for grammar parity, unused)
+    <Parcel> under MergeSettings -> WARN (ignored; expected <TOC>/<Group>)
+    duplicate <Group name>       -> WARN (the compose treats them as one)
+    <Group> with no @name        -> WARN
+    <DeployTarget>               -> WARN (pre-release spelling of <Destination>)
+    inline Action="http"         -> FAIL (WebDAV definitions embed credentials)
+-->
+<CompositionJob name="Broken Composition" version="1.0">
+  <Jobs target="WebWorks Reverb 2.0">
+    <Job role="shell" />
+    <Job path="api-guide.waj" role="member" build="yes" />
+  </Jobs>
+
+  <MergeSettings title="Product Documentation">
+    <Group name="API Guide" />
+    <Group name="API Guide" />
+    <Group />
+    <Parcel name="Not part of the grammar" />
+  </MergeSettings>
+
+  <DeployTarget name="LegacyMirror">
+    <DeploySettings>
+      <DeploySetting Name="LegacyMirror" Action="http">
+        <Configuration Value="http://docs.example.com/webdav" />
+      </DeploySetting>
+    </DeploySettings>
+  </DeployTarget>
+</CompositionJob>

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-invalid/no-destination.wacj
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-invalid/no-destination.wacj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Composition job with no <Destination>: the members are fine, but the run
+  fails at once ("cannot resolve the destination") because the shared mirror
+  is what a composition composes into. Also has no member declaring
+  role="shell", so the first member resolves the format (a warning, not an
+  error).
+-->
+<CompositionJob name="No Destination" version="1.0">
+  <Jobs target="WebWorks Reverb 2.0">
+    <Job path="api-guide.waj" role="parcel" />
+    <Job path="user-guide.waj" role="parcel" />
+  </Jobs>
+</CompositionJob>

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-mixed/Product Docs-log.txt
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-mixed/Product Docs-log.txt
@@ -1,0 +1,8 @@
+Composition job 'Product Docs' started at 9:22:44 AM, 2026-03-11.
+Running WebWorks ePublisher AutoMap version 2026.1.0.
+[WARN] Member 'api-guide' deploys to destination 'Staging', not the composition's destination 'ProductionMirror'.
+Member 'shell': output target 'WebWorks Reverb 2.0' (WebWorks Reverb 2.0, composition Jobs/@target).
+[ERROR] Destination 'ProductionMirror' is not defined in deploy.prefs, the --deploysettings overlay, or inline in the composition job.
+Composition job 'Product Docs' finished at 9:22:46 AM, 2026-03-11.
+Total time: 00:00:02.
+0 group(s) composed, 1 warning(s), 1 error(s) reported.

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-mixed/composition.wacj
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-mixed/composition.wacj
@@ -1,0 +1,7 @@
+<CompositionJob name="Product Docs" version="1.0">
+  <Jobs target="WebWorks Reverb 2.0">
+    <Job path="shell.waj" role="shell"/>
+    <Job path="api-guide.waj" role="member"/>
+  </Jobs>
+  <Destination name="ProductionMirror"/>
+</CompositionJob>

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-mixed/expected-default.txt
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-mixed/expected-default.txt
@@ -1,0 +1,1 @@
+[ERROR] 1 warning(s), 1 error(s) in Product Docs-log.txt

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-warning/Product Docs-log.txt
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-warning/Product Docs-log.txt
@@ -1,0 +1,10 @@
+Composition job 'Product Docs' started at 9:14:02 AM, 2026-03-11.
+Running WebWorks ePublisher AutoMap version 2026.1.0.
+[WARN] The MergeSettings title 'Product Documentation' is not used by composition; the composed site's title comes from the shell project's build.
+Member 'shell': output target 'WebWorks Reverb 2.0' (WebWorks Reverb 2.0, composition Jobs/@target).
+Member 'api-guide': output target 'WebWorks Reverb 2.0' (WebWorks Reverb 2.0, composition Jobs/@target).
+[WARN] Member 'api-guide' deploys to destination 'Staging', not the composition's destination 'ProductionMirror'.
+Composed group 'API Guide'.
+Composition job 'Product Docs' finished at 9:14:37 AM, 2026-03-11.
+Total time: 00:00:35.
+1 group(s) composed, 2 warning(s), 0 error(s) reported.

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-warning/composition.wacj
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-warning/composition.wacj
@@ -1,0 +1,7 @@
+<CompositionJob name="Product Docs" version="1.0">
+  <Jobs target="WebWorks Reverb 2.0">
+    <Job path="shell.waj" role="shell"/>
+    <Job path="api-guide.waj" role="member"/>
+  </Jobs>
+  <Destination name="ProductionMirror"/>
+</CompositionJob>

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-warning/expected-default.txt
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-warning/expected-default.txt
@@ -1,0 +1,1 @@
+[WARNING] 2 warning(s), 0 error(s) in Product Docs-log.txt

--- a/plugins/webworks-agent-skills/skills/automap/tests/test-log-scan.ps1
+++ b/plugins/webworks-agent-skills/skills/automap/tests/test-log-scan.ps1
@@ -1,6 +1,7 @@
 <#
 test-log-scan.ps1
-Test driver for Get-GenerateLogSummaries in Invoke-Automap.ps1.
+Test driver for Get-GenerateLogSummaries and Get-CompositionLogSummary in
+Invoke-Automap.ps1.
 
 Dot-sources the wrapper (its main-flow guard prevents a build from running),
 invokes the log scan against each fixture directory, and compares the summary
@@ -21,11 +22,11 @@ $fixtures = Join-Path $scriptDir 'fixtures'
 $script:Pass = 0
 $script:Fail = 0
 
-function Test-Fixture {
+function Assert-Summary {
     param(
         [string]$Name,
-        [string]$FixtureDir,
-        [string]$ExpectedFile
+        [string]$ExpectedFile,
+        [string]$Actual
     )
 
     $expected = ''
@@ -35,7 +36,7 @@ function Test-Fixture {
     }
     $expected = ($expected -replace "`r`n", "`n").TrimEnd("`n")
 
-    $actual = (@(Get-GenerateLogSummaries -BaseDir $FixtureDir) | ForEach-Object { $_.Text }) -join "`n"
+    $actual = $Actual
 
     if ($expected -ceq $actual) {
         $script:Pass++
@@ -50,6 +51,29 @@ function Test-Fixture {
         Write-Output $actual
         Write-Output '----------------'
     }
+}
+
+function Test-Fixture {
+    param(
+        [string]$Name,
+        [string]$FixtureDir,
+        [string]$ExpectedFile
+    )
+
+    $actual = (@(Get-GenerateLogSummaries -BaseDir $FixtureDir) | ForEach-Object { $_.Text }) -join "`n"
+    Assert-Summary -Name $Name -ExpectedFile $ExpectedFile -Actual $actual
+}
+
+function Test-CompositionFixture {
+    param(
+        [string]$Name,
+        [string]$CompositionFile,
+        [string]$ExpectedFile
+    )
+
+    $actual = (@(Get-CompositionLogSummary -Path $CompositionFile) |
+        Where-Object { $_ } | ForEach-Object { $_.Text }) -join "`n"
+    Assert-Summary -Name $Name -ExpectedFile $ExpectedFile -Actual $actual
 }
 
 # Single-target, warnings only: summary format.
@@ -82,6 +106,18 @@ Test-Fixture 'no-logs-dir' `
 Test-Fixture 'empty-logs-dir' `
     (Join-Path $fixtures 'empty-logs-dir') `
     (Join-Path $fixtures 'empty-logs-dir\expected-default.txt')
+
+# Composition log, warnings only: the product writes [WARN]/[ERROR] (Publish
+# Core's Messages.Warn/.Error), so warnings must be counted, not dropped.
+Test-CompositionFixture 'composition-warning' `
+    (Join-Path $fixtures 'composition-warning\composition.wacj') `
+    (Join-Path $fixtures 'composition-warning\expected-default.txt')
+
+# Composition log with both markers: summary is [ERROR], both counted. The log
+# is located by the <CompositionJob name="..."> attribute, not the file name.
+Test-CompositionFixture 'composition-mixed' `
+    (Join-Path $fixtures 'composition-mixed\composition.wacj') `
+    (Join-Path $fixtures 'composition-mixed\expected-default.txt')
 
 Write-Output ''
 Write-Output "Results: $($script:Pass) passed, $($script:Fail) failed"

--- a/plugins/webworks-agent-skills/skills/automap/tests/test-wacj-tools.ps1
+++ b/plugins/webworks-agent-skills/skills/automap/tests/test-wacj-tools.ps1
@@ -1,0 +1,263 @@
+<#
+test-wacj-tools.ps1
+Test driver for composition job (.wacj) support in the AutoMap Python tools:
+parse-job.py, validate-job.py, list-job-targets.py and create-job.py.
+
+Runs each tool against the fixtures under fixtures/composition-federation
+(a valid federated composition) and fixtures/composition-invalid (hand-edit
+defects that must be rejected), asserts exit codes and key output, and
+round-trips the composition through --config / create-job.py. Also spot-checks
+the .waj path so composition support cannot regress it.
+
+Usage: powershell -ExecutionPolicy Bypass -File test-wacj-tools.ps1
+Exit code: 0 if all assertions pass, 1 otherwise.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$scripts = Join-Path $scriptDir '..\scripts'
+$federation = Join-Path $scriptDir 'fixtures\composition-federation'
+$invalid = Join-Path $scriptDir 'fixtures\composition-invalid'
+
+$python = (Get-Command python -ErrorAction SilentlyContinue)
+if (-not $python) {
+    Write-Output 'SKIP: python is not on PATH; cannot run the .wacj tool tests.'
+    exit 1
+}
+
+$script:Pass = 0
+$script:Fail = 0
+
+function Invoke-Tool {
+    param(
+        [string]$Tool,
+        [string[]]$Arguments,
+        [string]$WorkingDirectory
+    )
+
+    $toolPath = Join-Path $scripts $Tool
+    $previousLocation = Get-Location
+    if ($WorkingDirectory) { Set-Location -LiteralPath $WorkingDirectory }
+
+    # Under $ErrorActionPreference = 'Stop', PowerShell 5.1 turns redirected
+    # native stderr lines into terminating NativeCommandErrors; relax while
+    # the tool runs (the tools write diagnostics to stderr by design).
+    $previousEap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $output = & $python.Source $toolPath @Arguments 2>&1 |
+            ForEach-Object { $_.ToString() }
+        $exit = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $previousEap
+        Set-Location -LiteralPath $previousLocation
+    }
+
+    return [pscustomobject]@{ Output = ($output -join "`n"); ExitCode = $exit }
+}
+
+function Assert-Equal {
+    param([string]$Name, $Expected, $Actual)
+
+    if ($Expected -eq $Actual) {
+        $script:Pass++
+        Write-Output "PASS: $Name"
+    }
+    else {
+        $script:Fail++
+        Write-Output "FAIL: $Name"
+        Write-Output "  expected: $Expected"
+        Write-Output "  actual:   $Actual"
+    }
+}
+
+function Assert-Contains {
+    param([string]$Name, [string]$Needle, [string]$Haystack)
+
+    if ($Haystack -and $Haystack.Contains($Needle)) {
+        $script:Pass++
+        Write-Output "PASS: $Name"
+    }
+    else {
+        $script:Fail++
+        Write-Output "FAIL: $Name"
+        Write-Output "  missing: $Needle"
+        Write-Output "--- output ---"
+        Write-Output $Haystack
+        Write-Output "--------------"
+    }
+}
+
+# --- parse-job.py -----------------------------------------------------------
+
+$composition = Join-Path $federation 'composition.wacj'
+
+$result = Invoke-Tool -Tool 'parse-job.py' -Arguments @($composition)
+Assert-Equal 'parse-job .wacj exit code' 0 $result.ExitCode
+Assert-Contains 'parse-job names the composition' 'Composition Job:' $result.Output
+Assert-Contains 'parse-job reports spec mode' 'spec (parcel set is exactly the declared spec)' $result.Output
+Assert-Contains 'parse-job reports the member count' 'Members (3 total, 1 built' $result.Output
+Assert-Contains 'parse-job reports the inline definition' 'Inline definition: ProductionMirror' $result.Output
+
+$result = Invoke-Tool -Tool 'parse-job.py' -Arguments @('--json', $composition)
+Assert-Equal 'parse-job --json exit code' 0 $result.ExitCode
+$json = $result.Output | ConvertFrom-Json
+Assert-Equal 'parse-job --json kind' 'composition' $json.kind
+Assert-Equal 'parse-job --json member count' 3 $json.members.Count
+Assert-Equal 'parse-job --json composition-wide target' 'WebWorks Reverb 2.0' $json.outputTarget
+Assert-Equal 'parse-job --json per-member target override' 'Online Docs' $json.members[2].effectiveTarget
+Assert-Equal 'parse-job --json target source' 'member override' $json.members[2].targetSource
+Assert-Equal 'parse-job --json build flag' $true $json.members[1].build
+Assert-Equal 'parse-job --json destination name' 'ProductionMirror' $json.destination.name
+Assert-Equal 'parse-job --json inline action' 'file' $json.destination.deploySettings[0].action
+Assert-Equal 'parse-job --json TOC container' 'container' $json.mergeSettings.spec[0].kind
+Assert-Equal 'parse-job --json nested group' 'Parcel A' $json.mergeSettings.spec[0].children[0].name
+
+# The legacy <DeployTarget> spelling loads as the destination.
+$result = Invoke-Tool -Tool 'parse-job.py' -Arguments @('--json', (Join-Path $invalid 'broken.wacj'))
+$json = $result.Output | ConvertFrom-Json
+Assert-Equal 'parse-job reads the legacy DeployTarget spelling' 'LegacyMirror' $json.destination.name
+Assert-Equal 'parse-job flags the legacy spelling' $true $json.destination.legacySpelling
+Assert-Equal 'parse-job normalizes an unknown role' 'infer' $json.members[1].role
+Assert-Equal 'parse-job keeps the declared role' 'member' $json.members[1].roleDeclared
+Assert-Equal 'parse-job rejects a non-boolean build' $false $json.members[1].build
+
+# --- validate-job.py --------------------------------------------------------
+
+$result = Invoke-Tool -Tool 'validate-job.py' -Arguments @('-v', $composition)
+Assert-Equal 'validate-job .wacj exit code' 0 $result.ExitCode
+Assert-Contains 'validate-job passes the fixture' 'Validation: PASSED' $result.Output
+
+$result = Invoke-Tool -Tool 'validate-job.py' -Arguments @('-v', '--check-members', $composition)
+Assert-Equal 'validate-job --check-members exit code' 0 $result.ExitCode
+Assert-Contains 'validate-job finds every member' 'All 3 members found' $result.Output
+Assert-Contains 'validate-job cross-checks .waj members' '.waj members cross-checked' $result.Output
+
+$result = Invoke-Tool -Tool 'validate-job.py' -Arguments @((Join-Path $invalid 'broken.wacj'))
+Assert-Equal 'validate-job rejects the broken fixture' 3 $result.ExitCode
+Assert-Contains 'validate-job reports the missing path' "missing its 'path' attribute" $result.Output
+Assert-Contains 'validate-job warns on the unknown role' 'unrecognized role' $result.Output
+Assert-Contains 'validate-job warns on the non-boolean build' 'non-boolean build' $result.Output
+Assert-Contains 'validate-job warns on the unused MergeSettings title' 'not used by composition' $result.Output
+Assert-Contains 'validate-job warns on an ignored element' '<Parcel> under <MergeSettings> is ignored' $result.Output
+Assert-Contains 'validate-job warns on duplicate groups' 'declared more than once' $result.Output
+Assert-Contains 'validate-job warns on the legacy spelling' 'pre-release spelling' $result.Output
+Assert-Contains 'validate-job rejects an inline WebDAV definition' "WebDAV ('http') action" $result.Output
+
+$result = Invoke-Tool -Tool 'validate-job.py' -Arguments @((Join-Path $invalid 'no-destination.wacj'))
+Assert-Equal 'validate-job rejects a composition with no destination' 3 $result.ExitCode
+Assert-Contains 'validate-job names the missing destination' 'Missing <Destination' $result.Output
+Assert-Contains 'validate-job warns when no member is the shell' 'No member declares role="shell"' $result.Output
+
+# --- list-job-targets.py ----------------------------------------------------
+
+$result = Invoke-Tool -Tool 'list-job-targets.py' -Arguments @('--json', $composition)
+Assert-Equal 'list-job-targets .wacj exit code' 0 $result.ExitCode
+$json = $result.Output | ConvertFrom-Json
+Assert-Equal 'list-job-targets lists every member' 3 $json.Count
+
+$result = Invoke-Tool -Tool 'list-job-targets.py' -Arguments @('--simple', '--enabled', $composition)
+Assert-Equal 'list-job-targets --enabled exit code' 0 $result.ExitCode
+Assert-Equal 'list-job-targets --enabled lists built members only' `
+    '[BUILD] parcel-a.waj -> WebWorks Reverb 2.0 (composition target)' $result.Output.Trim()
+
+# --- create-job.py + round trip ---------------------------------------------
+
+$temp = Join-Path ([System.IO.Path]::GetTempPath()) ("wacj-tests-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $temp | Out-Null
+
+try {
+    $result = Invoke-Tool -Tool 'create-job.py' -Arguments @('--template', '--composition')
+    Assert-Equal 'create-job --template --composition exit code' 0 $result.ExitCode
+    Set-Content -LiteralPath (Join-Path $temp 'template.json') -Value $result.Output -Encoding UTF8
+
+    $result = Invoke-Tool -Tool 'create-job.py' `
+        -Arguments @('--config', 'template.json', '--output', 'from-template.wacj', '-y') `
+        -WorkingDirectory $temp
+    Assert-Equal 'create-job generates from the template' 0 $result.ExitCode
+
+    $result = Invoke-Tool -Tool 'validate-job.py' -Arguments @((Join-Path $temp 'from-template.wacj'))
+    Assert-Equal 'the generated .wacj validates' 0 $result.ExitCode
+
+    # Round trip: parse --config -> create-job -> parse --json must be identical
+    # apart from the resolved member paths, which follow the file's location.
+    $result = Invoke-Tool -Tool 'parse-job.py' -Arguments @('--config', $composition)
+    Assert-Equal 'parse-job --config exit code' 0 $result.ExitCode
+    Set-Content -LiteralPath (Join-Path $temp 'roundtrip.json') -Value $result.Output -Encoding UTF8
+
+    $result = Invoke-Tool -Tool 'create-job.py' `
+        -Arguments @('--config', 'roundtrip.json', '--output', 'roundtrip.wacj', '-y') `
+        -WorkingDirectory $temp
+    Assert-Equal 'create-job regenerates the composition' 0 $result.ExitCode
+
+    $original = (Invoke-Tool -Tool 'parse-job.py' -Arguments @('--json', $composition)).Output | ConvertFrom-Json
+    $rebuilt = (Invoke-Tool -Tool 'parse-job.py' -Arguments @('--json', (Join-Path $temp 'roundtrip.wacj'))).Output | ConvertFrom-Json
+
+    Assert-Equal 'round trip keeps the name' $original.name $rebuilt.name
+    Assert-Equal 'round trip keeps the composition-wide target' $original.outputTarget $rebuilt.outputTarget
+    Assert-Equal 'round trip keeps the mode' $original.mode $rebuilt.mode
+    Assert-Equal 'round trip keeps every member' $original.members.Count $rebuilt.members.Count
+    Assert-Equal 'round trip keeps the member override' `
+        $original.members[2].target $rebuilt.members[2].target
+    Assert-Equal 'round trip keeps the build flag' `
+        $original.members[1].build $rebuilt.members[1].build
+    Assert-Equal 'round trip keeps the destination' `
+        $original.destination.name $rebuilt.destination.name
+    Assert-Equal 'round trip keeps the inline definition' `
+        $original.destination.deploySettings[0].configuration.Value `
+        $rebuilt.destination.deploySettings[0].configuration.Value
+    Assert-Equal 'round trip migrates to the current spelling' $false $rebuilt.destination.legacySpelling
+
+    # A composition config rejects the same defects the file grammar does.
+    $badConfig = @'
+{
+  "kind": "composition",
+  "name": "bad",
+  "members": [ { "path": "", "role": "middle" } ],
+  "destination": { "name": "" }
+}
+'@
+    Set-Content -LiteralPath (Join-Path $temp 'bad.json') -Value $badConfig -Encoding UTF8
+    $result = Invoke-Tool -Tool 'create-job.py' `
+        -Arguments @('--config', 'bad.json', '--output', 'bad.wacj', '-y') `
+        -WorkingDirectory $temp
+    Assert-Equal 'create-job rejects an invalid composition config' 3 $result.ExitCode
+    Assert-Contains 'create-job names the empty member path' 'Member 1 path cannot be empty' $result.Output
+    Assert-Contains 'create-job names the invalid role' "role 'middle' is invalid" $result.Output
+    Assert-Contains 'create-job names the empty destination' 'Destination name cannot be empty' $result.Output
+}
+finally {
+    Remove-Item -LiteralPath $temp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# --- .waj regression spot-checks -------------------------------------------
+
+$sampleJob = Join-Path $scriptDir 'sample.waj'
+
+$result = Invoke-Tool -Tool 'parse-job.py' -Arguments @('--json', $sampleJob)
+Assert-Equal 'parse-job .waj exit code' 0 $result.ExitCode
+$json = $result.Output | ConvertFrom-Json
+Assert-Equal 'parse-job .waj kind' 'job' $json.kind
+Assert-Equal 'parse-job .waj target count' 2 $json.targets.Count
+
+$result = Invoke-Tool -Tool 'validate-job.py' -Arguments @('-v', $sampleJob)
+Assert-Equal 'validate-job .waj exit code' 0 $result.ExitCode
+
+$result = Invoke-Tool -Tool 'validate-job.py' `
+    -Arguments @('-v', (Join-Path $scriptDir 'sample-designer-stationery.waj'))
+Assert-Equal 'validate-job project-as-stationery .waj exit code' 0 $result.ExitCode
+
+$result = Invoke-Tool -Tool 'list-job-targets.py' -Arguments @('--simple', '--enabled', $sampleJob)
+Assert-Equal 'list-job-targets .waj exit code' 0 $result.ExitCode
+Assert-Equal 'list-job-targets .waj enabled target' '[BUILD] WebWorks Reverb 2.0' $result.Output.Trim()
+
+# A composition job in a .waj file (and the reverse) is named, not mis-parsed.
+$result = Invoke-Tool -Tool 'parse-job.py' -Arguments @((Join-Path $federation 'parcel-b.wep'))
+Assert-Equal 'parse-job rejects a non-job extension' 1 $result.ExitCode
+
+Write-Output ''
+Write-Output "Results: $($script:Pass) passed, $($script:Fail) failed"
+
+if ($script:Fail -eq 0) { exit 0 } else { exit 1 }

--- a/plugins/webworks-agent-skills/skills/automap/tests/test-wacj-tools.ps1
+++ b/plugins/webworks-agent-skills/skills/automap/tests/test-wacj-tools.ps1
@@ -97,7 +97,7 @@ $composition = Join-Path $federation 'composition.wacj'
 $result = Invoke-Tool -Tool 'parse-job.py' -Arguments @($composition)
 Assert-Equal 'parse-job .wacj exit code' 0 $result.ExitCode
 Assert-Contains 'parse-job names the composition' 'Composition Job:' $result.Output
-Assert-Contains 'parse-job reports spec mode' 'spec (parcel set is exactly the declared spec)' $result.Output
+Assert-Contains 'parse-job reports Custom mode' 'custom (compose exactly the declared placements)' $result.Output
 Assert-Contains 'parse-job reports the member count' 'Members (3 total, 1 built' $result.Output
 Assert-Contains 'parse-job reports the inline definition' 'Inline definition: ProductionMirror' $result.Output
 
@@ -146,6 +146,12 @@ Assert-Contains 'validate-job warns on duplicate groups' 'declared more than onc
 Assert-Contains 'validate-job warns on the legacy spelling' 'pre-release spelling' $result.Output
 Assert-Contains 'validate-job rejects an inline WebDAV definition' "WebDAV ('http') action" $result.Output
 
+# No <MergeSettings> at all is Automatic mode, not an omission.
+$result = Invoke-Tool -Tool 'parse-job.py' -Arguments @('--json', (Join-Path $invalid 'no-destination.wacj'))
+$json = $result.Output | ConvertFrom-Json
+Assert-Equal 'parse-job reports Automatic mode' 'automatic' $json.mode
+Assert-Equal 'parse-job reports no MergeSettings' $false $json.mergeSettings.present
+
 $result = Invoke-Tool -Tool 'validate-job.py' -Arguments @((Join-Path $invalid 'no-destination.wacj'))
 Assert-Equal 'validate-job rejects a composition with no destination' 3 $result.ExitCode
 Assert-Contains 'validate-job names the missing destination' 'Missing <Destination' $result.Output
@@ -180,6 +186,23 @@ try {
 
     $result = Invoke-Tool -Tool 'validate-job.py' -Arguments @((Join-Path $temp 'from-template.wacj'))
     Assert-Equal 'the generated .wacj validates' 0 $result.ExitCode
+
+    # discover="true" is Custom mode with "Also include newly published
+    # parcels not listed above" checked.
+    $template = (Invoke-Tool -Tool 'create-job.py' -Arguments @('--template', '--composition')).Output | ConvertFrom-Json
+    $template.mergeSettings.discover = $true
+    Set-Content -LiteralPath (Join-Path $temp 'include-new.json') `
+        -Value ($template | ConvertTo-Json -Depth 10) -Encoding UTF8
+
+    $result = Invoke-Tool -Tool 'create-job.py' `
+        -Arguments @('--config', 'include-new.json', '--output', 'include-new.wacj', '-y') `
+        -WorkingDirectory $temp
+    Assert-Equal 'create-job generates the include-new variant' 0 $result.ExitCode
+    Assert-Contains 'create-job emits discover="true"' 'discover="true"' `
+        (Get-Content -LiteralPath (Join-Path $temp 'include-new.wacj') -Raw)
+
+    $json = (Invoke-Tool -Tool 'parse-job.py' -Arguments @('--json', (Join-Path $temp 'include-new.wacj'))).Output | ConvertFrom-Json
+    Assert-Equal 'parse-job reports the include-new mode' 'custom+include-new' $json.mode
 
     # Round trip: parse --config -> create-job -> parse --json must be identical
     # apart from the resolved member paths, which follow the file's location.

--- a/plugins/webworks-agent-skills/skills/automap/tests/test-wrapper-args.ps1
+++ b/plugins/webworks-agent-skills/skills/automap/tests/test-wrapper-args.ps1
@@ -117,6 +117,19 @@ $r = Invoke-Wrapper @('-ExePath', $stub, '--', '-t', 'Target A', '-d', (Join-Pat
 Assert 'deploy intent: no -n injected' (-not ($r.StubArgs -match '(^| )-n( |$)')) $r.StubArgs
 Assert 'deploy intent: --skip-reports still injected' ($r.StubArgs -match '--skip-reports') $r.StubArgs
 
+# --destination redirects the deploy; -n would suppress the deploy asked for.
+$r = Invoke-Wrapper @('-ExePath', $stub, '--', '-t', 'Target A', '--destination', 'ProductionMirror', $project)
+Assert 'deploy intent (--destination): no -n injected' (-not ($r.StubArgs -match '(^| )-n( |$)')) $r.StubArgs
+Assert 'deploy intent (--destination): --skip-reports still injected' ($r.StubArgs -match '--skip-reports') $r.StubArgs
+
+$r = Invoke-Wrapper @('-ExePath', $stub, '--', '-t', 'Target A', '--destination=ProductionMirror', $project)
+Assert 'deploy intent (--destination=): no -n injected' (-not ($r.StubArgs -match '(^| )-n( |$)')) $r.StubArgs
+
+# --dryrun rehearses the deploy; -n would leave nothing to rehearse.
+$r = Invoke-Wrapper @('-ExePath', $stub, '--', '-t', 'Target A', '--dryrun', $project)
+Assert 'deploy intent (--dryrun): no -n injected' (-not ($r.StubArgs -match '(^| )-n( |$)')) $r.StubArgs
+Assert 'deploy intent (--dryrun): --skip-reports still injected' ($r.StubArgs -match '--skip-reports') $r.StubArgs
+
 # 4. -NoDefaults: verbatim pass-through, no injection, no target requirement.
 $r = Invoke-Wrapper @('-ExePath', $stub, '-NoDefaults', '--', $project)
 Assert '-NoDefaults: exit 0' ($r.ExitCode -eq 0) $r.Output
@@ -177,8 +190,8 @@ Assert 'wacj -NoDefaults: no info line' (-not ($r.Output -match '\[INFO\] Compos
 $compositionLog = Join-Path $work 'Sample Composition-log.txt'
 Set-Content -LiteralPath $compositionLog -Encoding Ascii -Value @'
 Composition job 'Sample Composition' started.
-[Warning] parcel 'Extra' has no descriptor; omitted.
-[Error] Destination 'Mirror' is not defined in deploy.prefs, the --deploysettings overlay, or inline in the composition job.
+[WARN] parcel 'Extra' has no descriptor; omitted.
+[ERROR] Destination 'Mirror' is not defined in deploy.prefs, the --deploysettings overlay, or inline in the composition job.
 '@
 $r = Invoke-Wrapper @('-ExePath', $stub, '--', $composition)
 Assert 'wacj log scan: counts reported' ($r.Output -match '\[ERROR\] 1 warning\(s\), 1 error\(s\) in Sample Composition-log\.txt') $r.Output

--- a/plugins/webworks-agent-skills/skills/epublisher/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/SKILL.md
@@ -75,9 +75,26 @@ ePublisher resolves files through a 4-level hierarchy (highest to lowest priorit
 
 A **Stationery** (`.wxsp`) is a standalone, distributable project that bundles its format configuration *and* `<format>.base` snapshots, so its transforms resolve from those bundled snapshots. AutoMap jobs (`.waj`) traditionally reference a `.wxsp` and stage a fresh project from it on each build.
 
-A Designer `.wep` carries **no** `<format>.base` snapshots, so its transforms resolve from the Designer installation (resolver level 4) instead. Because of that, AutoMap can use a `.wep` *directly* as a stationery via `useAsStationery="True"` on the job's `<Project>` element (ePublisher 2026.1+), skipping the manual "Save As Stationery" step. (Express `.wrp` projects, by contrast, *do* carry their own `.base` snapshots — see `references/file-resolver-guide.md`.) The synchronization engine is extension-agnostic: it can stage and synchronize against a `.wxsp`, `.wep`, or `.wrp` origin.
+A Designer `.wep` carries **no** `<format>.base` snapshots, so its transforms resolve from the Designer installation (resolver level 4) instead. Because of that, AutoMap can use a `.wep` *directly* as a stationery via `useAsStationery="True"` on the job's `<Project>` element (ePublisher 2026.1+), skipping the manual "Save As Stationery" step. The synchronization engine is extension-agnostic: it can stage and synchronize against a `.wxsp`, `.wep`, or `.wrp` origin.
 
-**For job-file usage of `useAsStationery`, see the automap skill's `references/job-file-guide.md`.**
+Whether a project carries `.base` snapshots follows the **origin it was staged from**, not its own extension: a `.wrp` staged from a `.wxsp` bundles them, a `.wrp` staged from a `.wep` does not. See `references/file-resolver-guide.md`.
+
+Opening a standalone `.wxsp` is not a project-open operation. As of 2026.1, double-clicking one, passing it on the command line, or selecting it in **File > Open** starts the New Project from Stationery flow with that Stationery pre-selected, in both Designer and Express.
+
+**For job-file usage of `useAsStationery`, see the automap skill's `references/job-file-guide.md`. For `<Origin>` and synchronization semantics, see `references/project-parsing-guide.md`.**
+
+### Designer and Express Project Types (2026.1)
+
+`.wep` and `.wrp` share one file format. The difference is **origin, not product**: a `.wep` holds a design of its own, while a `.wrp` carries an `<Origin>` and imports its design from there.
+
+As of ePublisher 2026.1 the products no longer partition the project types. Designer opens, builds, synchronizes, and deploys `.wrp` projects, presenting the Express experience in that window — Document Manager, the synchronization prompt, no Style Designer, no Preview — and listing `.wep` and `.wrp` together under one **ePublisher Project Files** entry in its Open dialog. Designer also gains:
+
+- **File > New Project from Stationery...** — creates a `.wrp` from a `.wxsp` *or* a `.wep`. It is a separate command because Designer's **New Project** creates a Stationery *design* project.
+- **File > Save as Express Project...** — creates a `.wrp` linked back to the current `.wep`, giving a master/satellite arrangement (one design seat, any number of linked projects that pick up changes through the synchronization prompt).
+
+Design authoring stays exclusive to Designer: Style Designer, the Preview window, Stationery design projects, Save as Stationery, and Save as Express Project.
+
+Do not assert the pre-2026.1 split — "`.wrp` can only be opened in Express", "Designer cannot create a project from Stationery", "only Express synchronizes" are all false as of 2026.1, and all true before it. Check the version before recommending any of this; see `references/version-compatibility.md`.
 
 ### Deploy Destinations and Deploy Scope (new in 2026.1)
 
@@ -168,7 +185,7 @@ Returns JSON with versionRoot path, component directories, and availability flag
 - `format-traits-guide.md` - Trait types, reading/writing in project files, accessing in XSL, global vs per-target scope, Golden Test recipe, Diffable HTML Output recipe
 - `FormatTraitInfoStrings.resx` - Complete UI display name to internal name mapping (English)
 - `product-foundations.md` - Cross-cutting product knowledge (architecture, platform constraints, debugging)
-- `project-parsing-guide.md` - Detailed project file structure
+- `project-parsing-guide.md` - Detailed project file structure, `<Origin>` and synchronization semantics, Save as Express Project
 - `publish-pipeline-guide.md` - Pipeline architecture (`format.wwfmt`), stage execution, `files.info` tracking, data flow
 - `user-interaction-patterns.md` - Disambiguating user intent (query vs. creation)
 - `version-compatibility.md` - Supported versions and breaking changes
@@ -218,7 +235,7 @@ For platform-level gotchas (.wez files, XSLT 1.0 constraint, UI name mapping), s
 **Solutions:**
 1. Verify file is a valid .wep/.wrp/.wxsp file
 2. Check if project was created in a compatible ePublisher version
-3. Open project in ePublisher Designer (`.wep`) or Express (`.wrp`) to verify structure
+3. Open the project in ePublisher Designer or Express to verify structure — as of 2026.1 Designer opens both `.wep` and `.wrp`
 
 ### "Project file not found"
 

--- a/plugins/webworks-agent-skills/skills/epublisher/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/SKILL.md
@@ -81,7 +81,7 @@ A Designer `.wep` carries **no** `<format>.base` snapshots, so its transforms re
 
 ### Deploy Destinations and Deploy Scope (new in 2026.1)
 
-Output destinations (Target Settings **Deploy to** / Edit > **Deploy Destinations**) are machine-global named definitions shared across projects. As of ePublisher 2026.1: destinations can be **Folder** or **Amazon S3** (bucket/region/named credential profile/CloudFront distribution — no stored secrets; dry run supported); each target also declares a **Deploy** scope — Everything (complete site), Groups (content only), or Shell (site files only) — which powers federated parcel composition in WebWorks Reverb 2.0 (the field is disabled for formats without the capability). Deployments never delete outside their own scope slice, and Clean remains AutoMap-only. For the federation workflow, `.wacj` composition jobs, and inline destination definitions, see the automap skill's `references/composition-jobs.md`; for version gating, `references/version-compatibility.md`.
+Output destinations (Target Settings **Deploy to** / Edit > **Deploy Destinations**) are named definitions stored per user, per machine (`deploy.prefs`) and shared across projects and across Designer, Express, and AutoMap. As of ePublisher 2026.1: destinations can be **Folder** or **Amazon S3** (bucket/region/named credential profile/CloudFront distribution — no stored secrets; dry run supported); each target also declares a **Deploy** scope — Everything (complete site), Groups (content only), or Shell (site files only) — which powers federated parcel composition in WebWorks Reverb 2.0 (the field is disabled for formats without the capability). Deployments never delete outside their own scope slice, and Clean remains AutoMap-only. For the federation workflow, `.wacj` composition jobs, and inline destination definitions, see the automap skill's `references/composition-jobs.md`; for version gating, `references/version-compatibility.md`.
 
 ### Project File Format
 
@@ -218,7 +218,7 @@ For platform-level gotchas (.wez files, XSLT 1.0 constraint, UI name mapping), s
 **Solutions:**
 1. Verify file is a valid .wep/.wrp/.wxsp file
 2. Check if project was created in a compatible ePublisher version
-3. Open project in ePublisher Administrator to verify structure
+3. Open project in ePublisher Designer (`.wep`) or Express (`.wrp`) to verify structure
 
 ### "Project file not found"
 
@@ -235,7 +235,7 @@ For platform-level gotchas (.wez files, XSLT 1.0 constraint, UI name mapping), s
 
 **Solutions:**
 1. Use .wep (WebWorks ePublisher Project)
-2. Use .wrp (WebWorks ePublisher Report Project)
+2. Use .wrp (WebWorks ePublisher Express Project)
 3. Use .wxsp (WebWorks ePublisher Stationery Project)
 
 </troubleshooting>

--- a/plugins/webworks-agent-skills/skills/epublisher/references/file-resolver-guide.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/references/file-resolver-guide.md
@@ -10,17 +10,38 @@ An ePublisher project follows this standard organization:
 
 ```
 your-project/
-├── your-project.wep          # Project file (.wep=Designer, .wrp=Express, .wxsp=Stationery)
+├── your-project.wep          # Project file — .wep, .wrp, or .wxsp (see below)
 ├── Source/                   # Source documents (optional, can reside anywhere)
 │   └── docs/
 ├── Targets/                  # Target-specific overrides
 │   └── [TargetName]/
 ├── Formats/                  # Format-level overrides
 │   ├── WebWorks Reverb 2.0/
-│   └── WebWorks Reverb 2.0.base/  # .wrp and .wxsp projects only
+│   └── WebWorks Reverb 2.0.base/  # only when the project was staged from a .wxsp origin
 └── Output/                   # Generated output
     └── [TargetName]/
 ```
+
+### Project File Extensions
+
+The extension records which product **authors** the project, not which product can open it:
+
+| Extension | Authored by | Opened by |
+|-----------|-------------|-----------|
+| `.wep` | ePublisher Designer | Designer |
+| `.wrp` | ePublisher Express | Express; Designer as of 2026.1 |
+| `.wxsp` | Save as Stationery, from either product | Neither opens it as a project — see below |
+
+As of ePublisher 2026.1, Designer opens, builds, synchronizes, and deploys `.wrp` projects. Designer's **Open** dialog lists `.wep` and `.wrp` together under a single **ePublisher Project Files** entry, and a `.wrp` opened there keeps the Express experience for that window: Document Manager, the stationery synchronization prompt, no Style Designer and no Preview window. A `.wrp` therefore does **not** imply that Express is installed or required. What stays exclusive to Designer is the design work itself — Style Designer, the Preview window, Stationery design projects, **Save as Stationery**, and **Save as Express Project**.
+
+Designer also creates `.wrp` projects directly:
+
+- **File > New Project from Stationery...** — builds a `.wrp` from a `.wxsp` *or* a `.wep`. In Designer this is a separate command because **New Project** there creates a Stationery *design* project.
+- **File > Save as Express Project...** — creates a `.wrp` linked back to the current `.wep`. See "Origin and Synchronization" in `project-parsing-guide.md`.
+
+Also as of 2026.1, opening a standalone Stationery (`.wxsp`) by double-click, command line, or **File > Open** starts the New Project from Stationery flow with that Stationery pre-selected, in both products. Stationery has template semantics, not project semantics — there is no "open a `.wxsp` as a project" operation.
+
+**Do not use the extension to predict `.base` presence.** Whether a project carries Level 3 `.base` snapshots depends on the origin it was staged from, not on its own extension — see Level 3 below.
 
 ## The Four-Level Override Hierarchy
 
@@ -70,7 +91,7 @@ C:\projects\my-proj\Formats\WebWorks Reverb 2.0\Pages\sass\_colors.scss
 - Shared branding or styling across multiple outputs
 - Common functionality needed by all targets
 
-### Level 3: Packaged Installation Defaults (Isolates Project from installation changes when using ePublisher Express)
+### Level 3: Packaged Installation Defaults (Isolates the Project from Installation Changes)
 
 **Location:** `[Project]\Formats\[FormatName].base\[format-structure]\`
 
@@ -87,7 +108,14 @@ C:\projects\my-proj\Formats\WebWorks Reverb 2.0.base\Pages\Connect.asp
 C:\projects\my-proj\Formats\WebWorks Reverb 2.0.base\Pages\sass\_colors.scss
 ```
 
-**Note — using a `.wep` as a stationery:** A Designer `.wep` project carries **no** `.base` snapshots, so it has no Level 3 and resolves straight from the Designer installation (Level 4). That is exactly what makes a `.wep` usable directly as a stationery by an AutoMap job (`<Project ... useAsStationery="True">`, ePublisher 2026.1+). A standalone Stationery (`.wxsp`) — and an Express `.wrp` — instead bundle `.base` at this level. See the automap skill's `references/job-file-guide.md`.
+**Note — `.base` presence follows the origin, not the file extension.** Level 3 exists only when the project was staged from an origin that itself carried `.base` snapshots:
+
+| Origin the project was staged from | Level 3 present | Consequence |
+|------------------------------------|-----------------|-------------|
+| Standalone Stationery (`.wxsp`) | Yes | Self-contained — resolves without reaching the origin, and tolerates a differing installed format library |
+| A live `.wep`/`.wrp` used as stationery | No | Resolves straight from the installation (Level 4) — the origin and a compatible installed format library must stay reachable |
+
+A Designer `.wep` carries no `.base` snapshots of its own. That is exactly what makes it usable directly as a stationery by an AutoMap job (`<Project ... useAsStationery="True">`, ePublisher 2026.1+) and by Designer's **Save as Express Project...**. So an Express `.wrp` created from a `.wxsp` does bundle `.base`, while a `.wrp` created from a `.wep` origin does not — the extension alone does not tell you. See "Origin and Synchronization" in `project-parsing-guide.md` and the automap skill's `references/job-file-guide.md`.
 
 ### Level 4: Installation Defaults (Lowest Priority / Fallback)
 
@@ -117,7 +145,7 @@ When ePublisher needs a file (e.g., `Pages\Connect.asp`), it searches in this or
 
 1. Check target-specific location: `Targets\[TargetName]\Pages\Connect.asp`
 2. If not found, check format-level: `Formats\[FormatName]\Pages\Connect.asp`
-3. If not found, check format-base-level (Express project): `Formats\[FormatName].base\Pages\Connect.asp`
+3. If not found, check format-base-level (only when the project carries `.base` snapshots): `Formats\[FormatName].base\Pages\Connect.asp`
 4. If still not found, use installation default: `[Install]\Formats\[FormatName]\Pages\Connect.asp`
 
 **The first file found wins** - ePublisher stops searching once a match is found.

--- a/plugins/webworks-agent-skills/skills/epublisher/references/file-resolver-guide.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/references/file-resolver-guide.md
@@ -473,7 +473,7 @@ Four decisions matter, in order: which override level to copy to, what to do wit
 
    The `wwpage:attribute-src` attribute on the `<img>` tells ePublisher to copy the file into the output and rewrite the `src` path automatically. **For the full mechanism — syntax, variant table, `Files/` contrast, file-based vs setting-based resolvers — see `### Copying Custom Assets in ASP Templates` under `## Advanced Topics`** in this file. Workflow 4 does not duplicate that content.
 
-   Variant choice: branding images that should match the rebuild cycle use `copy-relative-to-output-root`; scripts and assets that need cache-busting use `copy-relative-to-output-root-with-generation-hash` (the base install uses the hashed variant for the script and splash-image references in `Connect.asp`, `Page.asp`, and `Splash.asp`).
+   Variant choice: branding images that should match the rebuild cycle use `copy-relative-to-output-root`; scripts and assets that need cache-busting use `copy-relative-to-output-root-with-generation-hash` (the base install uses the hashed variant for the script and asset references in `Connect.asp`, `Page.asp`, and `Splash.asp`).
 
 4. **Add new structural CSS in `_custom-skin.scss`, not the copied `skin.scss`.**
 
@@ -533,6 +533,8 @@ Four decisions matter, in order: which override level to copy to, what to do wit
 `logo-text.png` and `logo-art.png` live in `Formats/WebWorks Reverb 2.0/Pages/images/`. The wrapper rules for `.ww_skin_header_logo_left` and `.ww_skin_header_logo_right` live in `Formats/WebWorks Reverb 2.0/Pages/sass/_custom-skin.scss`. Every `.ww_skin_header_logo_container` from the base template is preserved, so variable-driven padding and sizing from `skin.scss` continue to apply.
 
 **Note on naming:** Project-specific examples sometimes use a different SCSS partial (e.g., `_custom.scss`) or a project prefix (e.g., `$rad_*`). The skill convention is `_custom-skin.scss` for chrome selectors and `_custom-webworks.scss` for content-page styles, with the `$theme_` prefix for custom variables. Map any project-specific naming onto these conventions when working from the skill so future customizers find the same partials and prefixes.
+
+**Reverb 2.0 on ePublisher 2026.1+ — `custom.scss` is the newer seam.** The `_custom-skin.scss` / `_custom-webworks.scss` pair documented in Workflow 3 above still works and is **not** deprecated; on pre-2026.1 builds it is the only option. From 2026.1, WebWorks Reverb 2.0 also ships a stock `Pages/sass/custom.scss` that compiles to `css/custom.css` and is already linked **last** on every page template (`Connect.asp`, `Page.asp`, `Splash.asp`, `NotFound.asp`, `Popup.asp`, `Search.asp`). Customizing it means copying one file into `Targets/[Target]/Pages/sass/` or `Formats/WebWorks Reverb 2.0/Pages/sass/` — no entry point to copy, no `@import` hook to add, and no import line to re-apply at upgrade time. The trade-off is cascade depth: `custom.css` loads after **both** `webworks.css` and `skin.css`, so it reaches chrome and content alike and unscoped selectors bleed across the boundary the two-partial split enforces. Prefer `custom.scss` on 2026.1+ Reverb 2.0; keep the partial pair for earlier builds, for projects that already wire it, and for rules that must stay inside one sheet's cascade depth. Full comparison: `../reverb2/references/scss-architecture.md` § "The `custom.scss` Layer".
 
 ## File Types and Locations
 

--- a/plugins/webworks-agent-skills/skills/epublisher/references/format-traits-guide.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/references/format-traits-guide.md
@@ -384,6 +384,13 @@ Keep the `{WWDefaultRule}` row even when every named heading is enumerated — i
 
 The prototype rule is necessary but not sufficient: it covers styles that have **no** explicit `split-priority`, and the per-rule overrides cover styles that **do**. Together they guarantee the value across the target.
 
+**Doing this in the UI (2026.1).** Style Designer's style list supports multi-select — Ctrl-click and Shift-click within a style category — and an edit made on the **Properties**, **Options**, **Target Properties**, or **Target Options** tab applies to every selected style. The per-rule half of the pattern above becomes one edit instead of one per heading. Two behaviors matter when reading the grid:
+
+- Values that disagree across the selection display **blank**, not the first style's value. A blank cell means "these styles differ here", not "unset".
+- `[Prototype]` (`{WWDefaultRule}`) is dropped from a *multiple* selection — editing it applies to every style in the category, which is never what a bulk edit means. Set the prototype in its own single selection first, then multi-select the downstream styles that already declare the same Option.
+
+Before 2026.1 the list is single-select only, so each style must be edited separately.
+
 ---
 
 **Version**: 1.0.0

--- a/plugins/webworks-agent-skills/skills/epublisher/references/project-parsing-guide.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/references/project-parsing-guide.md
@@ -5,6 +5,7 @@ Comprehensive guide to parsing ePublisher project files (`.wep`, `.wrp`, `.wxsp`
 ## Table of Contents
 
 - [Project File Structure](#project-file-structure)
+- [Origin and Synchronization](#origin-and-synchronization)
 - [Parsing Targets and Formats](#parsing-targets-and-formats)
 - [Managing Source Documents](#managing-source-documents)
 - [Common Parsing Operations](#common-parsing-operations)
@@ -18,9 +19,13 @@ ePublisher project files are XML documents with this high-level structure:
 <?xml version="1.0" encoding="utf-8"?>
 <Project Version="1.1.2.0"
          ProjectID="..."
+         ChangeID="..."
          RuntimeVersion="2024.1"
          FormatVersion="{Current}"
          xmlns="urn:WebWorks-Publish-Project">
+  <Origin>
+    <!-- Only in a project linked to a Stationery or to another project -->
+  </Origin>
   <Formats>
     <!-- Target and format configurations -->
   </Formats>
@@ -36,7 +41,88 @@ ePublisher project files are XML documents with this high-level structure:
 </Project>
 ```
 
+`<Origin>` is serialized first, ahead of `<Formats>` — see [Origin and Synchronization](#origin-and-synchronization).
+
+Saving as Stationery strips `ChangeID`, `<Origin>`, and `<Groups>` (along with the `ProjectID` and the project settings). That strip is what makes a design project usable as a stationery.
+
 For per-style trait configuration inside `<GlobalConfiguration>` or `<FormatConfiguration>`, including the `{WWDefaultRule}` prototype literal and the global-vs-per-target scope distinction, see [`format-traits-guide.md`](./format-traits-guide.md).
+
+## Origin and Synchronization
+
+A project created from a Stationery — or, as of ePublisher 2026.1, from another project — records where it came from in an `<Origin>` element. A design project authored directly in Designer has no `<Origin>`. The distinction between the two project types is **origin, not product**: `.wep` and `.wrp` use the same file format, and as of 2026.1 Designer opens both.
+
+### The `<Origin>` element
+
+```xml
+<Origin>
+  <Path Checksum="9f2a1c4e7b8d05364af1e2b9c7d84a05"
+        LastModified="2026-07-14T18:22:31Z">..\Stationery\Corporate.wxsp</Path>
+</Origin>
+```
+
+| Part | Meaning |
+|------|---------|
+| `<Path>` text | Path to the origin file, persisted relative to the project file. Absolute paths are accepted; a root-relative path (`\Stationery\Corporate.wxsp`) resolves against the project's own drive. |
+| `Checksum` | MD5 of the origin file as it stood when the project was last created from or synchronized with it |
+| `LastModified` | UTC last-write time of the origin at that same moment |
+
+The origin may be a `.wxsp`, a `.wep`, or a `.wrp`. The element shape and the comparison below are identical in all three cases.
+
+### When the synchronization prompt appears
+
+A linked project is treated as out of date when any of these is true:
+
+1. No origin is recorded
+2. The recorded origin file no longer exists
+3. The origin's last-write time is more than four hours away from the recorded `LastModified`, **or** its MD5 no longer matches `Checksum` (both must agree for the project to count as current)
+4. The origin's `stationery.manifest` differs from the copy cached in the project directory
+
+The check runs when a `.wrp` window opens — in Express, and in Designer as of 2026.1 — and before an AutoMap build. `.wep` design-project windows never run it: synchronization is a property of the project, not of the product it is opened in.
+
+Synchronizing copies from the origin: output formats, output targets and their settings, styles, conditions, variables, and cross-reference definitions. It **overwrites** target-setting customizations made locally in the linked project.
+
+**Not synchronized** — these are local to the project and survive every synchronization:
+
+- Merge Settings
+- Document Manager contents (groups and source documents)
+- Preferences
+
+Manual synchronization is **File > Synchronize with Stationery**. Its browse dialog accepts a `.wep` or `.wrp` as well as a `.wxsp`, so a linked project can be repointed at a different origin.
+
+### Choosing an origin type
+
+| Origin | `.base` snapshots in the linked project | Trade-off |
+|--------|------------------------------------------|-----------|
+| `.wxsp` Stationery | Yes | Self-contained. Building never needs the origin, and the project tolerates a differing installed format library. Use when the design must be *distributed* — to another site, a customer, or anyone who will not have the design project on hand. |
+| `.wep` / `.wrp` project | No | The origin must stay reachable to synchronize, and transforms resolve from the installation (resolver level 4), so origin and linked project need compatible installed format libraries. In exchange the linked project tracks the live design instead of a redistributed snapshot. |
+
+See `file-resolver-guide.md` for the resolver levels themselves.
+
+### Save as Express Project
+
+**File > Save as Express Project...** (Designer, 2026.1) creates a `.wrp` whose `<Origin>` points at the current `.wep`, without publishing Stationery. Designer saves the design project first, so an unsaved edit is not read as a change to synchronize the first time the new project opens. The new project gets its own directory: `<location>\<name>\<name>.wrp`.
+
+The command sits directly below **Save as Stationery** and applies to design projects only — it is disabled (not hidden) in an Express project window, including a `.wrp` hosted in Designer.
+
+This produces a master/satellite topology: one seat owns the master `.wep` and is the only seat that needs Style Designer; every other seat works in a linked satellite `.wrp` with its own source documents and output, picking up design changes through the ordinary synchronization prompt. Satellites can be opened in either product. There is no reverse sync — satellite changes never flow back.
+
+The satellite receives the design: output formats, output targets and their settings, styles, conditions, variables, cross-reference definitions, and the user, output-format, and format-target override files. It does not receive the design project's identity, so it is a project in its own right rather than a copy.
+
+**Include source documents, groups, and Merge Settings** (checkbox, cleared by default):
+
+| State | Result |
+|-------|--------|
+| Cleared (default) | Hollow shell — the satellite starts with no groups or documents, and the recipient adds their own |
+| Selected | Groups, documents, and Merge Settings are carried over |
+
+When it is selected:
+
+- **Group identities are preserved**, so Merge Settings that place those groups keep resolving in the satellite.
+- **Documents get fresh identities.** Do not expect `DocumentID` values to match between master and satellite.
+- **Document paths are re-relativized** to the satellite's directory — documents are copied holding the master's resolved absolute paths, then persisted relative to the new project location.
+- **Deprecated document-level style overrides are never carried**, in either state. Designer reports when it dropped some.
+
+Because the origin is a live project rather than a published artifact, satellites synchronize against whatever state was last *saved*. Keep the master on a shared path and treat saves as releases; **Save as Stationery** remains the formal publish gate.
 
 ## Parsing Targets and Formats
 
@@ -677,6 +763,6 @@ $ bash scripts/manage-sources.sh --validate project.wep
 
 ---
 
-**Version**: 1.0.0
-**Last Updated**: 2026-06-12
-**Target**: ePublisher 2024.1+ project files
+**Version**: 1.1.0
+**Last Updated**: 2026-08-01
+**Target**: ePublisher 2024.1+ project files (Origin and Synchronization covers 2026.1 behavior)

--- a/plugins/webworks-agent-skills/skills/epublisher/references/version-compatibility.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/references/version-compatibility.md
@@ -4,8 +4,10 @@
 
 | Component | Minimum | Recommended | Notes |
 |-----------|---------|-------------|-------|
-| ePublisher | 2020.2 | 2024.1+ | Primary development target |
-| AutoMap | 2020.2 | 2024.1+ | Required for automation |
+| ePublisher | 2020.2 | 2026.1 | Primary development target |
+| AutoMap | 2020.2 | 2026.1 | Required for automation |
+| Designer for `.wrp` projects | 2026.1 | 2026.1 | Before 2026.1, opening a `.wrp` requires ePublisher Express |
+| `.wep`-origin (`.base`-less) projects | 2026.1 | 2026.1 | Origin and a compatible installed format library must stay reachable |
 | Reverb Format | 2.0 | 2.0 | Only Reverb 2.0 supported |
 | Chrome | 90+ | Latest | For browser testing |
 | Node.js | 16+ | 18+ | For Puppeteer scripts |
@@ -19,7 +21,12 @@
 - Amazon S3 + CloudFront deploy destinations (named profile/role credentials, deploy-time invalidation, dry run; global `--dryrun`)
 - Inline destination definitions in `.waj`/`.wacj` (`<DeploySettings>`) and the `--deploysettings` overlay file
 - A failed deploy is an error (reaches the exit status); earlier versions warned and exited 0
-- See the automap skill's `references/composition-jobs.md` before recommending any of these — never suggest them to users on 2025.1 or earlier
+- Designer opens, builds, synchronizes, and deploys Express `.wrp` projects, presenting the Express window experience (Document Manager, synchronization prompt, no Style Designer, no Preview). Its Open dialog offers `.wep` and `.wrp` under one **ePublisher Project Files** entry. Double-clicking a `.wrp` opens Express when installed, Designer otherwise
+- Designer **File > New Project from Stationery...** — creates a `.wrp` from a `.wxsp` *or* a `.wep`
+- Designer **File > Save as Express Project...** — creates a `.wrp` linked to the current `.wep` via `<Origin>`, for a master/satellite arrangement; the "Include source documents, groups, and Merge Settings" option is off by default
+- Opening a standalone `.wxsp` (double-click, command line, File > Open) starts New Project from Stationery with it pre-selected, in both products. Earlier versions raise an unhandled error
+- Style Designer supports multi-select (Ctrl/Shift-click) for bulk style edits; values disagreeing across the selection display blank, and `[Prototype]` is excluded from a multiple selection
+- See the automap skill's `references/composition-jobs.md` before recommending any of the AutoMap and deploy items, and this skill's `project-parsing-guide.md` ("Origin and Synchronization") for the Designer/Express items — never suggest them to users on 2025.1 or earlier
 
 ### ePublisher 2024.1
 - New AutoMap CLI executable name

--- a/plugins/webworks-agent-skills/skills/reverb2/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/SKILL.md
@@ -4,9 +4,10 @@ description: >
   AUTHORITATIVE REFERENCE for WebWorks Reverb 2.0 output. Use when testing
   Reverb output in browser, statically linting output for structural breakage
   (self-closed elements, manifest/parcel GroupID consistency), analyzing CSH
-  links, customizing SCSS themes, inspecting url_maps.xml, generating test
-  reports, or (2026.1+) inspecting federated/composed sites and their
-  wwcomposition descriptors.
+  links, customizing SCSS themes (including the 2026.1 `custom.scss` layer),
+  inspecting url_maps.xml, generating test reports, or (2026.1+) inspecting
+  federated/composed sites and their wwcomposition descriptors, the splash
+  Groups Grid, or the Assistant avatar.
 ---
 
 <objective>
@@ -46,7 +47,16 @@ When investigating a runtime issue — a theme override that didn't apply, a bro
 
 **Detailed SCSS guidance:** `## SCSS Customization` (below) and `references/scss-architecture.md`.
 
-**Federated parcel composition (new in 2026.1):** a Reverb site can be assembled from independently built parcels under a shared shell. Builds emit `wwcomposition*` descriptor files (inert in standalone sites), shells legitimately have an empty `#parcels` tree, and a composed mirror mixes GroupIDs and generation hashes from different builds — all of which changes what linting and browser testing should expect. See `references/federation-architecture.md` before flagging any of those as breakage.
+**Some chrome is built at runtime, not published (2026.1).** Two surfaces have no markup in the `.asp` at all — the template ships an empty container and JavaScript fills it:
+
+| Surface | Container in the template | Built by |
+|---------|---------------------------|----------|
+| Splash **Groups Grid** (EPUB2907) | `Splash.asp` → `<nav id="splash_groups" class="ww_skin_splash_groups">` | `connect.js` collects card data from the master TOC → `page.js` builds the DOM |
+| Assistant **avatar** (EPUB2911) | — (every assistant slot) | `assistant.js` `Assistant_RenderAvatar` |
+
+Reading the template or grepping the published HTML for the card markup finds nothing; read the JavaScript instead. `splash.png` is **no longer referenced by any template** — a project that overrode it must now override `Splash.asp`. Full treatment, including the `$splash_groups_*` variables and the `ww_skin_*` hooks: `references/runtime-rendered-ui.md`.
+
+**Federated parcel composition (new in 2026.1):** a Reverb site can be assembled from independently built parcels under a shared shell. Builds emit `wwcomposition*` descriptor files (inert in standalone sites), shells legitimately have an empty `#parcels` tree, and a composed mirror mixes GroupIDs and generation hashes from different builds — all of which changes what linting and browser testing should expect. Where each parcel lands in the composed TOC follows a three-rung ladder (composition Merge Settings → the parcel's own declared containers → discovery order), and every placement problem degrades to top-level placement rather than failing the compose. See `references/federation-architecture.md` before flagging any of those as breakage.
 </runtime_architecture>
 
 <related_skills>
@@ -101,7 +111,7 @@ When investigating a runtime issue — a theme override that didn't apply, a bro
 
 | Feature | Script | Description |
 |---------|--------|-------------|
-| Output Linting | `lint-output.py` | Static pre-flight (no browser): self-closed non-void elements, manifest↔parcel GroupID consistency, parcel deploy-unit completeness, asset reference integrity. CI-friendly exit codes |
+| Output Linting | `lint-output.py` | Static pre-flight (no browser): self-closed non-void elements, manifest↔parcel GroupID consistency, parcel deploy-unit completeness, asset reference integrity, splash Groups Grid container. CI-friendly exit codes |
 | Browser Testing | `browser-test.js` | Load output in headless Chrome; pass/fail on the `preload` load signal (`--vanilla` for no-bypass file:// mode) |
 | CSH Analysis | `parse-url-maps.py` | Extract topic mappings from url_maps.xml |
 | SCSS Theming | `extract-scss-variables.py` | Read current theme values |
@@ -133,9 +143,10 @@ python scripts/lint-output.py <output-dir> [--json] [--strict] [--no-color]
 | Check | Severity | What it catches |
 |-------|----------|-----------------|
 | `self-closed-element` | error | A non-void element in XML self-closing form (`<script/>`, `<iframe/>`, `<div/>`, …). In `text/html` the `/` is ignored, so the element swallows the rest of the document — the first page never renders, with **zero** console errors. (Trac #2792.) Void elements (`<meta/>`, `<link/>`, …) and `<svg>`/`<math>` foreign content are exempt. |
-| `manifest-parcel-groupid` | error | The parcel's own GroupID disagrees with what the `#parcels` manifest binds. `connect.js` reads `id.split(':')[1]` from each anchor `<a id="<ctx>:<GID>" href="<Name>.html">` and looks up `toc:<GID>`/`data:<GID>`/`page:<GID>` inside the fetched parcel; a mismatch means every lookup returns null, the parcel never attaches, and the spinner hangs. Arises when output is assembled from multiple builds (the Reverb-on-S3 deploy-set model). Also flags a `<li id="group:<GID>">`-vs-anchor desync. |
+| `manifest-parcel-groupid` | error | The parcel's own GroupID disagrees with what the `#parcels` manifest binds. `connect.js` reads `id.split(':')[1]` from each anchor `<a id="<ctx>:<GID>" href="<Name>.html">` and looks up `toc:<GID>`/`data:<GID>`/`page:<GID>` inside the fetched parcel; a mismatch means every lookup returns null, the parcel never attaches, and the spinner hangs. Arises when output is assembled from multiple builds. Also flags a `<li id="group:<GID>">`-vs-anchor desync. |
 | `parcel-deploy-unit` | error | A manifest parcel `<Name>` is missing a deploy-unit member: `<Name>.html` and `<Name>/` (always), plus the runtime chunks `<Name>_ix.html`/`<Name>_lx.js`/`<Name>_sx.js`. The required chunk set is version/feature dependent (older builds omit `_lx.js`, search-off builds omit `_sx.js`), so it is read from the build's own `scripts/connect.js`. |
 | `reference-integrity` | warn | A local `scripts/`/`css/` asset referenced by `index.html` (`<script src>`, `<link href>`) is missing on disk. Remote (`http(s)://`, `//`) and `data:` refs are skipped. |
+| `splash-groups-container` | warn | `splash.html` lacks the `id="splash_groups"` container that this build's `page.js` renders the Groups Grid into — the splash comes up empty with no console error. Usually a pre-2026.1 `Splash.asp` override carried through an upgrade (EPUB2907). Skipped when `page.js` has no `splash_groups` lookup, so pre-2026.1 output is never flagged. |
 
 The check set is extensible — add new known-breakage checks to `lint-output.py`
 as they are discovered.
@@ -269,17 +280,20 @@ Format: `json` (default) or `table`
 
 ## SCSS Customization
 
-**Recommended setup (new projects):** Leave the *Skin* target setting unset and customize the Reverb 2.0 format directly — Layer 1 variable overrides plus `_custom-skin.scss` / `_custom-webworks.scss`, applied at the Formats or Targets level. Don't start from a packaged skin (`.weplugin`/Skin); those are deprecated. Full rationale, plus the customer-migration delivery pattern (reference / match / no-skin targets), in `references/scss-architecture.md` § "Recommended Setup for New Projects: No Skin" and § "Migration Delivery Pattern".
+**Recommended setup (new projects):** Leave the *Skin* target setting unset and customize the Reverb 2.0 format directly — Layer 1 variable overrides plus, for structural CSS, `custom.scss` on 2026.1+ (or `_custom-skin.scss` / `_custom-webworks.scss` on earlier builds), applied at the Formats or Targets level. Don't start from a packaged skin (`.weplugin`/Skin); those are deprecated. Full rationale, plus the customer-migration delivery pattern (reference / match / no-skin targets), in `references/scss-architecture.md` § "Recommended Setup for New Projects: No Skin" and § "Migration Delivery Pattern".
 
-### Three-Layer Architecture
+### Theming Layers
 
 | Layer | What it controls | Override file | Entry point |
 |-------|-----------------|---------------|-------------|
-| **1. Variable overrides** | Colors, sizes, fonts, icons, borders | `_colors.scss`, `_sizes.scss`, etc. | Compiled by `skin.scss` and `webworks.scss` |
-| **2. Skin CSS** | Toolbar, TOC, navigation chrome | `_custom-skin.scss` (user-created) | Imported by `skin.scss` |
-| **3. Content page CSS** | Content fonts, links, tables, mini-TOC | `_custom-webworks.scss` (user-created) | Imported by `webworks.scss` |
+| **1. Variable overrides** | Colors, sizes, fonts, icons, borders | `_colors.scss`, `_sizes.scss`, etc. | Compiled by `skin.scss`, `webworks.scss`, `custom.scss` |
+| **2. Custom selectors** *(2026.1+)* | Anything, any page type — chrome and content alike | `custom.scss` (replace the stock file) | Ships pre-wired: `css/custom.css`, linked **last** |
+| **2a. Skin CSS** | Toolbar, TOC, navigation chrome | `_custom-skin.scss` (user-created) | Imported by `skin.scss` |
+| **2b. Content page CSS** | Content fonts, links, tables, mini-TOC | `_custom-webworks.scss` (user-created) | Imported by `webworks.scss` |
 
-Layer 1 is safest (variable values only). Layers 2–3 require copying entry points and adding import hooks — they do **not** ship with custom imports pre-configured.
+Layer 1 is safest (variable values only). Layers 2a–2b require copying entry points and adding import hooks — they do **not** ship with custom imports pre-configured.
+
+**`custom.scss` (EPUB2908, 2026.1+)** is the seam to prefer for structural CSS. The stock `Pages/sass/custom.scss` compiles to `css/custom.css`, which `Connect.asp`, `Page.asp`, `Splash.asp`, `NotFound.asp`, `Popup.asp`, and `Search.asp` all link **last** — so its rules win equal-specificity contests against every stock sheet, on every page type including popups, and `@media print` rules there beat `print.css`. It imports the variable partials (so skin variables are usable) and emits no rules of its own. Customize by copying it into `Targets/<Target>/Pages/sass/` or `Formats/WebWorks Reverb 2.0/Pages/sass/` — the copy replaces it entirely, so keep the `@import` block. No entry point to copy, no import hook, nothing to re-apply at upgrade. The trade-off is that one sheet means one cascade depth: `custom.css` loads after **both** `webworks.css` and `skin.css`, so scope your selectors instead of relying on sheet order. The older two-partial pair still works and is not deprecated — comparison table in `references/scss-architecture.md` § "The `custom.scss` Layer".
 
 ### Partials Inventory
 
@@ -330,7 +344,7 @@ Highest first (file resolver hierarchy):
 3. `[Project]/Formats/WebWorks Reverb 2.0.base/Pages/sass/_colors.scss` — packaged defaults
 4. `[Install]/Formats/WebWorks Reverb 2.0/Pages/sass/_colors.scss` — installation fallback
 
-**Detailed guidance:** `workflows/scss-theming.md` (layer-specific steps), `references/scss-architecture.md` (cascade diagrams, compilation model, strict variable rules), `references/customization-conventions.md` (annotations for non-SCSS overrides, `locales.xml` upgrade).
+**Detailed guidance:** `workflows/scss-theming.md` (layer-specific steps), `references/scss-architecture.md` (cascade diagrams, compilation model, `custom.scss` layer, strict variable rules), `references/runtime-rendered-ui.md` (splash Groups Grid and Assistant avatar — runtime-built DOM, `$splash_groups_*` variables, `ww_skin_*` hooks), `references/customization-conventions.md` (annotations for non-SCSS overrides, `locales.xml` upgrade).
 </scss_customization>
 
 <templates>
@@ -429,9 +443,11 @@ python scripts/extract-scss-variables.py /path/to/project neo
 
 **Do not apply general web development patterns to Reverb.** Reverb 2.0 is a single-page application with its own JavaScript runtime (`Parcels`), navigation model, and SCSS architecture. Standard web debugging assumptions (e.g., "check the network tab for 404s") may not apply. Always consult the format's source files first.
 
-**`.weplugin` skin packages are deprecated.** These are zip archives typically containing `_colors.scss`, sometimes `_sizes.scss`, and occasionally `Connect.asp`. They will be removed in Reverb 3.0. To migrate: rename to `.zip`, extract, diff against installation defaults to identify actual customizations, then copy customized partials to the appropriate override level (`Formats/WebWorks Reverb 2.0/Pages/sass/` or `Targets/[Target]/Pages/sass/`). Use direct SCSS variable overrides with the `$theme_` naming convention instead. For structural CSS beyond variables, create `_custom-skin.scss` (chrome) or `_custom-webworks.scss` (content) — see `references/scss-architecture.md` § "Why Two Custom Partials, Not One". When moving a customer off a *skinned look* (a redesign, not a like-for-like port), follow the reference / match / no-skin delivery pattern in `references/scss-architecture.md` § "Migration Delivery Pattern". For non-SCSS overrides (`locales.xml`, ASP templates), see `references/customization-conventions.md`.
+**`.weplugin` skin packages are deprecated.** These are zip archives typically containing `_colors.scss`, sometimes `_sizes.scss`, and occasionally `Connect.asp`. They will be removed in Reverb 3.0. To migrate: rename to `.zip`, extract, diff against installation defaults to identify actual customizations, then copy customized partials to the appropriate override level (`Formats/WebWorks Reverb 2.0/Pages/sass/` or `Targets/[Target]/Pages/sass/`). Use direct SCSS variable overrides with the `$theme_` naming convention instead. For structural CSS beyond variables, override `custom.scss` on 2026.1+ (see `references/scss-architecture.md` § "The `custom.scss` Layer") or create `_custom-skin.scss` (chrome) / `_custom-webworks.scss` (content) on earlier builds — see § "Why Two Custom Partials, Not One". A packaged skin that ships its own full `connect.scss` also has to carry format-side fixes to that sheet forward by hand (the 2026.1 Assistant avatar rules, for instance) — one more reason not to start from one. When moving a customer off a *skinned look* (a redesign, not a like-for-like port), follow the reference / match / no-skin delivery pattern in `references/scss-architecture.md` § "Migration Delivery Pattern". For non-SCSS overrides (`locales.xml`, ASP templates), see `references/customization-conventions.md`.
 
 **Reverb output is not the format source.** The generated HTML/CSS/JS in the output directory is transformed output. To understand or fix runtime behavior, examine the format source files: `Pages/scripts/*.js` for JavaScript, `Pages/*.asp` for HTML templates, `Pages/sass/*.scss` for styles.
+
+**Some chrome isn't in the template either (2026.1).** The splash Groups Grid and the Assistant avatar are built at runtime by `page.js` / `connect.js` / `assistant.js` into containers the templates ship empty. Reading `Splash.asp` — or grepping the published HTML for card markup — finds nothing and proves nothing. See `references/runtime-rendered-ui.md`.
 
 </common_mistakes>
 

--- a/plugins/webworks-agent-skills/skills/reverb2/references/customization-conventions.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/references/customization-conventions.md
@@ -37,8 +37,22 @@ An upgrade auditor runs one grep per project tag (for example, `grep -r 'DICAD' 
 
 This procedure assumes the customer's `locales.xml` overrides the installed default through the file resolver hierarchy. If `locales.xml` is missing from the project override directory, no upgrade is required — the installed default already applies and will continue to apply after the format upgrade.
 
+## Overrides That Go Inert on 2026.1
+
+An override does not have to break to stop working — the format can simply stop
+consulting it. Audit for these when upgrading a Reverb 2.0 project:
+
+| Override | What changed | What to do instead |
+|---|---|---|
+| `Pages/images/splash.png` | No template references it any more (EPUB2907). The file still ships, so the override resolves and is copied — it just never renders. **Silent.** | Override `Pages/Splash.asp`, or restyle the Groups Grid via the `$splash_groups_*` variables and `custom.scss` |
+| A pre-2026.1 `Pages/Splash.asp` | Still resolves and still renders — but it has no `<nav id="splash_groups">`, so the new Groups Grid never appears. **Silent.** | Re-base the override on the current `Splash.asp`. `scripts/lint-output.py` flags this (`splash-groups-container`, warn) |
+| A copied `skin.scss` / `webworks.scss` whose only customization is an `@import "custom-*"` line | Still works. But `custom.scss` (2026.1+) needs no entry-point copy at all | Consider moving the rules to `custom.scss` and deleting the copied entry point — see `scss-architecture.md` § "Removing Redundant Overrides" |
+
+Mechanism and hooks for the first two: `runtime-rendered-ui.md`.
+
 ---
 
 **See also:**
-- `scss-architecture.md` — `$theme_` and project-prefix variable conventions for SCSS files
+- `scss-architecture.md` — `$theme_` and project-prefix variable conventions for SCSS files, and the `custom.scss` layer
+- `runtime-rendered-ui.md` — splash Groups Grid and Assistant avatar (runtime-built DOM)
 - `../epublisher/references/file-resolver-guide.md` — how overrides are resolved

--- a/plugins/webworks-agent-skills/skills/reverb2/references/federation-architecture.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/references/federation-architecture.md
@@ -18,7 +18,9 @@ normal output:
 
 - **`<Group Dir>/wwcomposition.xml`** — per-parcel descriptor: decoded group
   name, GroupID, title, entry/index-chunk hrefs (URL-encoded,
-  mirror-relative), generation hash, and a url_maps slice.
+  mirror-relative), generation hash, a url_maps slice, and an optional
+  `MergeSettings/Container` chain (the parcel's own placement declaration —
+  see "Placement in the composed TOC" below).
 - **`<Group Dir>/wwcomposition-manifest.html`** — the parcel's `#parcels`
   TOC `<li>` fragment, **byte-identical** to the leaf in that build's own
   `index.html`. Composition splices these raw bytes, never re-serializes.
@@ -65,6 +67,109 @@ single parcel's slice; cross-parcel ID uniformity does not hold and is not a
 defect. The `#parcels` manifest leaves are byte-copies of each parcel's own
 manifest fragment, so leaf-vs-parcel-unit consistency still holds per group.
 
+## Placement in the composed TOC
+
+Where a group's `<li>` lands in the composed `#parcels` tree is decided by two
+declarations: the composition's own Merge Settings, and the Merge Settings the
+parcel carries in its own deployed descriptor. For each group it composes, the
+engine applies the **first** rule that fits:
+
+| Rung | Rule | Source |
+|------|------|--------|
+| 1 | **The composition places the group.** It appears exactly where the composition's Merge Settings put it — top level, or inside the `<TOC>` containers wrapping it. | `.wacj` `<MergeSettings>` |
+| 2 | **The group places itself.** A group the composition does not place, whose descriptor declares a container chain, nests inside those containers at the top level. | `wwcomposition.xml` `MergeSettings/Container` |
+| 3 | **Nothing places the group.** It is appended in discovery order — descriptor group title, then decoded group name. Stable run to run. | discovery order |
+
+Rule 1 beats rule 2, and the override is **logged, not silent**: when a
+composition places a group that also declared its own container, the log
+records an Info line naming both (`Group 'X': merge settings placement
+overrides its declared container 'Guides/Install'.`). Groups placed by their
+own declaration are reported per container (`'Parcel A', 'Parcel C': placed by
+their declared merge settings into container 'Guides'.`). An unexpected
+position in a composed site therefore always traces back to a log line.
+
+**Where the parcel's declaration comes from.** The descriptor records the
+target's **explicit** Merge Settings container chain, outermost first:
+
+```xml
+<wwcomposition:Descriptor …>
+  <wwcomposition:MergeSettings>
+    <wwcomposition:Container name="Guides"/>
+    <wwcomposition:Container name="Install"/>
+  </wwcomposition:MergeSettings>
+  …
+</wwcomposition:Descriptor>
+```
+
+Authoring is equivalent in either project form: a `.wep`/`.wrp` target's
+`FormatConfiguration/MergeSettings` (a `<TOC>` wrapping the group's
+`<MergeGroup>`), or the `<MergeSettings>` block on a `.waj` `<Target>`, which
+AutoMap injects into the staged project at build time. A project with **no**
+explicit Merge Settings declares no placement — the synthesized fallback the
+descriptor transform uses is flat by construction, so its descriptor carries
+no `MergeSettings` element at all. The schema is additive: flat groups and
+descriptors written before the element existed compose unchanged.
+
+**Container merging.** Containers are created on demand and merged **by name**
+at each level, so parcels declaring the same container share one folder. A
+parcel-declared name also merges with a same-level `.wacj` container matched by
+its `name` **or** its displayed `title`. Sibling order stays deterministic:
+parcels arrive in discovery order and append, members of a shared container
+keep that order, and a container sits where its first member placed it. In
+hybrid mode everything discovered appends after the declared spec.
+
+**Where rule 2 applies.** Only in the modes that admit parcels the composition
+does not name: **Automatic** (discovery — compose every deployed group), and a
+**Custom** composition with *Also include newly published parcels* selected
+(hybrid). In a strictly Custom composition every composed group is named, so
+rule 1 covers all of them.
+
+## Containers are not groups
+
+A **container** is a folder in the composed TOC. A **group** is a set of
+documents with deployed output. Containers hold groups; only groups carry
+content. In a `.wacj`, `<TOC name="…">` declares a container and
+`<Group name="…"/>` places a group.
+
+The confusion is easy to reach: once one team's parcel declares `Guides`, that
+name is visible in the composed site, and it is tempting to list it as a
+`<Group>`. It has no deployed output, so it cannot be composed as one — and
+this is **diagnosed, not guessed**. The composition omits the entry and warns
+with the actual situation and the actual fix, naming the deployed groups that
+declared the container:
+
+```
+'Guides' is a placement container declared by deployed groups ('Parcel A', 'Parcel C'),
+not a group; omitted. To place those groups, add them directly where you want them.
+A group placed by this composition overrides its declared container.
+```
+
+(Inside an enclosing container the advice names it: *"To place those groups
+inside 'Manuals', add them there directly."*) A name that matches nothing at
+all still gets the generic line — `Group 'X': no deployed output was found at
+destination 'Prod'; omitted. Deploy its output to this destination, then run
+this composition again.` — so the two situations stay distinguishable in the
+log.
+
+Malformed and conflicting placement is reported with a fallback to the **top
+level**, never a failure:
+
+| Situation | Log line (Warn) |
+|-----------|-----------------|
+| A declared container with an empty name | `Group 'X' declares a placement container with an empty name; placed at the top level instead.` |
+| A declared container colliding with a group of that name at the same level | `Group 'X' declares placement container 'Guides', which collides with a group of that name; placed at the top level instead.` |
+| A declared chain landing beside a container carrying the parcel's own name | `Group 'X' declares a placement that collides with a container of the same name; placed at the top level instead.` |
+
+A spec container that ends up holding nothing is dropped with
+`Container 'Guides' contains no groups to compose; omitted.`
+
+**Placement problems never fail a compose.** Every case above degrades to flat
+(top-level) placement — exactly as if the parcel had declared nothing — and the
+site still composes and loads. Treat a placement warning as a TOC-shape
+question, never as a broken build. (`Group 'X'` in these lines becomes
+`Member 'M'` — or `Member 'M' group 'X'` when the two names differ — when the
+host job maps the group to a composition member.)
+
 ## Runtime tolerance
 
 The 2026.1 loader tolerates missing parcels: parcel iframes are armed for
@@ -92,3 +197,20 @@ Slice directory names mirror the format's naming exactly (space replacement
 settings, path-invalid character folding), so unusual group names still
 attribute correctly. Deployments never delete outside their own slice; stale
 files from a pre-federation full deploy must be cleaned deliberately.
+
+## Not covered here
+
+Two composition topics live outside this reference on purpose:
+
+- **Which output target each member composes through** — the determinant
+  selection rule (the member's own `Job/@target`, else the composition-wide
+  `Jobs/@target`, else auto-detection among the targets that member itself
+  declares; never a silent first match, and every member must select the same
+  format). That is job-artifact behavior, not output structure: see the
+  automap skill's `references/composition-jobs.md` § "Output target selection
+  (determinant)". The end-user framing is the *Output target* entry in the
+  docs topic `output-formats/webworks-reverb-20/reverb-federated-parcels.md`.
+- **The `.wacj` grammar** — members, roles, destinations, inline deploy
+  settings, and CLI dispatch: also the automap skill's
+  `references/composition-jobs.md`. This file never duplicates that grammar;
+  it describes only what composition leaves behind in the output.

--- a/plugins/webworks-agent-skills/skills/reverb2/references/runtime-rendered-ui.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/references/runtime-rendered-ui.md
@@ -1,0 +1,194 @@
+# Runtime-Rendered UI Surfaces
+
+> **Applies to ePublisher 2026.1 and later.** Both surfaces below are new or
+> reworked in 2026.1.
+
+Two pieces of Reverb 2.0 chrome are **not** in the published markup: the
+splash page's Groups Grid and the AI Assistant's avatar. The templates ship an
+empty container and the runtime builds the DOM into it. That inverts the usual
+debugging move — reading the `.asp` will not tell you what renders, and
+searching the published HTML for the card markup finds nothing. Read the
+JavaScript (`Pages/scripts/connect.js`, `Pages/scripts/page.js`,
+`Pages/scripts/assistant.js`), then style through the documented
+`ww_skin_*` hooks.
+
+## Splash Groups Grid (EPUB2907)
+
+The splash page is a responsive grid of entry-point cards generated at runtime
+from the help set's Groups and Merge Settings Containers. It replaces the
+former static splash image.
+
+### What the template contains
+
+`Pages/Splash.asp` is now lean: no splash image, no logo block, no inline
+styles. The whole grid region is one empty container:
+
+```html
+<nav id="splash_groups" class="ww_skin_splash_groups"
+     aria-label="Groups" wwpage:attribute-aria-label="groups-grid-label">&#160;</nav>
+```
+
+The `aria-label` is localized from the `GroupsGridLabel` locale string
+(`Transforms/splash.xsl` → `locales.xml`).
+
+### How the cards are built
+
+| Step | Where |
+|------|-------|
+| Wait for `Parcels.loaded_all`, flushing any deferred hydration first (`Navigation.FlushDeferredLoadRemaining`), then re-check the splash is still displayed | `Connect.SplashGroupsSchedule` (`connect.js`) |
+| Walk the **master TOC** in `#toc_content` — the `#parcels` manifest skeleton with each loaded parcel's TOC grafted in — and collect one card per top-level `<li>`, with the entries of its direct child `<ul>` as member links | `Connect.SplashGroups_CollectData` (`connect.js`) |
+| Post the result to the splash iframe as **structured titles and hrefs, never markup** | `Message.Post` → `'splash_groups_data'` |
+| Build the DOM with `createElement` / `textContent`, validate every href with `Message.IsSafeURL`, wire clicks through `Page.InterceptLink` | `Page.SplashGroupsRender` (`page.js`) |
+
+Consequences worth knowing:
+
+- **The grid mirrors the merge hierarchy, not the file tree.** A Merge Settings
+  container becomes a card whose members are the groups inside it; a top-level
+  group becomes a card whose members are its first TOC level. A container title
+  carries no link of its own, and a group title loses its manifest href once
+  its parcel TOC is grafted in — so both fall back to the first descendant
+  link. Every card is guaranteed to reach a link, or it is dropped.
+- **The master TOC is populated whether or not the Menu shows it.** The TOC
+  data island in each parcel page is emitted when
+  `toc-generate = true` **OR** `show-first-document = false`
+  (`Transforms/parcel.xsl`), so the grid still works with the Menu TOC turned
+  off. Only a target with the TOC disabled *and* the splash bypassed omits it.
+- **Federated shells get their cards the same way.** The shell's own build
+  contributes no groups; the grid is populated client-side from the composed
+  `#parcels` manifest and the parcel TOCs the runtime loads. Nothing about the
+  grid is baked in at compose time.
+
+### Responsive layout
+
+The grid renders **inside the page iframe**, where the Connect frame's
+`#layout_div` is not visible. The Connect frame therefore mirrors its layout
+vocabulary onto the grid container on every layout change
+(`Connect.SplashGroupsPostLayout` → `'splash_groups_layout'` →
+`Page.SplashGroupsApplyLayout`). Classes are rebuilt from booleans, never
+copied from the message:
+
+| Mode | Class on `#splash_groups` |
+|------|---------------------------|
+| Desktop | `ww_skin_splash_groups layout_wide` |
+| Mobile landscape | `ww_skin_splash_groups layout_narrow` |
+| Mobile portrait | `ww_skin_splash_groups layout_narrow layout_tall` |
+
+### DOM and skin hooks
+
+| Element | Class |
+|---------|-------|
+| Grid container (the `<nav>`) | `ww_skin_splash_groups` |
+| Grid list (`<ul>`) | `ww_skin_splash_groups_grid` |
+| Card (`<li>`) | `ww_skin_splash_group_card` |
+| Card title (`<div>` wrapping an `<a>` or `<span>`) | `ww_skin_splash_group_card_title` |
+| Member list (`<ul>`) | `ww_skin_splash_group_card_members` |
+
+Base styling lives in `Pages/sass/skin.scss` § *Splash - Groups Grid*; the
+responsive selectors live in `Pages/sass/webworks.scss` § *Splash - Groups Grid
+responsive layout* (that is the sheet governing content inside the iframe). The
+card hover/lift transitions are disabled under
+`@media (prefers-reduced-motion: reduce)`.
+
+### `$splash_groups_*` variables
+
+Layer-1 theming for the grid, by partial:
+
+| Partial | Variables |
+|---------|-----------|
+| `_sizes.scss` | `$splash_groups_padding`, `$splash_groups_padding_narrow`, `$splash_groups_grid_gap`, `$splash_groups_grid_gap_narrow`, `$splash_groups_card_min_width`, `$splash_groups_card_padding`, `$splash_groups_card_border_radius`, `$splash_groups_card_accent_height`, `$splash_groups_member_link_padding` |
+| `_colors.scss` | `$splash_groups_card_background_color`, `$splash_groups_card_border_color`, `$splash_groups_card_border_color_hover`, `$splash_groups_card_accent_color`, `$splash_groups_card_title_text_color`, `$splash_groups_card_title_text_color_hover`, `$splash_groups_card_member_text_color`, `$splash_groups_card_member_text_color_hover` |
+| `_borders.scss` | `$splash_groups_card_border_style`, `$splash_groups_card_border_width` |
+| `_fonts.scss` | `$splash_groups_card_title_font`, `$splash_groups_card_title_font_size`, `$splash_groups_card_title_font_weight`, `$splash_groups_card_member_font`, `$splash_groups_card_member_font_size` |
+
+Anything the variables do not reach goes in `custom.scss` (see
+`scss-architecture.md` § "The `custom.scss` Layer").
+
+### Upgrade impact: `splash.png` overrides stop working
+
+**No template references `splash.png` any more.** The file still ships at
+`Pages/images/splash.png`, so a project override of it is silently **inert**
+rather than an error — the splash simply shows the grid instead.
+
+A project that customized the splash by overriding `splash.png` must now
+override **`Pages/Splash.asp`** instead (or restyle the grid through the
+`$splash_groups_*` variables and `custom.scss`). Flag this during any 2026.1
+customization audit: an override of `Pages/images/splash.png` in
+`Targets/*/` or `Formats/*/` is dead weight after the upgrade.
+
+The inverse also bites: a project carrying a **pre-2026.1 `Splash.asp`
+override** keeps its old splash markup, which has no `#splash_groups`
+container — so the grid never renders and nothing reports it. `lint-output.py`
+flags exactly this case (`splash-groups-container`, warn).
+
+## Assistant avatar (EPUB2911)
+
+The AI Assistant renders the assistant's configured avatar image in place of
+the generic Font Awesome icon.
+
+### Source and validation
+
+`avatar_url` arrives on the WebWorks Platform's **public assistant payload**
+and is stored as-is by `Assistant_UpdateAssistantData`. Whether it is
+*renderable* is decided at render time by `Assistant_GetAvatarImageUrl`, which
+accepts only **absolute `http(s)` URLs** — `javascript:`, `data:`,
+protocol-relative, and site-relative values all fall back to the generic icon.
+The URL is attribute-escaped with `Assistant_EscapeAttribute` before
+interpolation (`Assistant_EscapeHtml` routes through `textContent` and leaves
+quote characters intact, which is unsafe for an attribute value).
+
+### Markup
+
+One helper, `Assistant_RenderAvatar`, feeds every assistant-side slot: the
+**welcome screen**, **assistant message rows**, the **thinking/reasoning
+row**, the **error row**, the **latest-response row**, the **streaming row**,
+and the **conversation-list (thread list) header**. The user-side avatar slot
+is unchanged.
+
+```html
+<!-- icon (no usable avatar_url) -->
+<div class="ww_skin_assistant_avatar"><i class="fa"></i></div>
+
+<!-- image -->
+<div class="ww_skin_assistant_avatar ww_skin_assistant_avatar_has_image">
+  <img class="ww_skin_assistant_avatar_image" alt=""
+       src="…" onerror="Assistant_HandleAvatarImageError(this)">
+</div>
+```
+
+`alt` is intentionally empty — the avatar is decorative; the assistant's name
+is always rendered beside it.
+
+### Failure fallback
+
+`Assistant_HandleAvatarImageError` swaps that slot back to the icon **and
+latches the failure** (`Assistant.assistant_avatar_unavailable`), so later
+re-renders neither emit the image nor re-request a URL already known to be
+broken. A payload carrying a *different* `avatar_url` clears the latch.
+
+### Skin hooks
+
+| Class | Role |
+|-------|------|
+| `ww_skin_assistant_avatar` | The slot container. Fixed size at every slot (2rem; 4rem on the welcome screen, 3rem in `.ww_skin_assistant_info`), with `overflow: hidden` so the image crops to the container's corner radius. |
+| `ww_skin_assistant_avatar_has_image` | **New in 2026.1.** Added to the container only in the image case, as a target for skins that style a photo differently from the icon (dropping the icon's background tint, for instance). The stock skins do not need it. |
+| `ww_skin_assistant_avatar_image` | The `<img>`: fills the container, `object-fit: cover`, `border-radius: inherit`. |
+
+Because the container is already fixed-size at every slot, the message list
+does **not** reflow as avatars load.
+
+Sizing and cropping live in `Pages/sass/connect.scss`; the icon's background
+and color come from `$assistant_avatar_background_color` /
+`$assistant_avatar_icon_color` (`_colors.scss`) and `$assistant_avatar_icon`
+(`_icons.scss`) via `Pages/sass/skin.scss`.
+
+> **Packaged skins carry their own copy.** A `.weplugin` skin that ships a full
+> `connect.scss` needs the avatar image rules applied to *its* copy too —
+> another reason the packaged-skin route is deprecated. See
+> `scss-architecture.md` § ".weplugin Migration".
+
+---
+
+**See also:**
+- `scss-architecture.md` — the `custom.scss` layer, variable partials, cascade
+- `federation-architecture.md` — composed `#parcels` manifests that feed the grid
+- `../epublisher/references/file-resolver-guide.md` — override hierarchy for `Splash.asp` and the partials

--- a/plugins/webworks-agent-skills/skills/reverb2/references/scss-architecture.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/references/scss-architecture.md
@@ -1,17 +1,18 @@
 # Reverb 2.0 SCSS Architecture
 
-## Three-Layer Theming Model
+## Theming Layers
 
-Reverb 2.0 CSS customization uses three independent layers, each with its own entry point and scope:
+Reverb 2.0 CSS customization uses independent layers, each with its own entry point and scope:
 
 | Layer | Entry Point | Scope | Override File |
 |-------|-------------|-------|---------------|
-| **1. Variable overrides** | `skin.scss` / `webworks.scss` | Change values used by existing rules | `_colors.scss`, `_sizes.scss`, `_fonts.scss`, `_icons.scss`, `_borders.scss` |
-| **2. Skin CSS** | `skin.scss` | Chrome: toolbar, TOC, navigation, breadcrumbs, popups | `_custom-skin.scss` (user-created) |
-| **3. Content page CSS** | `webworks.scss` | Content: fonts, links, tables, mini-TOC, code blocks | `_custom-webworks.scss` (user-created) |
+| **1. Variable overrides** | `skin.scss` / `webworks.scss` / `custom.scss` | Change values used by existing rules | `_colors.scss`, `_sizes.scss`, `_fonts.scss`, `_icons.scss`, `_borders.scss` |
+| **2. Custom selectors** *(2026.1+)* | `custom.scss` — ships pre-wired, compiled to `css/custom.css` and linked **last** on every page | Any selector, any page type, chrome and content alike | `custom.scss` (replace the stock file) |
+| **2a. Skin CSS** *(pre-2026.1 convention)* | `skin.scss` | Chrome: toolbar, TOC, navigation, breadcrumbs, popups | `_custom-skin.scss` (user-created) |
+| **2b. Content page CSS** *(pre-2026.1 convention)* | `webworks.scss` | Content: fonts, links, tables, mini-TOC, code blocks | `_custom-webworks.scss` (user-created) |
 
 **Layer 1** is the safest — you only change variable values, never selectors or rules.
-**Layers 2–3** give full CSS control but require understanding Reverb's DOM structure.
+**Layer 2** gives full CSS control but requires understanding Reverb's DOM structure. On 2026.1+ prefer `custom.scss`; layers 2a/2b remain supported and are the only option on earlier builds — see [The `custom.scss` Layer](#the-customscss-layer) for how the two relate.
 
 ## Recommended Setup for New Projects: No Skin
 
@@ -19,32 +20,127 @@ For a **new** project, leave the *Skin* target setting unset and customize the R
 
 Do **not** start from a packaged skin (a `.weplugin` selected via the *Skin* target setting). Packaged skins are deprecated (see [.weplugin Migration](#weplugin-migration) below) and insert an extra indirection layer between your overrides and the output. Customizing the unskinned format keeps every customization greppable and on the file-resolver fall-through path, which is far easier to audit and upgrade.
 
-Customize the unskinned format using the three layers above:
+Customize the unskinned format using the layers above:
 
 - **Layer 1 — variable overrides** with the `$theme_` convention (`_colors.scss`, `_sizes.scss`, …)
-- **Layer 2 — `_custom-skin.scss`** for structural chrome CSS (toolbar, TOC, navigation)
-- **Layer 3 — `_custom-webworks.scss`** for structural content-page CSS
+- **Layer 2 — `custom.scss`** for structural CSS of any kind (2026.1+)
+- **Layers 2a/2b — `_custom-skin.scss` / `_custom-webworks.scss`** for structural chrome and content-page CSS on pre-2026.1 builds, or when a rule must sit at a specific cascade depth
 
 Apply these at the **Formats** level (`Formats/WebWorks Reverb 2.0/Pages/sass/`) to affect all targets, or at the **Targets** level (`Targets/[Target]/Pages/sass/`) for a single target — see [File Resolver Integration](#file-resolver-integration) below for the full override priority.
 
 ## Compilation Model
 
-Reverb compiles two independent SCSS entry points during publishing:
+Reverb compiles independent SCSS entry points during publishing. The three that matter for customization:
 
 ```
 skin.scss          → skin.css      (toolbar, TOC, navigation chrome)
 webworks.scss      → webworks.css  (content page inside iframe)
+custom.scss        → custom.css    (user layer; linked LAST on every page)  [2026.1+]
 ```
 
-These are separate stylesheets loaded by different parts of the Reverb runtime. Variables defined in one are **not visible** to the other — each imports its own copy of the partials.
+These are separate stylesheets loaded by different parts of the Reverb runtime. Variables defined in one are **not visible** to the other — each imports its own copy of the partials. (`connect.scss`, `search.scss`, `social.scss`, `print.scss`, and the `menu_initial_*.scss` pair compile the same way; they are rarely customization targets.)
+
+## The `custom.scss` Layer
+
+> **New in ePublisher 2026.1** (EPUB2908). Earlier builds have no `custom.scss`
+> and no `css/custom.css` link — use `_custom-skin.scss` / `_custom-webworks.scss`
+> there.
+
+The format ships a stock `Pages/sass/custom.scss`. It compiles to
+`css/custom.css`, which **every** page template links as its **last**
+stylesheet:
+
+| Template | Published as | Sheets linked before `custom.css` |
+|----------|--------------|-----------------------------------|
+| `Connect.asp` | `index.html` | `connect.css`, `skin.css`, `menu_initial_open/closed.css` |
+| `Page.asp` | topic pages | `webworks.css`, `skin.css`, `social.css`, `catalog.css`, `document.css`, `print.css` |
+| `Splash.asp` | `splash.html` | `webworks.css`, `skin.css`, `social.css`, `print.css` |
+| `NotFound.asp` | `not-found.html` | `webworks.css`, `skin.css`, `social.css`, `print.css` |
+| `Popup.asp` | popups | `webworks.css`, `catalog.css`, `document.css` |
+| `Search.asp` | `search.html` | `search.css`, `skin.css` |
+
+(All six also link `font-awesome/css/all.min.css` first.)
+
+Last position is the whole point: a rule in `custom.scss` wins every
+**equal-specificity** cascade contest against the stock sheets, on every page
+type including popups. Print rules belong here too, inside `@media print`
+blocks — `custom.css` is `media="all"` and is linked *after* the `media="print"`
+`print.css`, so an equal-specificity `@media print` rule in `custom.scss` wins.
+
+### What the stock file contains
+
+Comments plus the variable-partial imports, and nothing else:
+
+```scss
+@import "functions";
+@import "colors";
+@import "fonts";
+@import "icons";
+@import "sizes";
+@import "borders";
+```
+
+Those imports emit no CSS on their own, so the compiled `custom.css` contributes
+**no rules** by default. Their job is to make every skin variable — including
+project overrides of the partials, which flow through the same resolver —
+usable inside your custom rules (`$link_default_color`, `$theme_primary`, …).
+
+> **The stock file carries no component design.** It is an empty seam. The
+> 2026.1 splash Groups Grid design, for example, lives in `skin.scss` and
+> `webworks.scss`, **not** here — so overriding `custom.scss` does not take
+> ownership of it. Keep the `@import` block when you replace the file, though;
+> dropping it breaks every variable reference in your own rules.
+
+### How to customize
+
+Copy `custom.scss` into the project at either level and edit the copy. It
+**replaces** the stock file entirely — there is no merge:
+
+```
+[Project]/Targets/[Target]/Pages/sass/custom.scss    ← single target
+[Project]/Formats/WebWorks Reverb 2.0/Pages/sass/custom.scss  ← all targets
+```
+
+No entry point to copy, no `@import` hook to add, and nothing to re-apply at
+upgrade time — the link is already in every shipped template.
+
+### Relationship to `_custom-skin.scss` / `_custom-webworks.scss`
+
+The older pair still works and is not deprecated. The difference is mechanical:
+
+| | `custom.scss` (2026.1+) | `_custom-skin.scss` / `_custom-webworks.scss` |
+|---|---|---|
+| Setup | Copy one file. Already linked. | Copy `skin.scss` and/or `webworks.scss`, create the partial, add `@import "custom-skin";` / `@import "custom-webworks";` |
+| Upgrade cost | None — no entry point is overridden | Re-apply the `@import` line to each new installed entry point |
+| Cascade position | After **both** `skin.css` and `webworks.css`, on every page type | Inside whichever sheet imports it |
+| Reaches popups, search, splash, not-found | Yes | Only where that sheet is linked (`skin.css` is not linked by `Popup.asp`) |
+
+Use `custom.scss` by default on 2026.1+. Reach for the older pair when:
+
+- the project targets a pre-2026.1 build, or already has the partials wired
+  (leave them; they keep working alongside `custom.scss`), or
+- a rule **must not** outrank the other sheet. The two-partial split exists
+  because `webworks.css` loads before `skin.css`: a bare `a { }` content rule
+  placed in `_custom-skin.scss` would outrank toolbar link colors. `custom.css`
+  loads after both, so the same bare rule in `custom.scss` reaches chrome links
+  too. One file means one cascade depth — **scope your selectors** (`.ww_skin_*`
+  for chrome, content-page selectors for content) instead of relying on sheet
+  order to do it for you.
+
+Do **not** invent a third partial name (`_custom.scss`, `_project.scss`).
+Between `custom.scss` and the well-known `_custom-skin.scss` /
+`_custom-webworks.scss` pair, the next customizer already has two places to
+look; a third hides the rules.
 
 ### Key guardrail
 
-The installed `skin.scss` and `webworks.scss` do **not** ship with custom import hooks. To use Layer 2 or Layer 3, you must:
+The installed `skin.scss` and `webworks.scss` do **not** ship with custom import hooks. To use layer 2a or 2b, you must:
 
 1. Copy the relevant entry point (`skin.scss` and/or `webworks.scss`) to your project
 2. Create your custom partial (`_custom-skin.scss` or `_custom-webworks.scss`)
 3. Add the `@import` line to the copied entry point
+
+`custom.scss` (2026.1+) has no equivalent step — its link ships in every page template.
 
 ### Why Two Custom Partials, Not One
 
@@ -55,7 +151,7 @@ Reverb 2.0 loads `webworks.css` before `skin.css` in the page template. Putting 
 | `_custom-webworks.scss` | Content page overrides — custom fonts, link styling, paragraph/list formatting |
 | `_custom-skin.scss` | Skin chrome overrides — toolbar, TOC, navigation, breadcrumbs, lightbox, print styles |
 
-**Upgrade workflow:** When upgrading the format, replace `skin.scss` and `webworks.scss` with the new installed versions and re-append the `@import` line for the corresponding custom partial. The `_custom-*.scss` partials need no changes.
+**Upgrade workflow:** When upgrading the format, replace `skin.scss` and `webworks.scss` with the new installed versions and re-append the `@import` line for the corresponding custom partial. The `_custom-*.scss` partials need no changes. Moving those rules into `custom.scss` on 2026.1+ retires this step entirely — at the cost of the cascade-depth separation described above.
 
 ## SCSS Partials Inventory
 
@@ -70,7 +166,9 @@ Six partials control all variable-driven styling:
 | `_borders.scss` | 150+ | Border widths, styles, colors, radii |
 | `_functions.scss` | 4 | Helper functions (color manipulation) |
 
-All partials live in `Pages/sass/` within the format directory structure.
+All partials live in `Pages/sass/` within the format directory structure. The stock `custom.scss` imports all six, so every variable and helper below is available in your custom rules.
+
+2026.1 adds the `$splash_groups_*` family across `_sizes.scss`, `_colors.scss`, `_borders.scss`, and `_fonts.scss` for the splash Groups Grid — inventoried in `runtime-rendered-ui.md` § "Splash Groups Grid".
 
 ## Color Cascade
 
@@ -291,12 +389,13 @@ All SCSS files follow the ePublisher file resolver hierarchy. See `../epublisher
 3. `Formats/WebWorks Reverb 2.0.base/Pages/sass/_colors.scss` — packaged defaults
 4. `[Install]/Formats/WebWorks Reverb 2.0/Pages/sass/_colors.scss` — installation fallback
 
-The same hierarchy applies to all partials, `skin.scss`, `webworks.scss`, and any custom files.
+The same hierarchy applies to all partials, `skin.scss`, `webworks.scss`, `custom.scss`, and any custom files.
 
 ---
 
 **See also:**
-- `../epublisher/references/file-resolver-guide.md` — full override hierarchy
+- `../epublisher/references/file-resolver-guide.md` — full override hierarchy (its Workflow 3 documents the `_custom-skin.scss` / `_custom-webworks.scss` route; [The `custom.scss` Layer](#the-customscss-layer) above is the 2026.1+ alternative)
+- `runtime-rendered-ui.md` — splash Groups Grid and Assistant avatar: runtime-built DOM, `$splash_groups_*` variables, `ww_skin_*` hooks
 - `workflows/scss-theming.md` — step-by-step theming workflow
 - `customization-conventions.md` — annotations for non-SCSS overrides and `locales.xml` upgrade
 - GitHub issue: quadralay/epublisher-express-trial#9 — `$theme_` convention rationale

--- a/plugins/webworks-agent-skills/skills/reverb2/scripts/lint-output.py
+++ b/plugins/webworks-agent-skills/skills/reverb2/scripts/lint-output.py
@@ -29,9 +29,9 @@ Checks
    `toc:<GID>`, `data:<GID>`, `breadcrumbs:<GID>`, and `page:<GID>:first/last`
    inside it. If the parcel's own GroupID (its `<body id="id:<GID>">` and those
    divs) disagrees with the manifest's — which happens when output is assembled
-   from multiple builds that each minted their own GroupIDs, e.g. the
-   Reverb-on-S3 deploy-set model — every lookup returns null, the parcel never
-   attaches, and the spinner hangs silently.
+   from multiple builds that each minted their own GroupIDs, e.g. federated
+   parcel composition or any hand-rolled multi-build assembly — every lookup
+   returns null, the parcel never attaches, and the spinner hangs silently.
 
 3. parcel-deploy-unit  (error)
    Each manifest parcel `<Name>` is published as a deploy unit: `<Name>.html`
@@ -47,6 +47,17 @@ Checks
    Local `scripts/` and `css/` assets referenced by `index.html`
    (`<script src>`, `<link href>`) exist on disk. Remote (`http(s)://`,
    protocol-relative `//`) and `data:` references are skipped.
+
+5. splash-groups-container  (warn)
+   The 2026.1 splash page is a Groups Grid built at runtime: `Splash.asp`
+   ships an empty `<nav id="splash_groups">` and `page.js` fills it from card
+   data the Connect frame posts over. If the container is absent the grid
+   never renders and nothing reports it — the usual cause is a pre-2026.1
+   `Splash.asp` override carried through an upgrade. Like the chunk set, the
+   expectation is read from the build itself: the check runs only when this
+   build's own `scripts/page.js` looks up `splash_groups`, so pre-2026.1
+   output is never flagged. Warn, not error: a deliberate `Splash.asp`
+   redesign that drops the grid is legitimate.
 
 The check set is extensible — new known-breakage checks get added here as they
 are discovered.
@@ -138,6 +149,11 @@ CHUNK_SUFFIXES = ('_ix.html', '_lx.js', '_sx.js')
 # Root-level shell HTML pages scanned for self-closed elements in addition to
 # index.html and the per-parcel pages. Only those that exist are scanned.
 SHELL_HTML_FILES = ('index.html', 'search.html', 'splash.html', 'not-found.html')
+
+# The splash page and the id of its runtime-filled Groups Grid container
+# (Splash.asp: <nav id="splash_groups" class="ww_skin_splash_groups">).
+SPLASH_PAGE = 'splash.html'
+SPLASH_GROUPS_ID = 'splash_groups'
 
 # Finding severities.
 SEVERITY_ERROR = 'error'
@@ -629,9 +645,10 @@ def _check_parcel_groupid(
 
     if gid_manifest not in parcel_gids:
         # The manifest GroupID appears on none of the parcel's landmarks — the
-        # whole parcel was built under a different GroupID (the classic deploy-set
-        # mismatch). connect.js binds toc:/data:/page: by the manifest GroupID,
-        # so every getElementById returns null and the parcel never attaches.
+        # whole parcel was built under a different GroupID (the classic
+        # multi-build assembly mismatch). connect.js binds toc:/data:/page: by
+        # the manifest GroupID, so every getElementById returns null and the
+        # parcel never attaches.
         observed = sorted(parcel_gids)
         observed_str = observed[0] if len(observed) == 1 else str(observed)
         findings.append(Finding(
@@ -655,6 +672,63 @@ def _check_parcel_groupid(
                 f"will not bind",
                 file=href_path,
             ))
+
+
+def build_renders_splash_groups(output_dir: Path) -> bool:
+    """Whether this build's own page.js renders the splash Groups Grid.
+
+    Same "ask the build, don't assume the version" rule as
+    expected_chunk_suffixes: `page.js` looks the container up by id
+    (`getElementById('splash_groups')`), so its presence there is the build's
+    own statement that it expects the container. Pre-2026.1 output has no such
+    lookup and is therefore never flagged. A missing/unreadable page.js means
+    "cannot tell" — the check is skipped.
+    """
+    page_js = output_dir / 'scripts' / 'page.js'
+    try:
+        text = page_js.read_text(encoding='utf-8', errors='replace')
+    except OSError:
+        return False
+    return f"'{SPLASH_GROUPS_ID}'" in text or f'"{SPLASH_GROUPS_ID}"' in text
+
+
+def check_splash_groups(output_dir: Path, findings: list[Finding]) -> None:
+    """Warn when a Groups-Grid build's splash page has no grid container.
+
+    The grid is built at runtime into `<nav id="splash_groups">`; without that
+    element `Page.SplashGroupsRender` returns early and the splash renders
+    empty, with no console error. Almost always a pre-2026.1 `Splash.asp`
+    override carried forward through an upgrade.
+    """
+    splash_path = output_dir / SPLASH_PAGE
+    if not splash_path.is_file():
+        return
+    if not build_renders_splash_groups(output_dir):
+        debug_log('page.js does not render the splash Groups Grid; check skipped')
+        return
+
+    try:
+        text = _read_text(splash_path)
+    except OSError as e:
+        findings.append(Finding(
+            'splash-groups-container', SEVERITY_WARN,
+            f"could not read file: {e}", file=SPLASH_PAGE,
+        ))
+        return
+
+    if any(id_value == SPLASH_GROUPS_ID for _, id_value in collect_element_ids(text)):
+        return
+
+    findings.append(Finding(
+        'splash-groups-container', SEVERITY_WARN,
+        f"this build's page.js renders the splash Groups Grid into "
+        f"id='{SPLASH_GROUPS_ID}', but {SPLASH_PAGE} has no such element - the "
+        f"grid never renders and the splash comes up empty, with no console "
+        f"error. Usual cause: a pre-2026.1 Splash.asp override carried through "
+        f"an upgrade (EPUB2907). Intentional if the project deliberately "
+        f"replaced the splash design",
+        file=SPLASH_PAGE,
+    ))
 
 
 def check_reference_integrity(
@@ -716,6 +790,7 @@ def lint(output_dir: Path) -> list[Finding]:
     check_self_closed(output_dir, html_files, findings)
     check_manifest_and_parcels(output_dir, entries, chunk_suffixes, findings)
     check_reference_integrity(output_dir, index_text, findings)
+    check_splash_groups(output_dir, findings)
     return findings
 
 

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/README.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/README.md
@@ -20,6 +20,7 @@ diff from a known-good build — exactly how the real breakages arise.
 | Self-closed **void** elements (`<meta/>`, `<link/>`) | `self-closed-element` must not flag void elements |
 | A remote `https://cdn.jsdelivr.net/...` `<script src>` | `reference-integrity` must skip remote refs |
 | Local `scripts/*.js` + `css/base.css` with `?v=` cache-busters | `reference-integrity` happy path (query stripped before the on-disk check) |
+| `splash.html` with an **empty** `<nav id="splash_groups">` + a `scripts/page.js` that looks that id up | `splash-groups-container` happy path. The container is empty by design (the grid is built at runtime), and the check is gated on the build's own `page.js` — removing `page.js` is how the suite proves pre-2026.1 output is never flagged |
 
 ## Run
 
@@ -29,5 +30,6 @@ python ../../verify-lint-output.py
 
 The verifier injects each defect (self-closed `<script/>`, whole-parcel GroupID
 mismatch, `<li>`/anchor GroupID desync, missing deploy-unit file, missing content
-directory, missing local asset, missing `index.html`) into a throwaway copy — the
-committed `good/` tree is never modified.
+directory, missing local asset, renamed splash Groups Grid container, missing
+`index.html`) into a throwaway copy — the committed `good/` tree is never
+modified.

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/scripts/page.js
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/scripts/page.js
@@ -1,0 +1,13 @@
+// page.js stub — models only what lint-output.py reads from the real file.
+//
+// build_renders_splash_groups() treats the 'splash_groups' lookup below as the
+// build's own statement that it expects the Groups Grid container in
+// splash.html. Pre-2026.1 page.js has no such lookup, which is how the check
+// stays version-tolerant.
+
+Page.SplashGroupsRender = function (param_groups) {
+  var groups_nav = Page.window.document.getElementById('splash_groups');
+  if (groups_nav === null) {
+    return;
+  }
+};

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/splash.html
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/fixtures/lint-output/good/splash.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<!--
+  Fixture: a STRUCTURALLY VALID minimal Reverb 2.0 splash page (2026.1 shape).
+  The Groups Grid container is empty by design — page.js fills it at runtime
+  from card data the Connect frame posts over — so an empty <nav> here is
+  correct, not a defect.
+
+  Exercises splash-groups-container: the check fires only when the build's own
+  scripts/page.js looks up 'splash_groups', which this fixture's page.js does.
+-->
+<html>
+<head>
+<meta charset="utf-8"/>
+<link rel="stylesheet" type="text/css" href="css/base.css?v=abc123"/>
+<title>Reverb lint fixture - splash</title>
+</head>
+<body id="splash">
+  <main id="page_content_container" class="ww_skin_splash_container" tabindex="-1">
+    <div id="page_content" class="ww_skin_splash_content">
+      <nav id="splash_groups" class="ww_skin_splash_groups" aria-label="Groups">&#160;</nav>
+    </div>
+  </main>
+  <script type="text/javascript" src="scripts/common.js?v=abc123"></script>
+  <script type="text/javascript" src="scripts/page.js?v=abc123"></script>
+</body>
+</html>

--- a/plugins/webworks-agent-skills/skills/reverb2/tests/verify-lint-output.py
+++ b/plugins/webworks-agent-skills/skills/reverb2/tests/verify-lint-output.py
@@ -314,6 +314,50 @@ def test_cli_missing_asset_warns() -> None:
               f"rc={proc_strict.returncode}")
 
 
+def test_build_renders_splash_groups() -> None:
+    with CopyOfGood() as root:
+        detected = linter.build_renders_splash_groups(root)
+        os.remove(root / 'scripts' / 'page.js')
+        absent = linter.build_renders_splash_groups(root)
+        check("build_renders_splash_groups: true with page.js, false without", detected and not absent,
+              f"detected={detected} absent={absent}")
+
+
+def test_cli_splash_groups_missing_container() -> None:
+    with CopyOfGood() as root:
+        splash = root / 'splash.html'
+        _write(splash, _read(splash).replace('id="splash_groups"', 'id="legacy_splash_image"'))
+        proc = run_cli(str(root), '--json')
+        data = json.loads(proc.stdout)
+        sg = _checks_present(data['findings'], 'splash-groups-container')
+        ok = (
+            proc.returncode == 0  # warnings alone do not fail
+            and data['success'] is True
+            and any(f['file'] == 'splash.html' and f['severity'] == 'warn' for f in sg)
+        )
+        check("CLI: splash.html without the Groups Grid container warns, exit 0", ok,
+              f"rc={proc.returncode} findings={sg}")
+
+        proc_strict = run_cli(str(root), '--json', '--strict')
+        ok_strict = proc_strict.returncode == 1
+        check("CLI: --strict turns the splash-groups warning into exit 1", ok_strict,
+              f"rc={proc_strict.returncode}")
+
+
+def test_cli_splash_groups_skipped_for_older_build() -> None:
+    """A pre-2026.1 build has no splash_groups lookup, so the check must not fire."""
+    with CopyOfGood() as root:
+        splash = root / 'splash.html'
+        _write(splash, _read(splash).replace('id="splash_groups"', 'id="legacy_splash_image"'))
+        os.remove(root / 'scripts' / 'page.js')
+        proc = run_cli(str(root), '--json', '--strict')
+        data = json.loads(proc.stdout)
+        sg = _checks_present(data['findings'], 'splash-groups-container')
+        ok = proc.returncode == 0 and not sg
+        check("CLI: older build (no splash_groups in page.js) is not flagged", ok,
+              f"rc={proc.returncode} findings={sg}")
+
+
 def test_cli_missing_index() -> None:
     tmp = Path(tempfile.mkdtemp(prefix='lint-output-empty-'))
     try:
@@ -374,6 +418,9 @@ def main() -> int:
         test_cli_older_build_omits_lx_chunk,
         test_cli_missing_content_dir,
         test_cli_missing_asset_warns,
+        test_build_renders_splash_groups,
+        test_cli_splash_groups_missing_container,
+        test_cli_splash_groups_skipped_for_older_build,
         test_cli_missing_index,
         test_cli_not_a_directory,
     ]

--- a/plugins/webworks-agent-skills/skills/reverb2/workflows/output-linting.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/workflows/output-linting.md
@@ -19,9 +19,12 @@ cheap *static* counterpart to the browser test (intake item 1), which is the
 *runtime* confirmation.
 
 Reach for it especially when output is **assembled from more than one build** —
-the Reverb-on-S3 "deploy set" model, a manifest splice, a hand-edit, or any
+federated parcel composition, a manifest splice, a hand-edit, or any
 pretty-printer/formatter run over the HTML. Those are exactly the situations
-that produce the breakages below.
+that produce the breakages below. (When the assembly *is* a composed mirror,
+read `references/federation-architecture.md` § "Linting a composed mirror"
+first — mixed GroupIDs and mixed generation hashes across parcels are correct
+there, not defects.)
 
 ## Step 1: Point It at the Output Directory
 
@@ -45,9 +48,10 @@ Flags:
 | Check | Severity | Breakage | Fix |
 |-------|----------|----------|-----|
 | `self-closed-element` | error | A non-void element written in XML self-closing form (`<script/>`, `<iframe/>`, `<div/>`, `<span/>`, `<ul/>`, …). In `text/html` the `/` is ignored, so the element parses as *open* and swallows the rest of the document. The first page never renders and there is **no** console error. (Trac #2792.) | Re-emit the element with a real close tag (`<div></div>`). Usually caused by an XML/XHTML formatter run over the output — stop pretty-printing the HTML, or use an HTML-aware formatter. Void elements (`<meta/>`, `<link/>`, `<br/>`, …) and `<svg>`/`<math>` foreign content are exempt. |
-| `manifest-parcel-groupid` | error | A parcel's own GroupID disagrees with what the `#parcels` manifest binds. `connect.js` reads `id.split(':')[1]` from each anchor `<a id="<ctx>:<GID>" href="<Name>.html">`, fetches `<Name>.html`, and looks up `toc:<GID>`/`data:<GID>`/`page:<GID>:first` inside it. On a mismatch every lookup returns null, the parcel never attaches, and the spinner hangs. | Rebuild the parcel and the manifest entry from the **same** GroupID, or rewrite the manifest anchor's GroupID to match the parcel (this is what a correct deploy-set assembler does — splice by GroupID). The linter also flags a `<li id="group:<GID>">`-vs-anchor desync within the manifest itself. |
+| `manifest-parcel-groupid` | error | A parcel's own GroupID disagrees with what the `#parcels` manifest binds. `connect.js` reads `id.split(':')[1]` from each anchor `<a id="<ctx>:<GID>" href="<Name>.html">`, fetches `<Name>.html`, and looks up `toc:<GID>`/`data:<GID>`/`page:<GID>:first` inside it. On a mismatch every lookup returns null, the parcel never attaches, and the spinner hangs. | Rebuild the parcel and the manifest entry from the **same** GroupID, or rewrite the manifest anchor's GroupID to match the parcel (this is what a correct assembler does — splice by GroupID; federated parcel composition splices each parcel's own manifest fragment byte-for-byte, which is why it never produces this). The linter also flags a `<li id="group:<GID>">`-vs-anchor desync within the manifest itself. |
 | `parcel-deploy-unit` | error | A manifest parcel `<Name>` is missing a deploy-unit member. | Deploy the whole unit together: `<Name>.html` (the manifest href) and the `<Name>/` content directory are always required; the runtime chunks `<Name>_ix.html`/`<Name>_lx.js`/`<Name>_sx.js` are required when the build's `scripts/connect.js` fetches them (older builds omit `_lx.js`, search-off builds omit `_sx.js`). A parcel is **not** a single self-contained folder. |
 | `reference-integrity` | warn | A local `scripts/`/`css/` asset referenced by `index.html` is missing on disk. | Deploy the referenced asset, or fix the reference. Remote (`http(s)://`, `//`) and `data:` references are not checked. |
+| `splash-groups-container` | warn | `splash.html` has no `id="splash_groups"` element, but this build's `scripts/page.js` renders the Groups Grid into it. `Page.SplashGroupsRender` returns early, so the splash comes up empty with no console error. (ePublisher 2026.1, EPUB2907.) | Usually a **pre-2026.1 `Splash.asp` override carried through an upgrade** — re-base it on the current `Splash.asp`, or add the `<nav id="splash_groups" class="ww_skin_splash_groups">` container back. Ignore it if the project deliberately replaced the splash design. The check is skipped entirely when `page.js` has no `splash_groups` lookup, so pre-2026.1 output is never flagged. |
 
 The self-closed scan covers `index.html`, the root shell pages (`search.html`,
 `splash.html`, `not-found.html`), and each parcel's `<Name>.html` and
@@ -126,7 +130,7 @@ New known-breakage checks are added to `scripts/lint-output.py` as they are
 discovered — write a `check_*` function that appends `Finding` objects, call it
 from `lint()`, and add a fixture-mutation scenario to
 `tests/verify-lint-output.py`. The GroupID-consistency check, for example, came
-straight out of a real Reverb-on-S3 deploy-set assembly bug.
+straight out of a real multi-build assembly bug in a Reverb site hosted on S3.
 </process>
 
 <success_criteria>

--- a/plugins/webworks-agent-skills/skills/reverb2/workflows/scss-theming.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/workflows/scss-theming.md
@@ -4,8 +4,9 @@
 
 <required_reading>
 Read before proceeding:
-- `references/scss-architecture.md` — three-layer model, color cascade, `$theme_` convention
+- `references/scss-architecture.md` — theming layers, the `custom.scss` seam, color cascade, `$theme_` convention
 - `../epublisher/references/file-resolver-guide.md` — override hierarchy and parallel structure rules
+- `references/runtime-rendered-ui.md` — only when the request touches the splash page or the Assistant avatar (2026.1+): those surfaces are built at runtime, so styling them means `$splash_groups_*` / `ww_skin_assistant_avatar*`, not template edits
 </required_reading>
 
 <process>
@@ -18,8 +19,10 @@ Ask the user what they want to customize, then route to the correct layer:
 |---------|-------|---------|
 | "Change brand colors" | 1 — Variable overrides | Step 2, then Step 3 |
 | "Adjust font sizes / spacing" | 1 — Variable overrides | Step 2, then Step 3 |
-| "Customize toolbar / TOC / navigation look" | 2 — Skin CSS | Step 2, then Step 4 |
-| "Style content page elements" | 3 — Content page CSS | Step 2, then Step 5 |
+| "Add custom CSS rules" (2026.1+) | 2 — `custom.scss` | Step 2, then Step 3B |
+| "Customize toolbar / TOC / navigation look" | 2a — Skin CSS | Step 2, then Step 3B, then Step 4 if needed |
+| "Style content page elements" | 2b — Content page CSS | Step 2, then Step 3B, then Step 5 if needed |
+| "Restyle the splash page" (2026.1+) | 1 + 2 | Step 2, then `references/runtime-rendered-ui.md` § "Splash Groups Grid" |
 | "Show current theme values" | — | Step 2 (extract only) |
 | "Migrate .weplugin skin" | — | Step 2, then Step 6 |
 
@@ -119,9 +122,54 @@ The same copy-and-edit pattern applies to all partials (`_colors.scss`, `_sizes.
 
 Skip to **Step 7** after editing.
 
-## Step 4: Layer 2 — Skin CSS Overrides
+## Step 3B: Layer 2 — `custom.scss` (ePublisher 2026.1+, preferred)
 
-Use when SCSS variables are insufficient and structural CSS changes are needed for the chrome (toolbar, TOC, navigation, breadcrumbs, popups). For why this is split from content-page overrides, see `references/scss-architecture.md` § "Why Two Custom Partials, Not One".
+Use when SCSS variables are insufficient and structural CSS is needed — chrome or content, either one. On 2026.1+ Reverb 2.0 this is the seam to reach for first. **Check the build first:** if the installed format has no `Pages/sass/custom.scss`, the project is on a pre-2026.1 build — use Step 4 / Step 5 instead.
+
+### 1. Copy `custom.scss` to the project
+
+```bash
+cp "[Install]/Formats/WebWorks Reverb 2.0/Pages/sass/custom.scss" \
+   "[Override]/Pages/sass/custom.scss"
+```
+
+The copy **replaces** the stock file entirely. Keep its `@import` block (`functions`, `colors`, `fonts`, `icons`, `sizes`, `borders`) — dropping it breaks every skin-variable reference in your own rules.
+
+### 2. Add rules below the imports
+
+```scss
+@import "functions";
+@import "colors";
+@import "fonts";
+@import "icons";
+@import "sizes";
+@import "borders";
+
+// Chrome — scope with .ww_skin_*
+.ww_skin_search_input {
+  width: 300px;
+}
+
+// Content page
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+@media print {
+  .ww_skin_page_toolbar { display: none; }
+}
+```
+
+No entry point to copy and no import hook to add — `css/custom.css` is already linked **last** by `Connect.asp`, `Page.asp`, `Splash.asp`, `NotFound.asp`, `Popup.asp`, and `Search.asp`, so these rules win equal-specificity contests against every stock sheet on every page type.
+
+**Scope your selectors.** `custom.css` loads after **both** `webworks.css` and `skin.css`, so a bare `a { }` rule here reaches chrome links too — the boundary the `_custom-skin.scss` / `_custom-webworks.scss` split enforces by sheet order does not exist in this one file.
+
+Skip to **Step 7** after editing.
+
+## Step 4: Layer 2a — Skin CSS Overrides (pre-2026.1, or when cascade depth matters)
+
+Use when SCSS variables are insufficient and structural CSS changes are needed for the chrome (toolbar, TOC, navigation, breadcrumbs, popups) — on a pre-2026.1 build, in a project that already wires this partial, or when a rule must stay inside `skin.css`'s cascade depth. For why this is split from content-page overrides, see `references/scss-architecture.md` § "Why Two Custom Partials, Not One".
 
 ### 1. Copy `skin.scss` to the project
 
@@ -154,9 +202,9 @@ cp "[Install]/Formats/WebWorks Reverb 2.0/Pages/sass/skin.scss" \
 
 Skip to **Step 7** after editing.
 
-## Step 5: Layer 3 — Content Page CSS Overrides
+## Step 5: Layer 2b — Content Page CSS Overrides (pre-2026.1, or when cascade depth matters)
 
-Use when customizing the content page inside the iframe (fonts, links, tables, mini-TOC, code blocks). Keep `a { }`, paragraph, and table rules here — putting them in `_custom-skin.scss` would incorrectly elevate their cascade specificity. See `references/scss-architecture.md` § "Why Two Custom Partials, Not One".
+Use when customizing the content page inside the iframe (fonts, links, tables, mini-TOC, code blocks) via the partial route. Keep `a { }`, paragraph, and table rules here — putting them in `_custom-skin.scss` would incorrectly elevate their cascade specificity. See `references/scss-architecture.md` § "Why Two Custom Partials, Not One".
 
 ### 1. Copy `webworks.scss` to the project
 
@@ -228,7 +276,7 @@ See `references/scss-architecture.md` § "Removing Redundant Overrides" for the 
 Confirm to user:
 ```
 Theme customization applied:
-- Layer: {1/2/3}
+- Layer: {1 / 2 (custom.scss) / 2a (skin) / 2b (content)}
 - Override level: {target-specific / format-level}
 - Files modified: {list}
 - Status: Ready to rebuild (or already rebuilt)
@@ -242,7 +290,8 @@ This workflow is complete when:
 - [ ] Override level determined (target vs format)
 - [ ] Override files created at correct location with parallel structure
 - [ ] `$theme_` naming convention used for custom variables (Layer 1)
-- [ ] Import hooks added to copied entry points (Layers 2–3)
+- [ ] For Layer 2 (`custom.scss`): the `@import` block was preserved and selectors are scoped (chrome vs content)
+- [ ] Import hooks added to copied entry points (Layers 2a–2b only)
 - [ ] User informed of next steps (rebuild)
 - [ ] Build completes without SCSS errors (if rebuild performed)
 - [ ] Redundant override files deleted if they match installed defaults


### PR DESCRIPTION
Closes #142.

Back-fills the 2026.1 feature set (federated parcel composition, Designer/Express convergence, Reverb runtime UI) into the three skills, fixes the five bugs the issue front-loaded, and adds `.wacj` tooling support. Every behavioral claim was verified against the product trunk or the epublisher-docs sources — several issue claims were corrected along the way (see below).

## Bugs (first commit)

- `Invoke-Automap.ps1` composition-log scan now matches the markers the product actually writes (`[WARN]`/`[ERROR]`, verified in `Messages.resx`); previously composition warnings were silently dropped. New composition-log fixtures + test driver.
- Deploy-intent detection now includes `--destination` and `--dryrun`, so they no longer trigger the injected `-n` that suppressed the deploy the caller asked for.
- Doc corrections: `.wrp` = Express (not Report) project; destinations are per-user/per-machine (`deploy.prefs`), not machine-global; "open project in ePublisher Administrator" troubleshooting advice replaced with Designer/Express.

## automap skill

- Federated vs. derivative members keyed on the `build` flag, with the verified forwarded-switch table (`--target`/`--destination`/`--deployscope`/`--deploysettings`/`--dryrun`).
- New determinant output-target selection section (`Jobs/@target`, per-`Job` override, auto-detect rules) with shipped error strings quoted verbatim.
- `--destination` and `-q`/`--quiet` documented; per-job Build options (`<Options skipReports verboseLogging>`) with the OR/AND combine rules and wrapper implications.
- Administrator 2026.1 parity: composition editor, `Edit > Deploy Destinations`, job-level destination definitions and the `(not defined on this computer)` label semantics, Preview Output in Browser (three-rung S3 URL derivation).
- Scheduled-jobs rewrite: version-independent launcher, `Last Run Result` codes, the direct-CLI example removed.
- Log semantics: composition relay rule, missing-job-target hard error, localized-marker caveat.
- Stale sweep: version-agnostic install paths, `.waj`/`.wacj` input table, exit-code table ownership, footer stamps.
- **`.wacj` tooling**: new `lib/wacj.py` grammar module; `parse-job.py`, `validate-job.py` (`--check-members`), `list-job-targets.py`, `create-job.py` (`--composition`) all accept `.wacj`; Merge Settings modes reported with the Administrator's labels (`automatic`/`custom`/`custom+include-new`); federation and defect-catalogue fixtures; new 73-assertion test suite.

## epublisher skill

- Designer/Express convergence (EPUB2885): Designer opens/builds/synchronizes/deploys `.wrp` with the Express experience; `File > New Project from Stationery`; double-click arbitration.
- Save as Express Project (EPUB2905) and a new "Origin and Synchronization" reference section: `<Origin>` element shape, sync triggers (checksum + 4-hour tolerance), what is not synchronized, origin-type trade-offs, master/satellite topology.
- Corrected a pre-existing error: `.base` snapshot presence follows the staging **origin**, not the project file extension.
- `.wxsp` open behavior (EPUB2909), Style Designer multi-select (EPUB2913), and 2026.1 rows in `version-compatibility.md`.

## reverb2 skill

- Placement precedence (EPUB2857) and "Containers are not groups" (EPUB2883) sections in `federation-architecture.md`, with shipped diagnostics quoted verbatim.
- New `references/runtime-rendered-ui.md`: splash Groups Grid (EPUB2907) and Assistant avatar (EPUB2911) — runtime-built DOM, `$splash_groups_*` variables, security/escaping behavior, upgrade hazard for `splash.png` overrides.
- `custom.scss` seam (EPUB2908) documented and reconciled with the older two-partial convention in the epublisher skill (both remain valid, trade-offs stated).
- New `splash-groups-container` lint check, gated on the build's own `page.js` so pre-2026.1 output is never flagged.
- Terminology sweep: "Reverb-on-S3 deploy-set model" → federated parcel composition.

## Issue claims corrected during verification

- `--deployscope=shell` on a `.wacj` is **parsed and silently ignored**, not invalid; documented as a which-options-apply table.
- `.wep`/`.wrp` members claim was correct as written (shipped docs' `.waj`-or-`.wep` shorthand is the developer guide only).
- The non-compose-capable error wording differs from the issue's quote; shipped text used.
- Container diagnostics live in `CompositionEngine.cs` (EPUB2883), not `CompositionJobRunner.cs`.
- The stock `custom.scss` does **not** carry the splash-grid design — it is an empty seam; the grid lives in `skin.scss`/`webworks.scss`.
- Save as Express Project gives documents **fresh identities** (the issue was right; ticket 2905's "preserve DocumentIDs" is stale relative to shipped code).
- Preview Output's CloudFront rung is verified by the authenticated `GetDistribution` call, not a HEAD probe.

## Tests

All local suites green: `test-wacj-tools.ps1` 73, `test-wrapper-args.ps1` 39, `test-log-scan.ps1` 8, `verify-lint-output.py` 29, `verify-landmark-resolver.py` 130, `check-python-utf8.py` OK.

Tickets 2885, 2905, 2907, 2908, 2909, 2911, 2913 are still in testing status; everything is phrased as 2026.1 behavior with no GA claims.

Version bumped to 3.8.0 (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
