### PR TITLE
Closes #151: align pdf-xslfo image-sizing labels with the resx display names

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "webworks-agent-skills",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "owner": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/.claude-plugin/plugin.json
+++ b/plugins/webworks-agent-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webworks-agent-skills",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, Reverb output testing, and PDF - XSL-FO customization",
   "author": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/skills/pdf-xslfo/SKILL.md
+++ b/plugins/webworks-agent-skills/skills/pdf-xslfo/SKILL.md
@@ -66,7 +66,7 @@ Real solved cases, with mechanics and caveats, in `references/solved-cases.md`:
 
 | Case | Essence |
 |------|---------|
-| Raster image scaling/quality (EPUB2923) | Scale option resamples the bitmap (blurry); 2026.1+ dimension properties scale at render time keeping full resolution; a percentage Content Width is relative to the image's intrinsic size |
+| Raster image scaling/quality (EPUB2923) | Scale % option resamples the bitmap (blurry); 2026.1+ dimension properties scale at render time keeping full resolution; a percentage Content Width is relative to the image's intrinsic size |
 | Repeating table captions | FOP repeats only `fo:table-header` content; emit the caption as its first all-column row (FOP does not implement `fo:table-and-caption`) |
 | PDF missing, build green (EPUB2926) | Pre-2026.1 FOP failures are not surfaced; diagnose from generate.log, guard overrides against emitting empty FO cells |
 
@@ -112,7 +112,7 @@ XSLT 1.0 only — never XSLT 2.0 in overrides.
 Usually an override emitting structurally incomplete FO for an edge case (classic: an empty `fo:table-cell` from an empty source paragraph — solved-cases § Case 3). Reproduce against the stitched `.fo`, fix the emitting template, never the `.fo` itself.
 
 ### Blurry images
-The Scale option resamples bitmaps. See solved-cases § Case 1 for the render-time alternative (2026.1+) and the 2025.1 paths.
+The Scale % option resamples bitmaps. See solved-cases § Case 1 for the render-time alternative (2026.1+) and the 2025.1 paths.
 
 ### Wrong fonts / missing glyphs
 FOP resolves fonts through `Helpers/apache-fop-<version>.xconf`, not the OS alone. `references/fop-engine.md` § Fonts.

--- a/plugins/webworks-agent-skills/skills/pdf-xslfo/references/solved-cases.md
+++ b/plugins/webworks-agent-skills/skills/pdf-xslfo/references/solved-cases.md
@@ -15,14 +15,14 @@ lossy one worked for raster images. The `Frame-Markup-External-Graphic`
 template in `Transforms/content.xsl` strips all dimension properties for
 raster images and always emits the DPI-normalized viewport — so the Graphic
 style dimension properties in Style Designer silently did nothing, and the
-only working knob was the **Scale** option, which *resamples the bitmap at
+only working knob was the **Scale %** option, which *resamples the bitmap at
 generation time*: a 600x400 image scaled to 20% ships as a 120x80 bitmap
 (96 DPI effective on the page).
 
 **Solution (2026.1+, EPUB2923):** use Graphic style **dimension properties**
-instead of Scale — the FO engine scales at render time and the
+instead of Scale % — the FO engine scales at render time and the
 full-resolution original stays embedded (~5x the linear resolution of the
-Scale result at the same layout size):
+Scale % result at the same layout size):
 
 - **Content Width / Content Height** (Advanced group): a percentage is
   relative to the image's **own intrinsic size** — per XSL-FO semantics,
@@ -33,19 +33,19 @@ Scale result at the same layout size):
 
 **Caveats:**
 
-- Use **one mechanism per style**, not both — Scale resamples first and
+- Use **one mechanism per style**, not both — Scale % resamples first and
   defeats the quality benefit.
 - Explicit dimensions are honored verbatim: an oversized Width can overflow
   the page; sizes larger than natural upscale.
 - Vector (SVG) images have their own sizing path and are unaffected.
 - Companion quality tip: set the Graphic style **Format** option to `png`
-  (and File Extension to `.png`) so regenerated screenshots/line art avoid
-  JPEG artifacts.
+  (and **Output file extension** to `.png`) so regenerated screenshots/line
+  art avoid JPEG artifacts.
 - **Per-image scaling from Markdown++:** assign a dedicated graphic style
   inline — `<!--style:SmallLogo-->` before the image — and set the property
   on that style (markdown-integration skill for the wiring).
 - **2025.1 and earlier:** dimension properties on raster images are ignored;
-  the paths are the Scale option or a support-delivered project-level
+  the paths are the Scale % option or a support-delivered project-level
   override of `content.xsl` annotated with EPUB2923.
 
 **References:** Trac EPUB2923 (r36058, ships 2026.1); how-to spec in


### PR DESCRIPTION
## Summary

Implements #151 — the pdf-xslfo references name the Graphic style option **Scale** and **File Extension**, but the resx display names (source of truth for Style Designer labels) are **Scale %** and **Output file extension**, which the ePublisher docs' grounding topic and Style Designer documentation already use. Aligns `references/solved-cases.md` (six label edits, verb-sense "scale" untouched) and the two SKILL.md mentions (routing row, Troubleshooting "Blurry images").

Doc-only patch bump per CONTRIBUTING versioning: 3.9.0 → 3.9.1.

Downstream: quadralay/epublisher-docs#93 applies the same alignment to the staged aux-knowledge fuel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)