### PR TITLE
chore: remove compound-engineering-plugin references (CLAUDE.md audit cleanup)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "webworks-agent-skills",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "owner": {
     "name": "Quadralay Corporation",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,65 +1,23 @@
 # CLAUDE.md
 
-## Workflow Commands
+## Behavioral Rules
 
-This project uses workflow commands from [compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin).
+### Version bump before PR
 
-### Plan
-
-Use `/workflows:plan` to create implementation plans:
-
-1. `/workflows:plan <description>` creates `plans/<name>.md`
-2. Review and refine the plan locally
-3. Create GitHub issue from plan (select "Create GitHub Issue" option)
-4. Delete local plan file after issue creation
-
-**Single source of truth:** Once a plan becomes a GitHub issue, the issue is authoritative. Local plan files are temporary working documents.
-
-### Work
-
-Use `/workflows:work` to implement from an issue:
-
-1. `/workflows:work <issue number or URL>`
-2. Creates feature branch from main
-3. Implements changes following the plan
-4. Commits and creates PR linking to issue
-
-### Review
-
-Use `/workflows:review` for code review:
-
-1. `/workflows:review` (on PR branch) or `/workflows:review <PR number>`
-2. Runs parallel review agents (simplicity, patterns, security, etc.)
-3. Synthesizes findings by severity (P1/P2/P3)
-4. Offers to simplify or fix issues before merge
-
-## Version Management
-
-Bump the plugin version before creating a PR using the bump script:
+Run the bump script before creating a PR; include the bump in the PR:
 
 ```bash
-scripts/bump-version.sh patch  # 2.1.0 -> 2.1.1 (bug fixes)
-scripts/bump-version.sh minor  # 2.1.0 -> 2.2.0 (new features)
-scripts/bump-version.sh major  # 2.1.0 -> 3.0.0 (breaking changes)
+scripts/bump-version.sh [patch|minor|major]
 ```
 
-The script updates both `plugin.json` and `marketplace.json` to keep versions synchronized.
+### New Python Tools
 
-**When to bump:**
-- `patch`: Bug fixes, documentation updates, minor improvements
-- `minor`: New skills, new features, enhancements
-- `major`: Breaking changes, major restructuring
+Create new skill Python tools by copying `templates/skill-python-tool.py` — it bakes in the UTF-8 conventions that Windows locale codepages otherwise break. Rules in CONTRIBUTING.md "New Python Tools".
 
-**Workflow:**
-1. Make your changes
-2. Run `scripts/bump-version.sh <type>`
-3. Include the version bump in your PR
-4. Merge PR - version is already updated
+### Plans vs. Issues
 
-## New Python Tools
-
-Create new skill Python tools by copying `templates/skill-python-tool.py` — it bakes in the UTF-8 conventions (stdio reconfigure, `PYTHONUTF8` for children, explicit encodings on file and subprocess I/O) that Windows locale codepages otherwise break. Rules in CONTRIBUTING.md "New Python Tools".
+Once a plan becomes a GitHub issue, the issue is authoritative; local plan files are temporary working documents. Convention: `docs/solutions/plan-documents-workflow.md`.
 
 ## Documented Solutions
 
-`docs/solutions/` — documented solutions to past problems (bugs, best practices, workflow patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in documented areas.
+`docs/solutions/` — documented solutions to past problems (bugs, best practices, workflow patterns). Consult when implementing or debugging in documented areas.

--- a/docs/solutions/plan-documents-workflow.md
+++ b/docs/solutions/plan-documents-workflow.md
@@ -99,7 +99,7 @@ Plans in `plans/` are valid artifacts when:
 
 ## Current Convention (2026)
 
-The repository now uses `docs/plans/` for new plan files, with date-prefixed names like `YYYY-MM-DD-NNN-{type}-{description}-plan.md` (e.g., `2026-05-22-001-feat-humanizer-auto-detection-plan.md`). Plans are created via `/workflows:plan` and retained alongside the GitHub issues they spawn — the issue is the canonical problem statement, and the plan stays as historical context. The legacy `plans/` directory still holds pre-2026 plans (flat names, e.g., `add-skip-reports-option.md`); they remain as archive but new work goes under `docs/plans/`.
+The repository now uses `docs/plans/` for new plan files, with date-prefixed names like `YYYY-MM-DD-NNN-{type}-{description}-plan.md` (e.g., `2026-05-22-001-feat-humanizer-auto-detection-plan.md`). Plans are retained alongside the GitHub issues they spawn — the issue is the canonical problem statement, and the plan stays as historical context. The legacy `plans/` directory still holds pre-2026 plans (flat names, e.g., `add-skip-reports-option.md`); they remain as archive but new work goes under `docs/plans/`.
 
 ## Related
 

--- a/docs/solutions/plan-documents-workflow.md
+++ b/docs/solutions/plan-documents-workflow.md
@@ -99,10 +99,9 @@ Plans in `plans/` are valid artifacts when:
 
 ## Current Convention (2026)
 
-The repository now uses `docs/plans/` for new plan files, with date-prefixed names like `YYYY-MM-DD-NNN-{type}-{description}-plan.md` (e.g., `2026-05-22-001-feat-humanizer-auto-detection-plan.md`). Plans are retained alongside the GitHub issues they spawn — the issue is the canonical problem statement, and the plan stays as historical context. The legacy `plans/` directory still holds pre-2026 plans (flat names, e.g., `add-skip-reports-option.md`); they remain as archive but new work goes under `docs/plans/`.
+Plan files are no longer retained in the repository. A plan is a temporary local working document; once it becomes a GitHub issue, the issue is the canonical problem statement and the local plan file is deleted. The earlier conventions — merged plans in `plans/`, then date-prefixed plans in `docs/plans/` — were retired when the retained plans were removed as process artifacts (commit 8d76cc8).
 
 ## Related
 
-- PR #17: Added `plans/README.md` establishing the workflow
-- `plans/add-skip-reports-option.md`: Example of a kept legacy plan
-- `docs/plans/`: current location for date-prefixed plans
+- PR #17: Added `plans/README.md` establishing the original workflow (file since removed)
+- Commit 8d76cc8: removed retained plans from `plans/` and `docs/plans/`

--- a/plugins/webworks-agent-skills/.claude-plugin/plugin.json
+++ b/plugins/webworks-agent-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webworks-agent-skills",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "author": {
     "name": "Quadralay Corporation",


### PR DESCRIPTION
## Summary

Cleanup PR from a `claude-md-audit` pass, prompted by dropping the compound-engineering-plugin:

- **CLAUDE.md** reduced 65 → 23 lines:
  - Removed the Workflow Commands section — the plugin is no longer used, and its `/workflows:plan|work|review` command names no longer resolve anyway.
  - Trimmed Version Management to the bump command plus the before-PR rule (semver explanations are printed by the script's own usage output).
  - Rescued the durable rule from the removed section as a one-liner: once a plan becomes a GitHub issue, the issue is authoritative (links to `docs/solutions/plan-documents-workflow.md`).
  - Kept the New Python Tools UTF-8 rule and the `docs/solutions/` pointer.
- **docs/solutions/plan-documents-workflow.md**: dropped the stale "created via `/workflows:plan`" phrase, then rewrote the "Current Convention (2026)" section — `docs/plans/` no longer exists and the legacy `plans/` archive was emptied in 8d76cc8, so the convention is now: plans are temporary local working documents, deleted once their GitHub issue (the canonical problem statement) exists. Related links to since-removed plan files updated to match.
- Version bumped 3.8.1 → 3.8.2 (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)