### PR TITLE
Closes #144: match localized log markers in the wrapper's post-build scan

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "webworks-agent-skills",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "owner": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/.claude-plugin/plugin.json
+++ b/plugins/webworks-agent-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webworks-agent-skills",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "author": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/skills/automap/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/automap/SKILL.md
@@ -343,7 +343,7 @@ After a successful build (exit 0), the wrapper scans each target's `generate.log
 - Targets with non-zero counts get a one-line summary (`[WARNING]` on stdout when only warnings, `[ERROR]` on stderr when any errors). Clean targets emit nothing.
 - Exit codes are unchanged — the scan is observational. A successful build that records warnings still exits 0.
 
-**Caveat — the scan matches English markers only.** `[WARN]`/`[ERROR]` are localized: a German install writes `[WARNUNG]`/`[FEHLER]`, French `[AVERTISSEMENT]`/`[ERREUR]`, Japanese the kanji equivalents. The scan's patterns are hard-coded English, so on a non-English install it reports 0/0 for logs that are full of marked lines. **Do not read a zero count on such a machine as a clean build** — check the exit code, or grep the log for the console's own tokens.
+**The scan matches the shipped localized markers.** `[WARN]`/`[ERROR]` are localized, and the scan covers every spelling ePublisher ships: German `[WARNUNG]`/`[FEHLER]`, French `[AVERTISSEMENT]`/`[ERREUR]`, Japanese `[警告]`/`[エラー]`. An install language with no translated resources falls back to the English markers, which the scan also matches, so counts are trustworthy on any install.
 
 For a `.wacj`, the scanned `<job name>-log.txt` also contains **relayed member-build lines** that keep their markers. Those belong to the member's own ledger, so the wrapper's count is deliberately looser than the composition's own closing tally — see references/composition-jobs.md.
 

--- a/plugins/webworks-agent-skills/skills/automap/references/cli-reference.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/cli-reference.md
@@ -299,7 +299,7 @@ grep -nE '\[ERROR\]|\[WARN\]' "<project-or-staging>/Logs/<target>/generate.log"
 
 The patterns below are the tokens used in `generate.log` and AutoMap's console output.
 
-> **Markers are localized.** `[WARN]` / `[ERROR]` are the *English-install* spellings. The same resources drive every log in the product, so a German install writes `[WARNUNG]` / `[FEHLER]`, a French one `[AVERTISSEMENT]` / `[ERREUR]`, and a Japanese one the kanji equivalents. The wrapper's post-build scan matches the English tokens only, so on a non-English install its per-target counts read 0 even when the log is full of marked lines. On such a machine, grep for the console's own tokens, or fall back to the process exit code. (2026.1 extended the same markers from `generate.log` to the job and composition logs.)
+> **Markers are localized.** `[WARN]` / `[ERROR]` are the *English-install* spellings. The same resources (Publish Core `Messages.resx`, keys `Warn`/`Error`) drive every log in the product, so a German install writes `[WARNUNG]` / `[FEHLER]`, a French one `[AVERTISSEMENT]` / `[ERREUR]`, and a Japanese one `[警告]` / `[エラー]`. The wrapper's post-build scan matches all four spellings of each severity, so its per-target counts are correct on any install; a language with no translated resources falls back to the English tokens, which the scan also matches. A hand-written `grep` still needs the local spelling — use the pattern for the install's language. The scan does **not** count `[FATAL]` (German `[UNBEHEBBAR]`, French `[IRRÉCUPPÉRABLE]`, Japanese `[致命的]`); a fatal failure surfaces as a non-zero exit code instead. (2026.1 extended the same markers from `generate.log` to the job and composition logs.)
 
 ### Error Patterns
 

--- a/plugins/webworks-agent-skills/skills/automap/scripts/Invoke-Automap.ps1
+++ b/plugins/webworks-agent-skills/skills/automap/scripts/Invoke-Automap.ps1
@@ -59,6 +59,31 @@ Set-StrictMode -Version 2.0
 $script:ProjectExtensionPattern = '\.(wep|wrp|waj|wacj|wxsp)$'
 $script:DefaultStagingRoot = Join-Path $env:USERPROFILE 'Documents\WebWorks ePublisher AutoMap\Staging'
 
