### PR TITLE
Closes #153: State the 2026.1 register rule and canonical-glossary pointers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "webworks-agent-skills",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, and Reverb output testing",
   "owner": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/.claude-plugin/plugin.json
+++ b/plugins/webworks-agent-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "webworks-agent-skills",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "AI agent skills for WebWorks ePublisher platform: project management, Markdown++ integration, AutoMap automation, Reverb output testing, and PDF - XSL-FO customization",
   "author": {
     "name": "Quadralay Corporation",

--- a/plugins/webworks-agent-skills/skills/automap/references/composition-jobs.md
+++ b/plugins/webworks-agent-skills/skills/automap/references/composition-jobs.md
@@ -26,6 +26,13 @@ The lifecycle has three independent steps:
 Reverb 2.0 only: the format declares the composition capabilities in
 `format.wwfmt`; other formats always deploy everything.
 
+> **Register note:** this reference speaks the developer register ("mirror",
+> "descriptor", "harvest") for precision about mechanism. Since 2026.1 the
+> product's own logs and dialogs — and any user-facing text you author — use
+> the user register instead: *shared destination*, *deployed record*, "read
+> the deployed output". See the epublisher skill's `product-foundations.md`
+> § Naming and Terminology for the full map.
+
 ## Grammar
 
 A `.wacj` is a distinct artifact that *references* jobs — like `.sln` vs

--- a/plugins/webworks-agent-skills/skills/epublisher/references/product-foundations.md
+++ b/plugins/webworks-agent-skills/skills/epublisher/references/product-foundations.md
@@ -44,6 +44,18 @@ Files are resolved through a 4-level priority chain (highest first):
 
 - **Internal names differ from UI display names**: Settings in `.fti` files and project files (`.wep/.wrp/.wxsp/.waj`) use internal names. The UI display name mapping is in the product source code, not in format files.
 - **Use the product's terminology**: "Targets" not "configurations," "Stationery" not "templates," "Groups" not "collections."
+- **Two registers exist since 2026.1 — write user-facing text in the user register.** Skill references use the developer register where it is precise about mechanism ("mirror", "harvest", "descriptor"). Anything user-facing that you author or edit — help topics, customer deliverables, UI or log wording — must use the pinned user-register terms instead:
+
+  | Developer register (internal) | User register (user-facing) |
+  |---|---|
+  | deploy target, deployment target | deploy destination |
+  | mirror | shared destination; "the deployed output at the destination" |
+  | descriptor, composition descriptor | deployed record |
+  | harvest | "read the deployed output" |
+  | orchestration (job model) | composition |
+  | Mimic | launcher |
+
+  Canonical glossaries: the ePublisher dev repo's `docs/reference/glossary.md` (product vocabulary, pinned per release) and `quadralay/markdown-plus-plus` `GLOSSARY.md` (Markdown++ vocabulary — a *comment tag* contains *commands*; combine commands with `;` in one tag, never as stacked tags).
 - **`.wez` files are installer artifacts**: They look like format sources but are zip archives used only for packaging. Always work with the extracted `Formats/<format name>/` directory.
 
 ## Trusted Sources

--- a/plugins/webworks-agent-skills/skills/reverb2/references/federation-architecture.md
+++ b/plugins/webworks-agent-skills/skills/reverb2/references/federation-architecture.md
@@ -11,6 +11,13 @@ output** — what to expect when inspecting, linting, or browser-testing a
 composed mirror. For the build/deploy/compose workflow, grammar, and CLI, see
 the automap skill's `references/composition-jobs.md`.
 
+> **Register note:** this reference speaks the developer register ("mirror",
+> "descriptor", "harvest") for precision about output internals. User-facing
+> text — help topics, customer messages, doc edits — uses the 2026.1 user
+> register instead: *shared destination*, *deployed record*, "read the
+> deployed output". See the epublisher skill's `product-foundations.md`
+> § Naming and Terminology for the full map.
+
 ## Composition artifacts in build output
 
 Every Reverb 2.0 build (2026.1+) emits composition descriptors alongside its


### PR DESCRIPTION
Closes #153. Companion to quadralay/epublisher-docs#110/#112 and quadralay/markdown-plus-plus#131 - makes this repo compatible with the pinned glossaries.

## Audit result

- **Clean** of the tag/command conflation that misled the Express assistant: no "style tag above the multiline tag" phrasing anywhere in the plugins; Markdown++ syntax defers to the markdown-plus-plus plugin (fixed at the source in markdown-plus-plus#132).
- **No retired "deploy target" spellings**; "Orchestration Blueprint" (publish-pipeline-guide.md) is the pipeline sense, not the retired job-model sense.
- **Deliberately developer-register** federation references (~40 prose uses of mirror/harvest/descriptor) - kept, per the dev-repo glossary''s allowance for developer docs.

## Changes

1. **`epublisher/references/product-foundations.md` "Naming and Terminology"** - the single terminology home now states the two-register rule, carries the retired->current map (deploy target -> deploy destination, mirror -> shared destination, descriptor -> deployed record, harvest -> read the deployed output, orchestration -> composition, Mimic -> launcher), and points at the canonical glossaries: dev repo `docs/reference/glossary.md` and `quadralay/markdown-plus-plus` `GLOSSARY.md` (comment tag contains commands; combine with `;` in one tag).
2. **`reverb2/references/federation-architecture.md`** and **`automap/references/composition-jobs.md`** - short register notes at the top pointing to the map. The epublisher-docs aux cleaning pass had added such a note to its *copy* of composition-jobs.md only; putting it in the source means the next aux re-staging keeps it.

Version bumped to 3.9.2 (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)