### PR TITLE
Closes #147: warn that target-only rules are silently ignored

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "webworks-agent-skills",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "owner": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/.claude-plugin/plugin.json
+++ b/plugins/webworks-agent-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webworks-agent-skills",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "author": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/skills/epublisher/references/format-traits-guide.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/references/format-traits-guide.md
@@ -136,6 +136,38 @@ Trait values can be configured at two scopes inside a `.wep`. Both scopes use th
 - **`<GlobalConfiguration>`** carries traits that apply to every target in the project. Use this for project-wide defaults — an Option on the Paragraph prototype here cascades into every target's build.
 - **`<FormatConfiguration TargetID="…">`** carries per-target overrides. The `TargetID` must match the `TargetID` on a `<Format>` element in `<Formats>`. Values placed here only apply to that one target and override anything inherited from `<GlobalConfiguration>`.
 
+> **A per-target rule must also be declared in `<GlobalConfiguration>`.** At build
+> time the engine builds its rule catalog from `<GlobalConfiguration>` only, then
+> looks up each rule's name in the target's `<FormatConfiguration>` collection for
+> override values (product source: `Core/Engine/Extension/Project.cs`,
+> `InitializeProjectRuleCollection`). A `<Rule>` that exists only inside
+> `<FormatConfiguration>` is never registered — `GetContextRule` silently falls
+> back to the category's default rule, the trait has no effect, and nothing is
+> reported in the build log. Designer-authored projects never hit this: the GUI
+> maintains the global catalog from document scans and writes Target
+> Properties/Target Options values as overrides. Hand-authored or script-edited
+> project files can. When adding a per-target rule by hand, also declare it
+> globally — an empty declaration is sufficient:
+>
+> ```xml
+> <GlobalConfiguration ChangeID="">
+>   <Rules Type="Graphic" Default="{WWDefaultRule}" ChangeID="">
+>     <Rule Key="ScaledImage" />                 <!-- declaration: registers the rule -->
+>   </Rules>
+> </GlobalConfiguration>
+> <FormatConfigurations>
+>   <FormatConfiguration TargetID="rvbDsgn001" ChangeID="">
+>     <Rules Type="Graphic" ChangeID="">
+>       <Rule Key="ScaledImage">
+>         <Options>
+>           <Option Name="scale" Value="20" Source="Explicit" />  <!-- per-target values -->
+>         </Options>
+>       </Rule>
+>     </Rules>
+>   </FormatConfiguration>
+> </FormatConfigurations>
+> ```
+
 `<FormatConfiguration>` holds more than just `<Rules>`. Its children:
 
 - `<Rules>` — per-target style rule overrides (Options and Properties), grouped by category.

--- a/plugins/webworks-agent-skills/skills/epublisher/references/format-traits-guide.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/references/format-traits-guide.md
@@ -333,6 +333,8 @@ When the `.resx` lookup is insufficient (e.g., you need to know the default valu
 
 This file is sourced from the ePublisher product source code at `dev/source/windows/dotnet/WebWorks/Publish/Core/Resources/FormatTraitInfoStrings.resx`. Update it when a new ePublisher version is released. The format is backward compatible — new entries are added but existing entries are not renamed or removed.
 
+This provenance pointer is a maintainer note, not a citation pattern to copy: it records where the vendored `.resx` copy in this directory comes from, for whoever refreshes it at release time. Product source paths are not available to skill readers, so reader-facing guidance elsewhere in these skills must cite only artifacts readers can open — installed format `.fti`/`.xsl` files, project files, and this skill's vendored copies — and state engine behavior on its own, without pointing into product source.
+
 **Note:** Settings and Options have a direct one-to-one mapping between their `.resx` UI display name and their internal `.fti` name. Properties do not — the UI organizes Properties into a hierarchical tree (e.g., `text-indent` appears under **Text > Flow > Indent**), so there is no single UI label that matches the internal name. Property internal names follow the standard CSS property naming model, so they can usually be extrapolated from the CSS property name (e.g., `font-size`, `margin-left`, `text-indent`, `color`).
 
 ## Golden Test Project

--- a/plugins/webworks-agent-skills/skills/epublisher/references/format-traits-guide.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/references/format-traits-guide.md
@@ -139,8 +139,7 @@ Trait values can be configured at two scopes inside a `.wep`. Both scopes use th
 > **A per-target rule must also be declared in `<GlobalConfiguration>`.** At build
 > time the engine builds its rule catalog from `<GlobalConfiguration>` only, then
 > looks up each rule's name in the target's `<FormatConfiguration>` collection for
-> override values (product source: `Core/Engine/Extension/Project.cs`,
-> `InitializeProjectRuleCollection`). A `<Rule>` that exists only inside
+> override values. A `<Rule>` that exists only inside
 > `<FormatConfiguration>` is never registered — `GetContextRule` silently falls
 > back to the category's default rule, the trait has no effect, and nothing is
 > reported in the build log. Designer-authored projects never hit this: the GUI


### PR DESCRIPTION
## Summary

Adds the missing engine invariant to the epublisher skill's `format-traits-guide.md` **Global vs per-target style overrides** section: the build-time rule catalog is enumerated from `<GlobalConfiguration>` only, and `<FormatConfiguration>` rules act purely as name-keyed overrides (`Core/Engine/Extension/Project.cs`, `InitializeProjectRuleCollection`). A `<Rule>` present only in a `<FormatConfiguration>` is never registered — `GetContextRule` falls back to the category default with no build-log signal.

The new warning block explains why Designer-authored projects never hit this (the GUI keeps the global catalog in sync from document scans) and shows the declare-globally / override-per-target pattern with an empty global `<Rule Key="…"/>` declaration.

Hit in practice 2026-08-03: a hand-authored support sample set a Graphic `scale` option in a target-only rule and the option silently did nothing.

Bumps plugin version to 3.8.3 (doc-only).

## Verification

- Reproduced both behaviors against a trunk debug build: target-only rule → scale ignored, image ships by-reference at original size; after adding the empty global declaration → image regenerated at the scaled size.
- `skills/epublisher/templates/project.wep` already follows the correct pattern (all rules declared globally); no template change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)