+# Severity markers the product stamps on log lines. Publish Core localizes
+# them (Core/Resources/Messages.resx plus its .de/.fr/.ja satellites, keys
+# Warn/Error), and the satellites ship with every install, so matching the
+# English tokens alone reports a false 0/0 on a localized machine. Both scan
+# sites share these sets. Each token carries its closing bracket, so '[WARN]'
+# cannot also match inside '[WARNUNG]'.
+#
+# The Japanese tokens are built from character codes rather than written as
+# literals: this file has no BOM, and Windows PowerShell 5.1 parses a BOM-less
+# script in the host's ANSI codepage, which would mangle literal kanji.
+$script:WarnMarkers = @(
+    '[WARN]',                                                # en
+    '[WARNUNG]',                                             # de
+    '[AVERTISSEMENT]',                                       # fr
+    ('[' + [char]0x8B66 + [char]0x544A + ']')                # ja
+)
+$script:ErrorMarkers = @(
+    '[ERROR]',                                               # en
+    '[FEHLER]',                                              # de
+    '[ERREUR]',                                              # fr
+    ('[' + [char]0x30A8 + [char]0x30E9 + [char]0x30FC + ']') # ja
+)
+$script:WarnMarkerPattern = (($script:WarnMarkers | ForEach-Object { [regex]::Escape($_) }) -join '|')
+$script:ErrorMarkerPattern = (($script:ErrorMarkers | ForEach-Object { [regex]::Escape($_) }) -join '|')
+
 function Write-StderrLine {
     param([string]$Message)
     [Console]::Error.WriteLine($Message)
@@ -162,6 +187,25 @@ function Get-AutomapExePath {
     return $null
 }
 
+# Counts marked lines in one log file and returns @{ Warn = <n>; Error = <n> },
+# or $null when the file cannot be read. The read encoding is pinned to UTF-8
+# because that is what the product writes -- generate.log with a BOM, the
+# composition log without -- so the non-ASCII tokens do not depend on the
+# host's active codepage.
+function Get-LogMarkerCount {
+    param([string]$Path)
+
+    try {
+        return [pscustomobject]@{
+            Warn  = @(Select-String -LiteralPath $Path -Pattern $script:WarnMarkerPattern -Encoding UTF8).Count
+            Error = @(Select-String -LiteralPath $Path -Pattern $script:ErrorMarkerPattern -Encoding UTF8).Count
+        }
+    }
+    catch {
+        return $null
+    }
+}
+
 # Scans Logs/<Target>/generate.log under a base directory and returns one
 # summary object per target that has warnings or errors:
 #   @{ Text = '[WARNING] 3 warning(s), 0 error(s) in Logs/T/generate.log'; IsError = $false }
@@ -174,15 +218,10 @@ function Get-GenerateLogSummaries {
     if (-not (Test-Path -LiteralPath $logsRoot -PathType Container)) { return $summaries }
 
     foreach ($logFile in Get-ChildItem -Path (Join-Path $logsRoot '*\generate.log') -ErrorAction SilentlyContinue | Sort-Object FullName) {
-        $warnCount = 0
-        $errorCount = 0
-        try {
-            $warnCount = @(Select-String -LiteralPath $logFile.FullName -Pattern '[WARN]' -SimpleMatch).Count
-            $errorCount = @(Select-String -LiteralPath $logFile.FullName -Pattern '[ERROR]' -SimpleMatch).Count
-        }
-        catch {
-            continue
-        }
+        $counts = Get-LogMarkerCount -Path $logFile.FullName
+        if (-not $counts) { continue }
+        $warnCount = $counts.Warn
+        $errorCount = $counts.Error
         if (($warnCount -eq 0) -and ($errorCount -eq 0)) { continue }
 
         # Display path relative to the base directory, forward slashes.
@@ -219,15 +258,10 @@ function Get-CompositionLogSummary {
     $logFile = Join-Path $dir "$jobName-log.txt"
     if (-not (Test-Path -LiteralPath $logFile -PathType Leaf)) { return $null }
 
-    $warnCount = 0
-    $errorCount = 0
-    try {
-        $warnCount = @(Select-String -LiteralPath $logFile -Pattern '[WARN]' -SimpleMatch).Count
-        $errorCount = @(Select-String -LiteralPath $logFile -Pattern '[ERROR]' -SimpleMatch).Count
-    }
-    catch {
-        return $null
-    }
+    $counts = Get-LogMarkerCount -Path $logFile
+    if (-not $counts) { return $null }
+    $warnCount = $counts.Warn
+    $errorCount = $counts.Error
     if (($warnCount -eq 0) -and ($errorCount -eq 0)) { return $null }
 
     $isError = ($errorCount -gt 0)

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-localized/Product Docs-log.txt
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-localized/Product Docs-log.txt
@@ -1,0 +1,8 @@
+Composition job 'Product Docs' started at 9:22:44 AM, 2026-03-11.
+Running WebWorks ePublisher AutoMap version 2026.1.0.
+[警告] メンバー 'api-guide' は宛先 'Staging' にデプロイします。
+Member 'shell': output target 'WebWorks Reverb 2.0'.
+[エラー] 宛先 'ProductionMirror' が定義されていません。
+Composition job 'Product Docs' finished at 9:22:46 AM, 2026-03-11.
+Total time: 00:00:02.
+0 group(s) composed, 1 warning(s), 1 error(s) reported.

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-localized/composition.wacj
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-localized/composition.wacj
@@ -1,0 +1,7 @@
+<CompositionJob name="Product Docs" version="1.0">
+  <Jobs target="WebWorks Reverb 2.0">
+    <Job path="shell.waj" role="shell"/>
+    <Job path="api-guide.waj" role="member"/>
+  </Jobs>
+  <Destination name="ProductionMirror"/>
+</CompositionJob>

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-localized/expected-default.txt
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/composition-localized/expected-default.txt
@@ -1,0 +1,1 @@
+[ERROR] 1 warning(s), 1 error(s) in Product Docs-log.txt

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/localized-targets/Logs/DE/generate.log
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/localized-targets/Logs/DE/generate.log
@@ -1,0 +1,7 @@
+﻿Generation started at 9:07:01 PM, 2026-02-11.
+Running WebWorks ePublisher AutoMap version 2026.1.0.
+[WARNUNG] Projekt verwendet die veraltete Formatversion '2024.1'.
+Processing pipeline 'DE', 1 of 1.
+[FEHLER] Ausgabedatei konnte nicht erstellt werden.
+Generation finished at 9:07:42 PM, 2026-02-11.
+Total time: 00:00:41.

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/localized-targets/Logs/FR/generate.log
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/localized-targets/Logs/FR/generate.log
@@ -1,0 +1,7 @@
+﻿Generation started at 9:02:53 PM, 2026-02-11.
+Running WebWorks ePublisher AutoMap version 2026.1.0.
+[AVERTISSEMENT] Le projet utilise la version de format héritée '2024.1'.
+Processing pipeline 'FR', 1 of 1.
+[AVERTISSEMENT] Alias de rubrique Stationery remplacé.
+Generation finished at 9:03:35 PM, 2026-02-11.
+Total time: 00:00:41.

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/localized-targets/Logs/JA/generate.log
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/localized-targets/Logs/JA/generate.log
@@ -1,0 +1,7 @@
+﻿Generation started at 9:04:01 PM, 2026-02-11.
+Running WebWorks ePublisher AutoMap version 2026.1.0.
+[警告] フォーマットバージョン '2024.1' を使用しています。
+Processing pipeline 'JA', 1 of 1.
+[エラー] 出力ファイルを作成できません。
+Generation finished at 9:04:42 PM, 2026-02-11.
+Total time: 00:00:41.

--- a/plugins/webworks-agent-skills/skills/automap/tests/fixtures/localized-targets/expected-default.txt
+++ b/plugins/webworks-agent-skills/skills/automap/tests/fixtures/localized-targets/expected-default.txt
@@ -1,0 +1,3 @@
+[ERROR] 1 warning(s), 1 error(s) in Logs/DE/generate.log
+[WARNING] 2 warning(s), 0 error(s) in Logs/FR/generate.log
+[ERROR] 1 warning(s), 1 error(s) in Logs/JA/generate.log

--- a/plugins/webworks-agent-skills/skills/automap/tests/test-log-scan.ps1
+++ b/plugins/webworks-agent-skills/skills/automap/tests/test-log-scan.ps1
@@ -97,6 +97,16 @@ Test-Fixture 'mixed-target' `
     (Join-Path $fixtures 'mixed-target') `
     (Join-Path $fixtures 'mixed-target\expected-default.txt')
 
+# Localized installs: Publish Core translates the markers it writes (de
+# [WARNUNG]/[FEHLER], fr [AVERTISSEMENT]/[ERREUR], ja the kanji pair), so an
+# English-only scan would report a false 0/0 here. The German log also pins
+# the token boundary: '[WARN]' must not also match inside '[WARNUNG]', or the
+# warning count would read 2. Logs are UTF-8 with a BOM, as the product writes
+# generate.log.
+Test-Fixture 'localized-targets' `
+    (Join-Path $fixtures 'localized-targets') `
+    (Join-Path $fixtures 'localized-targets\expected-default.txt')
+
 # Missing Logs/ directory emits nothing.
 Test-Fixture 'no-logs-dir' `
     (Join-Path $fixtures 'no-logs-dir') `
@@ -118,6 +128,13 @@ Test-CompositionFixture 'composition-warning' `
 Test-CompositionFixture 'composition-mixed' `
     (Join-Path $fixtures 'composition-mixed\composition.wacj') `
     (Join-Path $fixtures 'composition-mixed\expected-default.txt')
+
+# Localized composition log: same marker set as generate.log, but this log is
+# written without a BOM (FileInfo.CreateText()), so it also covers reading
+# non-ASCII markers out of a BOM-less UTF-8 file.
+Test-CompositionFixture 'composition-localized' `
+    (Join-Path $fixtures 'composition-localized\composition.wacj') `
+    (Join-Path $fixtures 'composition-localized\expected-default.txt')
 
 Write-Output ''
 Write-Output "Results: $($script:Pass) passed, $($script:Fail) failed"


### PR DESCRIPTION
Closes #144.

`Invoke-Automap.ps1`'s post-build log scan matched only the literal English `[WARN]`/`[ERROR]` markers, so German, French, and Japanese installs read 0 warnings / 0 errors for logs full of marked lines — a silent false-clean.

- Marker tokens were grounded in the **shipped satellite assemblies** (`{de,fr,ja}\WebWorks.Publish.Core.resources.dll`), not just trunk resx: de `[WARNUNG]`/`[FEHLER]`, fr `[AVERTISSEMENT]`/`[ERREUR]`, ja `[警告]`/`[エラー]`.
- Both scan sites now share a `Get-LogMarkerCount` helper using one escaped regex alternation per severity. Output format and exit codes are unchanged.
- Read encoding pinned to UTF-8 — the product writes `generate.log` with a BOM but the composition log without one, and ANSI-codepage decoding mangles the kanji tokens exactly on the machines this fix targets.
- The `.ps1` stays pure ASCII (no BOM): Japanese tokens are built from `[char]` codes so Windows PowerShell 5.1's ANSI parsing of BOM-less scripts can't corrupt them.
- New fixtures mirror the product's BOM behavior per log kind; the German fixture also pins the token boundary (`[WARN]` must not match inside `[WARNUNG]`).
- Suites pass on both engines: test-log-scan 10, test-wrapper-args 39, test-wacj-tools 73 (PS 5.1 and pwsh 7).

Known non-goals, recorded in #144: `[FATAL]` remains uncounted in any language (pre-existing; surfaces via exit code), and trunk `Messages.fr.resx` appears to carry a typo in the French Fatal string (`[IRRÉCUPPÉRABLE]`).

Version bumped to 3.8.1 (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
