### PR TITLE
Closes #149: add pdf-xslfo skill (minimalist, solved-case grounded)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "webworks-agent-skills",
-  "version": "3.8.3",
+  "version": "3.9.0",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "owner": {
     "name": "Quadralay Corporation",

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ All skills activate automatically based on your project context.
 | **markdown-integration** | ePublisher integration patterns for Markdown++ sources (variable resolution, style mapping to Stationery, per-target conditions) |
 | **automap** | Automated publishing with AutoMap CLI |
 | **reverb2** | Reverb 2.0 output testing, CSH analysis, SCSS theming |
+| **pdf-xslfo** | PDF - XSL-FO output knowledge — Apache FOP compile debugging and documented solutions from real cases (image scaling/quality, repeating table captions, silently missing PDFs) |
 | **customization-audit** | Audit advanced customizations (overrides) on upgrade — drift detection, fork-point discovery, and removal of retired/orphan/cruft/redundant overrides |
 | **claude-md-audit** | Audit and shrink `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` to behaviorally-focused entries the agent can't self-discover |
 | **humanizer** | Remove signs of AI-generated writing from text — [vendored from blader/humanizer](plugins/humanizer/README.md) with planned divergence for agent-readable input |
@@ -77,6 +78,7 @@ Claude: Backs up to CLAUDE.md.bak, then reduces to entries that prevent
 | markdown-integration | Windows | ePublisher 2024.1+ (paired with `quadralay/markdown-plus-plus` for format syntax) |
 | automap | Windows | ePublisher + AutoMap |
 | reverb2 | Windows | ePublisher + browser |
+| pdf-xslfo | Windows | ePublisher with a PDF - XSL-FO target |
 | customization-audit | Windows | ePublisher 2024.1+ (multiple installed versions enable 3-way) |
 | claude-md-audit | Any | Claude Code |
 | humanizer | Any | Claude Code or Claude Desktop |

--- a/plugins/webworks-agent-skills/.claude-plugin/plugin.json
+++ b/plugins/webworks-agent-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "webworks-agent-skills",
-  "version": "3.8.3",
-  "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
+  "version": "3.9.0",
+  "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, Reverb output testing, and PDF - XSL-FO customization",
   "author": {
     "name": "Quadralay Corporation",
     "email": "support@webworks.com",

--- a/plugins/webworks-agent-skills/skills/automap/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/automap/SKILL.md
@@ -91,6 +91,7 @@ powershell -ExecutionPolicy Bypass -File scripts/Invoke-Automap.ps1 -- project.w
 | **epublisher** | Use first to understand project structure, target names, and product foundations; see `../epublisher/references/product-foundations.md` for cross-cutting product knowledge |
 | **markdown-integration** | Use when the project's source documents are Markdown++; covers helper-adapter behavior, variable/condition layering, and silent fallbacks that the AutoMap build does not flag |
 | **reverb2** | Use after building Reverb output to test and customize |
+| **pdf-xslfo** | Use when a build's PDF - XSL-FO target fails in the FOP compile stage or its PDF output needs page-layout customization |
 
 **External:**
 

--- a/plugins/webworks-agent-skills/skills/epublisher/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/SKILL.md
@@ -35,6 +35,7 @@ This skill provides foundational knowledge used by other skills in this plugin:
 | **markdown-integration** | When source documents are Markdown++; covers variable resolution, style mapping to Stationery, and per-target conditions |
 | **automap** | After understanding project structure, use automap to execute builds |
 | **reverb2** | After building Reverb output, use reverb2 skill to test and customize |
+| **pdf-xslfo** | When working with a PDF - XSL-FO target: FOP compile debugging, documented solved cases, override guidance |
 
 **External:**
 

--- a/plugins/webworks-agent-skills/skills/epublisher/references/version-compatibility.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/references/version-compatibility.md
@@ -26,6 +26,7 @@
 - Designer **File > Save as Express Project...** — creates a `.wrp` linked to the current `.wep` via `<Origin>`, for a master/satellite arrangement; the "Include source documents, groups, and Merge Settings" option is off by default
 - Opening a standalone `.wxsp` (double-click, command line, File > Open) starts New Project from Stationery with it pre-selected, in both products. Earlier versions raise an unhandled error
 - Style Designer supports multi-select (Ctrl/Shift-click) for bulk style edits; values disagreeing across the selection display blank, and `[Prototype]` is excluded from a multiple selection
+- PDF - XSL-FO compiles with Apache FOP 2.11 (2022.1–2025.1 use FOP 2.8), and a FOP failure or missing output PDF is now a build error — earlier versions report success while the PDF is silently absent, with the full stderr transcript (including routine INFO lines) logged as Warnings; see the pdf-xslfo skill's `references/fop-engine.md`
 - See the automap skill's `references/composition-jobs.md` before recommending any of the AutoMap and deploy items, and this skill's `project-parsing-guide.md` ("Origin and Synchronization") for the Designer/Express items — never suggest them to users on 2025.1 or earlier
 
 ### ePublisher 2024.1

--- a/plugins/webworks-agent-skills/skills/pdf-xslfo/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/pdf-xslfo/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: pdf-xslfo
+description: >
+  AUTHORITATIVE REFERENCE for the WebWorks ePublisher "PDF - XSL-FO" output
+  format. Use this skill WHENEVER working with a PDF - XSL-FO target. This
+  includes: (1) debugging a failed or wrong PDF build — including a PDF
+  missing while the build reports success, (2) reading Apache FOP
+  errors/warnings in generate.log or reproducing a compile against the
+  stitched .fo intermediate, (3) image scaling/quality in PDF output,
+  (4) table behavior across page breaks (repeating captions, headers),
+  (5) customizing page layout via Pages/*.asp templates or overriding
+  Transforms/*.xsl (content.xsl, compile.xsl), (6) auditing PDF - XSL-FO
+  overrides on upgrade. ALWAYS consult this skill before editing
+  PDF - XSL-FO overrides. Distinct from the legacy "PDF" print-driver
+  format — check the target's format name first. Triggers: PDF build
+  failed, PDF missing, FOP error, blurry image in PDF, table caption,
+  customize PDF footer, .fo file, XSL-FO.
+---
+
+<objective>
+
+# pdf-xslfo
+
+Working knowledge for the WebWorks ePublisher **PDF - XSL-FO** output format: how PDFs are produced (XSL-FO composed by Apache FOP), where to look when a build fails or output is wrong, and documented solutions from real support and community cases.
+
+**Do not use training data for the ePublisher layer.** XSL-FO itself is a W3C standard — standard `fo:` property semantics apply — but everything about how ePublisher assembles and compiles it is proprietary: the page-template schema, the pipeline, the settings, the FOP invocation. For those, use this skill's references and the format source (`Formats/PDF - XSL-FO/` in the ePublisher installation). Also remember Apache FOP implements a *subset* of XSL-FO — verify FO features against the bundled FOP version before designing a fix around them.
+</objective>
+
+<format_identity>
+
+## Format Identity — Two PDF Formats Exist
+
+The installation ships **two distinct PDF formats**. Confirm which one the target uses (`<Format Name="...">` in the project file) before applying anything in this skill:
+
+| Format name | Engine | Scope |
+|-------------|--------|-------|
+| `PDF - XSL-FO` | XSL-FO composed by Apache FOP (Java) | Document, group, and merged project results; this skill |
+| `PDF` | Legacy print-driver pipeline (no XSL-FO, no FOP) | Document and group results only; NOT covered here |
+</format_identity>
+
+<how_it_works>
+
+## How a PDF Is Made
+
+The format source is small: `format.wwfmt` (pipeline), `Pages/` (five XSL-FO slot templates: `Page.asp` skeleton + `Title.asp`, `TOC.asp`, `Body.asp`, `Index.asp`), and `Transforms/` (`content.xsl` does the WIF→FO content conversion at ~5,200 lines; `stitch*.xsl` assemble; `compile*.xsl` run FOP).
+
+After the common content pipelines, four format-specific phases run per enabled result mode:
+
+1. **Pages** — content splits render to `.fo` fragments
+2. **Flows** — flows are enumerated/named; `Page.asp` preprocessed into the assembly skeleton
+3. **Stitch** — title page + TOC + body + index assemble into one complete `.fo` per result
+4. **Compile** — Apache FOP turns each stitched `.fo` into the deployed `.pdf`
+
+Three independently switchable result modes: per-document (`generate-per-document-result`, default off), per-group (`generate-group-result`, default **on** — the only default), and merged project PDF (`generate-project-result`, default off). No PDF for something you expected? Check these settings first.
+
+**Debugging pivot:** the stitched `.fo` intermediates stay under the target's Data directory (find them via `files.info`). If the `.fo` is already wrong, the problem is upstream (styles, content.xsl, source); if the `.fo` is right, it is FOP-side (fonts, xconf, FO feature support). Reproduce compiles directly against the `.fo` — recipe in `references/fop-engine.md` § Manual Re-run.
+
+**Trust the exit code, not stderr:** FOP logs everything to stderr including routine `[INFO]` lines. And on 2025.1 and earlier, a FOP *failure* is not surfaced — the build reports success while the PDF is silently missing (EPUB2926, fixed in 2026.1); the only evidence is an `[ERROR]` line in `Logs/<target>/generate.log`.
+</how_it_works>
+
+<solved_cases>
+
+## Documented Solutions
+
+Real solved cases, with mechanics and caveats, in `references/solved-cases.md`:
+
+| Case | Essence |
+|------|---------|
+| Raster image scaling/quality (EPUB2923) | Scale option resamples the bitmap (blurry); 2026.1+ dimension properties scale at render time keeping full resolution; a percentage Content Width is relative to the image's intrinsic size |
+| Repeating table captions | FOP repeats only `fo:table-header` content; emit the caption as its first all-column row (FOP does not implement `fo:table-and-caption`) |
+| PDF missing, build green (EPUB2926) | Pre-2026.1 FOP failures are not surfaced; diagnose from generate.log, guard overrides against emitting empty FO cells |
+
+Consult these before inventing a new approach — the caveats (border model, empty-content guards, one-scaling-mechanism-per-style) are where the time goes.
+</solved_cases>
+
+<customization>
+
+## Customization
+
+Standard file-resolver hierarchy applies (epublisher skill `references/file-resolver-guide.md`): `Targets/[TargetName]/` beats `Formats/PDF - XSL-FO/` beats `.base` beats installation. Choose the *least* powerful mechanism that works:
+
+1. **Format settings / style properties** (Style Designer) — no override files, survives upgrades. Style properties map ~1:1 to standard XSL-FO properties.
+2. **Page template override** (`Pages/*.asp`) — structural page changes. The templates are slot skeletons the engine fills from Page style configuration; keep the `wwpage:*` attributes intact.
+3. **Transform override** (`Transforms/*.xsl`) — content or compile behavior. Heavyweight: these are whole-file copies that shadow upstream fixes on every upgrade. Annotate each edit with its ticket number, keep deltas minimal, and re-base at upgrade (customization-audit skill detects the drift). `compile.xsl` overrides additionally pin the Apache FOP version — see `references/fop-engine.md`.
+
+XSLT 1.0 only — never XSLT 2.0 in overrides.
+</customization>
+
+<related_skills>
+
+## Related Skills
+
+| Skill | Relationship |
+|-------|--------------|
+| **epublisher** | Project structure, file resolver, format traits, generic pipeline model and Data-directory debugging (`references/publish-pipeline-guide.md`, `references/wif-guide.md`) |
+| **automap** | Build PDF - XSL-FO targets from CLI. Not compose-capable — `.wacj` composition jobs reject it. On pre-2026.1, verify expected PDFs exist after a green build (EPUB2926) |
+| **customization-audit** | Audit PDF - XSL-FO overrides on upgrade (whole-file `content.xsl`/`compile.xsl` copies drift) |
+| **markdown-integration** | Markdown++ sources feeding the PDF target (per-image graphic styles, variables, conditions) |
+
+**External:** Apache FOP documentation and compliance tables at `xmlgraphics.apache.org/fop/` — authoritative for FOP errors, font configuration, and which FO features the bundled version implements.
+</related_skills>
+
+<troubleshooting>
+
+## Troubleshooting
+
+### PDF missing from Output
+1. Check the three `generate-*-result` settings (only the group result defaults on).
+2. Search `Logs/<target>/generate.log` for `[ERROR]` / `SEVERE` / `Exception` — pre-2026.1 builds report success over a FOP failure (EPUB2926). The first such line is the real failure.
+
+### FOP validation error
+Usually an override emitting structurally incomplete FO for an edge case (classic: an empty `fo:table-cell` from an empty source paragraph — solved-cases § Case 3). Reproduce against the stitched `.fo`, fix the emitting template, never the `.fo` itself.
+
+### Blurry images
+The Scale option resamples bitmaps. See solved-cases § Case 1 for the render-time alternative (2026.1+) and the 2025.1 paths.
+
+### Wrong fonts / missing glyphs
+FOP resolves fonts through `Helpers/apache-fop-<version>.xconf`, not the OS alone. `references/fop-engine.md` § Fonts.
+
+### Customization didn't take
+Confirm the override level actually wins, rebuild fully, then check the stitched `.fo` to see whether the change even reached the FO.
+</troubleshooting>
+
+<references>
+
+## Reference Files
+
+- `references/solved-cases.md` — documented solutions from real cases: image scaling/quality, repeating table captions, silent FOP failure; distilled lessons
+- `references/fop-engine.md` — FOP invocation, version per ePublisher release, xconf/fonts, log reading, manual re-run, compile-override implications
+</references>
+
+<success_criteria>
+
+## Success Criteria
+
+- Correct format identified (`PDF - XSL-FO`, not legacy `PDF`) before any change
+- Expected PDFs verified present for each enabled result mode — a green build alone is not proof on pre-2026.1
+- Fixes applied at the narrowest sufficient level; transform overrides annotated and re-based on upgrade
+</success_criteria>

--- a/plugins/webworks-agent-skills/skills/pdf-xslfo/references/fop-engine.md
+++ b/plugins/webworks-agent-skills/skills/pdf-xslfo/references/fop-engine.md
@@ -1,0 +1,146 @@
+# Apache FOP Compile Engine
+
+How the Compile stage turns a stitched `.fo` into a PDF, which FOP version
+each ePublisher release uses, how to read FOP output, and how to reproduce a
+compile outside the build. Verified against the ePublisher 2026.1
+`Transforms/compile.xsl` and the `Helpers/` directory.
+
+## Invocation Mechanics
+
+`compile.xsl` (shared by the document/group/project wrappers) does the
+following per stitched `.fo`:
+
+1. Resolves the bundled JRE (`wwenv:JREHome()`) and the FOP helper
+   (`wwhelper:apache-fop-<version>`) plus its configuration
+   (`wwhelper:apache-fop-<version>.xconf`) to short (8.3) paths.
+2. Writes a temporary batch file **beside the stitched `.fo`**
+   (`<file>.fo.bat`) that sets `JAVA_HOME`, `FOP_HOME`,
+   `CLASSPATH=%FOP_HOME%\build\*;%FOP_HOME%\lib\*` and runs:
+
+   ```
+   java.exe <memory-opts> org.apache.fop.cli.Main -c <xconf> -fo <file>.fo -pdf <out>.pdf
+   ```
+
+3. Executes the batch, logs the transcript, and **deletes the batch file**
+   (success or failure — it is not left behind for reproduction).
+
+Java memory options depend on the JVM bitness (`wwenv:JavaBits()`):
+
+- 64-bit: `-Xms512M -Xmx4g`
+- 32-bit: `-Xms128M -Xmx1024M`
+
+The batch file itself is written in `Windows-1252`, or `Shift_JIS` when the
+UI locale is Japanese — relevant only if paths contain characters outside
+that codepage (the short-path conversion is the mitigation).
+
+## FOP Version per ePublisher Release
+
+The FOP helper name is **hard-coded in `compile.xsl`**, so the shipping FOP
+follows the ePublisher release — and an overridden `compile.xsl` pins
+whatever version it names. Verified from installed format sources:
+
+- ePublisher ~2010.1–2011.x — Apache FOP (unversioned helper path)
+- 2012.1–2013.x — FOP 1.0
+- 2014.1 — FOP 1.1
+- 2015.1–2020.1 — FOP 2.0
+- 2021.1 — FOP 2.6
+- 2022.1–2025.1 — FOP 2.8 (EPUB2446)
+- 2026.1 — FOP 2.11 (EPUB2786; new in 2026.1)
+
+`Helpers/` keeps every FOP version side by side (`apache-fop-1.0` through
+`apache-fop-2.11`, each with its own `.xconf`), so an old pinned override
+keeps *working* after an upgrade — silently compiling with the old engine and
+its old bugs/behaviors. The customization-audit skill's drift detection
+surfaces exactly this; when upgrading a project that overrides `compile.xsl`,
+diff against the new installed version and re-apply the customization on top.
+
+## Configuration and Fonts
+
+FOP reads `Helpers/apache-fop-<version>.xconf` (note: at the `Helpers/` root,
+not inside the FOP directory). This is standard Apache FOP configuration —
+renderer settings and, most importantly, **font discovery**. FOP does not
+simply use whatever Windows renders with: glyph coverage, bold/italic
+synthesis, and CJK output all depend on what the xconf exposes.
+
+Font symptoms and their meaning:
+
+- `Font "X,normal,700" not found. Substituting with "any,normal,700".` —
+  the style asks for a font FOP cannot resolve; output falls back, metrics
+  shift. Fix the style's font family or the xconf font config.
+- Glyphs rendering as `.notdef` (blank/box) — the resolved font lacks the
+  glyphs. Real instance: FrameMaker Symbol-font characters (mu, Delta,
+  radical) rendered as `.notdef` until the xconf was corrected — fixed in
+  2026.1 (EPUB2811) with an `apache-fop-2.8.xconf` backport for 2025.1
+  (EPUB2812). The backport is the precedent for delivering an xconf fix to
+  an older release.
+- Consult the Apache FOP documentation (`xmlgraphics.apache.org/fop/`) for
+  the xconf font syntax of the specific FOP version in play — it differs
+  across the 1.x/2.x line.
+
+Prefer changing the *style's* font to a font FOP already resolves. Editing
+the xconf is an installation-level change (there is no project-level override
+for Helpers): it affects every project building on that machine and must be
+re-applied when the installation is upgraded — document it in the project if
+you take that path.
+
+## Reading FOP Output
+
+Two facts shape log reading:
+
+1. **FOP routes all console logging to stderr, including `[INFO]`.** Stderr
+   content is not a failure signal; the exit code is
+   (`exit errorlevel` in the batch propagates it to the build).
+2. The compile stage logs the transcript into `generate.log` /
+   the build console:
+   - (2026.1+, EPUB2926) A FOP failure — non-zero exit or missing output
+     PDF — is raised as a build **error**. On success, lines matching
+     `[WARN]`, `[ERROR]`, `[FATAL]`, `SEVERE`, or `Exception` are logged as
+     build Warnings; everything else as progress Messages. On failure, the
+     full transcript is kept at Warning as a backstop.
+   - (pre-2026.1) A FOP failure is **not surfaced**: the build reports
+     success while that result's PDF is silently missing, and the full
+     stderr transcript logs as Warnings even on success — expect `[INFO]`
+     noise flagged as warnings; it does not indicate a problem by itself.
+     When an expected PDF is missing, grep `generate.log` for `[ERROR]`
+     (see `solved-cases.md` § Case 3).
+
+When diagnosing, find the **first** `[ERROR]`/`SEVERE`/`Exception` line; FOP
+errors cascade and later messages are usually consequences. Common classes:
+
+| Message class | Meaning | Fix direction |
+|---------------|---------|---------------|
+| `ValidationException` / "is not a valid child" / "is missing child elements" | The stitched FO violates the FO content model (classic: an empty `fo:table-cell` from an override meeting an empty source paragraph — `solved-cases.md` § Case 3) | Fix the emitting template/override — diff against the installed baseline |
+| `PropertyException` / "Invalid property value" | A style property emitted a value FOP rejects | Trace the named property back to the Style Designer value |
+| `OutOfMemoryError` | Heap exhausted on a large merged result | 64-bit JVM; split the result; raise heap via compile override (last resort) |
+| Font substitution warnings | See Fonts above | Style font family or xconf |
+| `FileNotFoundException` on an image | Image referenced by the FO is missing/moved | Check the image pipeline output in Data; by-reference vectors point at originals |
+
+## Manual Re-run (reproduce outside the build)
+
+The build deletes its batch file, but the stitched `.fo` remains in the
+target's Data directory (find it via `files.info`). Reproduce a compile with
+the same pieces the build used:
+
+```bat
+set JAVA_HOME=<install>\Helpers\WebWorks\...jre path (or any compatible JRE)
+set FOP_HOME=C:\Program Files\WebWorks\ePublisher\<version>\Helpers\apache-fop-<v>
+set CLASSPATH=%FOP_HOME%\build\*;%FOP_HOME%\lib\*
+"%JAVA_HOME%\bin\java.exe" -Xmx4g org.apache.fop.cli.Main ^
+  -c "C:\Program Files\WebWorks\ePublisher\<version>\Helpers\apache-fop-<v>.xconf" ^
+  -fo "<data>\<stitched>.fo" -pdf "%TEMP%\test.pdf"
+```
+
+Match the FOP version and xconf to what the target's effective `compile.xsl`
+names (check for an override first). A manual run gives you fast iteration on
+FO-level problems: edit the `.fo` copy directly to bisect what FOP objects
+to, then map the fix back to the style/template that generated it — never
+ship an edited `.fo`.
+
+## Overriding compile.xsl
+
+Legitimate reasons: raising Java memory, adding FOP CLI options (PDF/A,
+accessibility flags), or pinning a specific FOP for a rendering regression.
+Costs: the override freezes the FOP version and invocation against upgrades
+(see the version list above) and reimplements log handling. Annotate the
+override with its ticket number, keep the delta minimal against the installed
+baseline, and re-baseline on every ePublisher upgrade.

--- a/plugins/webworks-agent-skills/skills/pdf-xslfo/references/solved-cases.md
+++ b/plugins/webworks-agent-skills/skills/pdf-xslfo/references/solved-cases.md
@@ -1,0 +1,141 @@
+# Solved Cases
+
+Real problems solved on PDF - XSL-FO projects, harvested from support and
+community work. Each entry gives the problem, the root cause in the format,
+the working solution, and its caveats — apply the pattern, not just the
+specific fix. Distilled lessons at the end.
+
+## Case 1: Raster image scaling and print quality (EPUB2923)
+
+**Problem:** A user scales a logo down (say to 20%) and the PDF result is
+visibly blurry in print and on zoom.
+
+**Root cause:** Two different mechanisms exist, and before 2026.1 only the
+lossy one worked for raster images. The `Frame-Markup-External-Graphic`
+template in `Transforms/content.xsl` strips all dimension properties for
+raster images and always emits the DPI-normalized viewport — so the Graphic
+style dimension properties in Style Designer silently did nothing, and the
+only working knob was the **Scale** option, which *resamples the bitmap at
+generation time*: a 600x400 image scaled to 20% ships as a 120x80 bitmap
+(96 DPI effective on the page).
+
+**Solution (2026.1+, EPUB2923):** use Graphic style **dimension properties**
+instead of Scale — the FO engine scales at render time and the
+full-resolution original stays embedded (~5x the linear resolution of the
+Scale result at the same layout size):
+
+- **Content Width / Content Height** (Advanced group): a percentage is
+  relative to the image's **own intrinsic size** — per XSL-FO semantics,
+  `20%` renders the full-resolution original at 20% of its natural
+  dimensions.
+- **Width / Height** (Layout group): an absolute box (e.g. `1.25in`); the
+  image scales into it, aspect preserved (`scaling="uniform"`).
+
+**Caveats:**
+
+- Use **one mechanism per style**, not both — Scale resamples first and
+  defeats the quality benefit.
+- Explicit dimensions are honored verbatim: an oversized Width can overflow
+  the page; sizes larger than natural upscale.
+- Vector (SVG) images have their own sizing path and are unaffected.
+- Companion quality tip: set the Graphic style **Format** option to `png`
+  (and File Extension to `.png`) so regenerated screenshots/line art avoid
+  JPEG artifacts.
+- **Per-image scaling from Markdown++:** assign a dedicated graphic style
+  inline — `<!--style:SmallLogo-->` before the image — and set the property
+  on that style (markdown-integration skill for the wiring).
+- **2025.1 and earlier:** dimension properties on raster images are ignored;
+  the paths are the Scale option or a support-delivered project-level
+  override of `content.xsl` annotated with EPUB2923.
+
+**References:** Trac EPUB2923 (r36058, ships 2026.1); how-to spec in
+[quadralay/epublisher-docs#85](https://github.com/quadralay/epublisher-docs/issues/85);
+three-way sample project and regression gate in quadralay/epublisher-tests
+PR #39 (`images/pdf-graphic-dimension-properties`).
+
+## Case 2: Repeating table captions across page breaks
+
+**Problem:** When a table spans multiple pages, the heading row repeats on
+each continuation page but the caption appears only on the first page. The
+customer wanted the caption to repeat like the heading row does.
+
+**Root cause:** Apache FOP repeats only the contents of `fo:table-header`
+at the top of each page a table breaks onto. The stock format emits the
+caption as a standalone block *before* the `fo:table`, so it cannot repeat.
+`fo:table-and-caption` / `fo:table-caption` are **not** the answer — Apache
+FOP does not implement them.
+
+**Solution (project-level override of `content.xsl`):**
+
+1. Remove the standalone caption block emitted before the table.
+2. Emit the header section whenever the table has a caption, even with no
+   column-heading rows (a caption-only table still repeats its caption).
+3. In `Content-TableSection`, emit the caption as the **first,
+   all-column-spanning row of `fo:table-header`**. Style the cell white,
+   zero-padding, `border-style="hidden"` so it reads as a caption, not a
+   header cell; render the caption text with the same templates the
+   standalone caption used so its paragraph style is preserved.
+
+**Caveats:**
+
+- `hidden`, not `none`: in the collapsing-border model `none` has the lowest
+  priority and loses to the header section's solid border, which bleeds a
+  border onto the caption row.
+- **Guard against empty captions** — see Case 3: an empty caption paragraph
+  (e.g. all text hidden by conditions) must not emit an empty
+  `fo:table-cell`. Render the caption content into a buffer first and emit
+  the caption row only when the rendered content is non-empty.
+- The repeating caption necessarily sits *inside* the table's outer border.
+- Applies to every captioned table, not just long ones (short tables look
+  unchanged).
+- Whole-file override of `content.xsl`: on upgrade, re-base the edits onto
+  the new installed file or the copy shadows newer upstream fixes.
+- Verified with FOP 2.8 (2025.1); the `fo:table-header` repeat behavior is
+  identical on FOP 2.11.
+
+## Case 3: Build succeeds but a PDF is missing (EPUB2926)
+
+**Problem:** Generation completes, AutoMap exits 0, the build/job status
+reports success — but one book's PDF is simply absent from the output.
+
+**Root cause:** Before the EPUB2926 fix, an Apache FOP rendering failure was
+not surfaced: the compile stage logged FOP's `[ERROR]` output into
+`Logs/<target>/generate.log` and moved on. Any fatal FO validation error
+kills that entire result's PDF while everything else builds normally. The
+triggering instance came from Case 2's Revision 1: an empty caption produced
+an empty `fo:table-cell`, and FOP aborted with
+`org.apache.fop.fo.ValidationException: "fo:table-cell" is missing child
+elements. Required content model: marker* (%block;)+`.
+
+**Diagnosis (all versions):** when an expected PDF is missing, search
+`Logs/<target>/generate.log` for `[ERROR]`, `SEVERE`, or `Exception` —
+the first such line names the real failure; later ones are usually cascade.
+Then reproduce against the stitched `.fo` intermediate (see
+`fop-engine.md` § Manual Re-run).
+
+**Fixed (2026.1, EPUB2926):** the compile stage captures the FOP exit code
+and raises a build **error** when FOP fails or the output PDF is missing,
+and partitions the FOP transcript so warning/error lines surface as build
+Warnings instead of being buried.
+
+**Caveats:** on 2025.1 and earlier, treat "build green" as *not* proof the
+PDFs exist — verify the expected outputs are present, especially in CI
+(automap skill) where nobody eyeballs the output directory.
+
+## Distilled Lessons
+
+- **FOP implements a subset of XSL-FO.** Standard-FO solutions can be dead
+  ends (`fo:table-and-caption`). Check FOP's compliance page for the bundled
+  FOP version before designing a fix around an FO feature.
+- **The FO the format emits is the contract.** Fatal FOP validation errors
+  (empty `fo:table-cell`, invalid property values) usually trace back to a
+  format override emitting structurally incomplete FO for an edge case the
+  stock format never hits. When overriding `content.xsl`, buffer generated
+  content and emit enclosing structure only when the content is non-empty.
+- **Whole-file overrides shadow upstream fixes.** `content.xsl` is ~5,200
+  lines; a project override is a full copy with a few edits. Mark each edit
+  with its ticket/case annotation, keep the delta minimal, and re-base on
+  every ePublisher upgrade (customization-audit skill automates the drift
+  detection).
+- **Verify against the bundled FOP version** of the project's base format
+  (version list in `fop-engine.md`), and state that in the delivery notes.


### PR DESCRIPTION
## Summary

New skill for the **PDF - XSL-FO** output format (issue #149), analogous to `reverb2` for Reverb 2.0 — deliberately **minimalist and grounded in real solved cases**, not comprehensive format documentation.

**SKILL.md** (139 lines): two-PDF-formats disambiguation, the content → flows → stitch → FOP compile pipeline in brief (with the stitched-`.fo`-in-Data debugging pivot), the customization ladder (settings → styles → templates → transforms), and troubleshooting entry points. Pipeline/engine facts verified against the installed 2026.1 format source.

**references/solved-cases.md**: three documented solutions harvested from support/community work:
- Raster image scaling and print quality — Scale-option resampling vs 2026.1+ dimension properties, intrinsic-relative percentage semantics (EPUB2923; how-to spec in quadralay/epublisher-docs#85)
- Repeating table captions across page breaks — caption as the first all-column `fo:table-header` row; FOP does not implement `fo:table-and-caption`; `hidden` vs `none` in the collapsing border model; the empty-caption buffer guard
- PDF missing while the build reports success (EPUB2926) — diagnosis on pre-2026.1, fixed behavior on 2026.1

**references/fop-engine.md**: FOP invocation mechanics, the version-per-release pinning list (unversioned → 1.0 → 1.1 → 2.0 → 2.6 → 2.8 → 2.11; EPUB2446/EPUB2786), xconf/font behavior (EPUB2811/EPUB2812), transcript/log reading, manual re-run recipe, and compile-override drift implications.

**Registration**: README skill + requirements tables, epublisher/automap Related Skills rows, a 2026.1 `version-compatibility.md` entry (FOP 2.11, failure surfacing), plugin description.

**Version**: 3.8.3 → 3.9.0 (minor, new skill) via `scripts/bump-version.sh`.

## Test plan

- Repo lint conventions pass: no backtick-dollar/backtick-exclamation sequences in tables (macro strings are in bullet lists), SKILL.md under 500 lines, frontmatter parses, `scripts/check-python-utf8.py` clean (no new Python)
- Facts cross-checked against `C:\Program Files\WebWorks\ePublisher\<version>\Formats\PDF - XSL-FO\` for every installed release 2010.1–2026.1 (FOP pinning list) and against Trac EPUB2923/EPUB2926 ticket records

🤖 Generated with [Claude Code](https://claude.com/claude-code)